### PR TITLE
Player Pick'em scoring v1 — dynamic matrix, live read-time

### DIFF
--- a/docs/features/player-pickem/scoring.md
+++ b/docs/features/player-pickem/scoring.md
@@ -1,0 +1,107 @@
+# Player Pick'em Scoring
+
+Status: v1 (read-time live scoring; persistence + standings deferred)
+Date: 2026-08-27
+
+## Model
+
+Performance points from real statistics (see player-pickem.md — player
+props were deliberately rejected). The SCORING MATRIX is data; the
+ENGINE is code:
+
+- `PlayerScoringRuleSet` — named, versioned rule set; `IsDefault` marks
+  the fallback. Per-league selection is a later nullable FK on
+  `PickemGroup` (schema shaped for it now, per the design doc).
+- `PlayerScoringRule` — one row per scored stat:
+  `{ StatKey, Points, PerUnits }` where
+  `points = value * Points / PerUnits` (fractional, rounded to 2dp —
+  the modern reading of "1 point per 25 yards"; floor-per-full-unit is
+  a one-line engine change if ever wanted).
+
+`StatKey` is `category.statName` from the canonical
+AthleteCompetitionStatistic chain (e.g. `passing.passingYards`), OR a
+`derived.*` key the engine computes from raw stats before applying the
+matrix. Derivations are engine code because they're structural (a
+missed kick IS attempts minus made); point VALUES are matrix data.
+
+Derived keys (v1):
+
+| Key | Derivation |
+|---|---|
+| derived.missedExtraPoints | kicking.extraPointAttempts − extraPointsMade |
+| derived.fieldGoalsMade17_39 | made1_19 + made20_29 + made30_39 |
+| derived.fieldGoalsMissed17_39 | (att1_19+att20_29+att30_39) − made17_39 |
+| derived.fieldGoalsMade40_49 / Missed40_49 | bucket made / att − made |
+| derived.fieldGoalsMade50_59 | kicking.fieldGoalsMade50_59 |
+| derived.fieldGoalsMade60Plus | kicking.fieldGoalsMade60_99 |
+
+## Default matrix (seeded; source: operator's standard chart)
+
+Position-agnostic — the union of the chart's per-position tables (a
+QB's receiving yards score like anyone's; the chart simply never lists
+stats a position rarely accrues):
+
+| StatKey | Points | PerUnits |
+|---|---|---|
+| passing.passingYards | 1 | 25 |
+| passing.passingTouchdowns | 6 | 1 |
+| passing.interceptions | −2 | 1 |
+| rushing.rushingYards | 1 | 10 |
+| rushing.rushingTouchdowns | 6 | 1 |
+| receiving.receivingYards | 1 | 10 |
+| receiving.receivingTouchdowns | 6 | 1 |
+| fumbles.fumblesLost | −2 | 1 |
+| passing.twoPtPass / rushing.twoPtRush / receiving.twoPtReception | 2 | 1 |
+| kicking.extraPointsMade | 1 | 1 |
+| derived.missedExtraPoints | −2 | 1 |
+| derived.fieldGoalsMade17_39 | 3 | 1 |
+| derived.fieldGoalsMissed17_39 | −2 | 1 |
+| derived.fieldGoalsMade40_49 | 4 | 1 |
+| derived.fieldGoalsMissed40_49 | −1 | 1 |
+| derived.fieldGoalsMade50_59 | 5 | 1 |
+| derived.fieldGoalsMade60Plus | 6 | 1 |
+
+No receptions rule — the chart is standard (non-PPR). DEF rules
+(blocked kick, safety, sacks, points-allowed tiers) wait for the DEF
+slot; the tier shape is already representable as derived keys.
+
+## Flow (v1 — live, read-time)
+
+1. Producer: `GetAthleteStatlines(contestIds, athleteSeasonIds)` — for
+   each (athleteSeason, contest) pair, the flattened
+   `category.statName → value` map for the scoring categories
+   (passing/rushing/receiving/fumbles/kicking). Competition resolves
+   via Contest 1:1. Live-fresh via the play-driven refresh debounce.
+2. API: `GetMyPlayerLineup` batches one statline call for the lineup's
+   anchored slots, applies the default rule set, and returns per-slot
+   `Points` + a compact `StatLine` display string + lineup `TotalPoints`.
+   No persistence — recompute on every read while games run.
+3. Web: points on each slot chip + a lineup total.
+
+## Refresh triggers
+
+No polling, no background jobs (operator constraint):
+
+- **Phase 1 (shipped with v1)**: the play-completed SignalR events
+  already flowing Producer → API → ContestUpdatesContext stamp
+  `contests[id].lastUpdated`. The roster builder watches the timestamps
+  of ITS anchored contests and, on activity, silently refetches the
+  lineup twice — ~45s after the play (fast feedback) and again at ~4min
+  (after the Producer stat-document debounce catches up). Quiet games
+  cost zero requests; nobody polls.
+- **Phase 2 (next PR, with persistence + standings)**: the stat
+  DOCUMENT processor publishes `AthleteCompetitionStatsUpdated
+  (contestId, athleteSeasonId)` → shovel to API → consumer matches
+  PlayerLineupSlot anchors → recompute/persist → SignalR broadcast to
+  the league group. Final results persist on the existing
+  contest-finalized event chain (no jobs). Precise where Phase 1 is
+  approximate.
+
+## Deferred
+
+- Post-final persistence (slot/lineup results on game finalization,
+  mirroring team-pick scoring) + weekly/season standings.
+- Per-league rule-set selection UI; rule-set admin editor.
+- DEF scoring (with the DEF slot).
+- Threshold BONUSES (300-yard game, etc.) — the rule schema gains a
+  RuleType when needed; v1 is linear + derived-event only.

--- a/src/SportsData.Api/Application/UI/PlayerLineups/Dtos/PlayerLineupDto.cs
+++ b/src/SportsData.Api/Application/UI/PlayerLineups/Dtos/PlayerLineupDto.cs
@@ -7,6 +7,9 @@ public class PlayerLineupDto
     public int SeasonWeek { get; set; }
     /// <summary>Filled slots only — the client knows the fixed shape.</summary>
     public List<PlayerLineupSlotDto> Slots { get; set; } = [];
+
+    /// <summary>Sum of slot points, recomputed on every read while games run.</summary>
+    public decimal TotalPoints { get; set; }
 }
 
 public class PlayerLineupSlotDto
@@ -25,4 +28,14 @@ public class PlayerLineupSlotDto
     public string? OpponentName { get; set; }
     /// <summary>Derived server-side at read time via the product-wide kickoff−5 rule.</summary>
     public bool IsLocked { get; set; }
+
+    /// <summary>
+    /// Live fantasy points from the league's scoring matrix, recomputed
+    /// at read time from canonical statlines (kept fresh by the
+    /// play-driven refresh). Null = no statline yet (pre-kickoff or bye).
+    /// </summary>
+    public decimal? Points { get; set; }
+
+    /// <summary>Compact scored-stat display ("187 PaYd · 2 PaTD") — always matches Points.</summary>
+    public string? StatLine { get; set; }
 }

--- a/src/SportsData.Api/Application/UI/PlayerLineups/Queries/GetMyPlayerLineup/GetMyPlayerLineupQueryHandler.cs
+++ b/src/SportsData.Api/Application/UI/PlayerLineups/Queries/GetMyPlayerLineup/GetMyPlayerLineupQueryHandler.cs
@@ -4,10 +4,12 @@ using Microsoft.EntityFrameworkCore;
 
 using SportsData.Api.Application.UI.Leagues.Authorization;
 using SportsData.Api.Application.UI.PlayerLineups.Dtos;
+using SportsData.Api.Application.UI.PlayerLineups.Scoring;
 using SportsData.Api.Extensions;
 using SportsData.Api.Infrastructure.Data;
 using SportsData.Api.Infrastructure.Data.Entities;
 using SportsData.Core.Common;
+using SportsData.Core.Infrastructure.Clients.Athlete;
 using SportsData.Core.Infrastructure.Clients.Contest;
 
 namespace SportsData.Api.Application.UI.PlayerLineups.Queries.GetMyPlayerLineup;
@@ -35,6 +37,7 @@ public class GetMyPlayerLineupQueryHandler : IGetMyPlayerLineupQueryHandler
     private readonly AppDataContext _dataContext;
     private readonly ILeagueMembershipGuard _membershipGuard;
     private readonly IContestClientFactory _contestClientFactory;
+    private readonly IAthleteClientFactory _athleteClientFactory;
     private readonly IDateTimeProvider _dateTimeProvider;
 
     public GetMyPlayerLineupQueryHandler(
@@ -42,12 +45,14 @@ public class GetMyPlayerLineupQueryHandler : IGetMyPlayerLineupQueryHandler
         AppDataContext dataContext,
         ILeagueMembershipGuard membershipGuard,
         IContestClientFactory contestClientFactory,
+        IAthleteClientFactory athleteClientFactory,
         IDateTimeProvider dateTimeProvider)
     {
         _logger = logger;
         _dataContext = dataContext;
         _membershipGuard = membershipGuard;
         _contestClientFactory = contestClientFactory;
+        _athleteClientFactory = athleteClientFactory;
         _dateTimeProvider = dateTimeProvider;
     }
 
@@ -92,7 +97,65 @@ public class GetMyPlayerLineupQueryHandler : IGetMyPlayerLineupQueryHandler
                 .ToList() ?? [],
         };
 
+        await ApplyLiveScoringAsync(dto, gate.Group!, cancellationToken);
+
         return new Success<PlayerLineupDto>(dto);
+    }
+
+    /// <summary>
+    /// Read-time live scoring: one batch statline call for the lineup's
+    /// anchored slots, priced by the league's scoring matrix (v1: the
+    /// IsDefault set; per-league selection is a later FK). Fail OPEN —
+    /// scoring is display enrichment, never a reason to 500 the roster.
+    /// Persistence on game finalization is deliberately deferred
+    /// (docs/features/player-pickem/scoring.md).
+    /// </summary>
+    private async Task ApplyLiveScoringAsync(
+        PlayerLineupDto dto,
+        PickemGroup group,
+        CancellationToken cancellationToken)
+    {
+        var anchored = dto.Slots.Where(s => s.ContestId.HasValue).ToList();
+        if (anchored.Count == 0) return;
+
+        try
+        {
+            var rules = await _dataContext.PlayerScoringRules
+                .AsNoTracking()
+                .Where(r => r.RuleSet.IsDefault)
+                .ToListAsync(cancellationToken);
+            if (rules.Count == 0) return;
+
+            var statlines = await _athleteClientFactory
+                .Resolve(group.Sport)
+                .GetAthleteStatlines(
+                    anchored.Select(s => s.ContestId!.Value).Distinct().ToList(),
+                    anchored.Select(s => s.AthleteSeasonId).Distinct().ToList(),
+                    cancellationToken);
+            if (!statlines.IsSuccess) return;
+
+            var byKey = statlines.Value.ToDictionary(x => (x.AthleteSeasonId, x.ContestId));
+            foreach (var slot in anchored)
+            {
+                if (!byKey.TryGetValue((slot.AthleteSeasonId, slot.ContestId!.Value), out var line))
+                    continue;
+                var score = PlayerPickemScoringEngine.Score(rules, line.Stats);
+                slot.Points = score.Points;
+                slot.StatLine = PlayerPickemScoringEngine.BuildStatLine(score.Contributions);
+            }
+
+            dto.TotalPoints = dto.Slots.Sum(s => s.Points ?? 0m);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "Live scoring skipped for lineup. LeagueId={LeagueId} Week={Week}",
+                dto.LeagueId, dto.SeasonWeek);
+        }
     }
 
     private async Task<PlayerLineup?> TryCloneFromPriorWeekAsync(

--- a/src/SportsData.Api/Application/UI/PlayerLineups/Queries/GetMyPlayerLineup/GetMyPlayerLineupQueryHandler.cs
+++ b/src/SportsData.Api/Application/UI/PlayerLineups/Queries/GetMyPlayerLineup/GetMyPlayerLineupQueryHandler.cs
@@ -123,6 +123,7 @@ public class GetMyPlayerLineupQueryHandler : IGetMyPlayerLineupQueryHandler
             var rules = await _dataContext.PlayerScoringRules
                 .AsNoTracking()
                 .Where(r => r.RuleSet.IsDefault)
+                .Select(r => new ScoringRule(r.StatKey, r.Points, r.PerUnits))
                 .ToListAsync(cancellationToken);
             if (rules.Count == 0) return;
 

--- a/src/SportsData.Api/Application/UI/PlayerLineups/Scoring/PlayerPickemScoringEngine.cs
+++ b/src/SportsData.Api/Application/UI/PlayerLineups/Scoring/PlayerPickemScoringEngine.cs
@@ -1,0 +1,113 @@
+using SportsData.Api.Infrastructure.Data.Entities;
+
+namespace SportsData.Api.Application.UI.PlayerLineups.Scoring;
+
+/// <summary>
+/// Applies a scoring matrix to a flattened statline. The engine owns the
+/// STRUCTURAL pieces — derived keys (missed kicks, FG distance buckets)
+/// and the per-unit math — while every point VALUE comes from the
+/// dynamically-loaded rule set. See docs/features/player-pickem/scoring.md.
+/// </summary>
+public static class PlayerPickemScoringEngine
+{
+    /// <summary>One rule's contribution — powers the per-slot breakdown display.</summary>
+    public readonly record struct StatContribution(string StatKey, decimal StatValue, decimal Points);
+
+    public readonly record struct SlotScore(decimal Points, IReadOnlyList<StatContribution> Contributions);
+
+    public static SlotScore Score(
+        IReadOnlyCollection<PlayerScoringRule> rules,
+        IReadOnlyDictionary<string, decimal> stats)
+    {
+        var enriched = WithDerived(stats);
+        var contributions = new List<StatContribution>();
+        decimal total = 0m;
+
+        foreach (var rule in rules)
+        {
+            if (!enriched.TryGetValue(rule.StatKey, out var value) || value == 0m)
+                continue;
+            if (rule.PerUnits == 0m)
+                continue; // malformed rule; never divide by zero
+
+            var points = Math.Round(value * rule.Points / rule.PerUnits, 2, MidpointRounding.AwayFromZero);
+            if (points == 0m)
+                continue;
+
+            total += points;
+            contributions.Add(new StatContribution(rule.StatKey, value, points));
+        }
+
+        return new SlotScore(Math.Round(total, 2, MidpointRounding.AwayFromZero), contributions);
+    }
+
+    /// <summary>
+    /// Derived keys are structural facts (a missed kick IS attempts minus
+    /// made; the chart's 17-39 tier IS the union of ESPN's 1-19/20-29/
+    /// 30-39 buckets), so they live in code — the matrix only prices them.
+    /// </summary>
+    private static Dictionary<string, decimal> WithDerived(IReadOnlyDictionary<string, decimal> stats)
+    {
+        var result = new Dictionary<string, decimal>(stats, StringComparer.Ordinal);
+        decimal Get(string key) => stats.TryGetValue(key, out var v) ? v : 0m;
+
+        var made1739 = Get("kicking.fieldGoalsMade1_19") + Get("kicking.fieldGoalsMade20_29") + Get("kicking.fieldGoalsMade30_39");
+        var att1739 = Get("kicking.fieldGoalAttempts1_19") + Get("kicking.fieldGoalAttempts20_29") + Get("kicking.fieldGoalAttempts30_39");
+        var made4049 = Get("kicking.fieldGoalsMade40_49");
+        var att4049 = Get("kicking.fieldGoalAttempts40_49");
+
+        result["derived.missedExtraPoints"] = Get("kicking.extraPointAttempts") - Get("kicking.extraPointsMade");
+        result["derived.fieldGoalsMade17_39"] = made1739;
+        result["derived.fieldGoalsMissed17_39"] = att1739 - made1739;
+        result["derived.fieldGoalsMade40_49"] = made4049;
+        result["derived.fieldGoalsMissed40_49"] = att4049 - made4049;
+        result["derived.fieldGoalsMade50_59"] = Get("kicking.fieldGoalsMade50_59");
+        result["derived.fieldGoalsMade60Plus"] = Get("kicking.fieldGoalsMade60_99");
+
+        return result;
+    }
+
+    /// <summary>
+    /// Compact display line for the roster UI ("187 PaYd · 2 PaTD"),
+    /// built from the SCORED contributions so it always matches the
+    /// points shown. Unknown keys fall back to the raw stat name.
+    /// </summary>
+    public static string BuildStatLine(IReadOnlyList<StatContribution> contributions)
+    {
+        if (contributions.Count == 0) return string.Empty;
+        return string.Join(" · ", contributions.Select(c =>
+        {
+            var label = StatLabels.TryGetValue(c.StatKey, out var l)
+                ? l
+                : c.StatKey[(c.StatKey.IndexOf('.') + 1)..];
+            var value = c.StatValue == Math.Truncate(c.StatValue)
+                ? ((int)c.StatValue).ToString()
+                : c.StatValue.ToString("0.##");
+            return $"{value} {label}";
+        }));
+    }
+
+    private static readonly Dictionary<string, string> StatLabels = new(StringComparer.Ordinal)
+    {
+        ["passing.passingYards"] = "PaYd",
+        ["passing.passingTouchdowns"] = "PaTD",
+        ["passing.interceptions"] = "INT",
+        ["passing.twoPtPass"] = "2PT",
+        ["rushing.rushingYards"] = "RuYd",
+        ["rushing.rushingTouchdowns"] = "RuTD",
+        ["rushing.twoPtRush"] = "2PT",
+        ["receiving.receivingYards"] = "ReYd",
+        ["receiving.receivingTouchdowns"] = "ReTD",
+        ["receiving.receptions"] = "Rec",
+        ["receiving.twoPtReception"] = "2PT",
+        ["fumbles.fumblesLost"] = "FumL",
+        ["kicking.extraPointsMade"] = "XP",
+        ["derived.missedExtraPoints"] = "XP Miss",
+        ["derived.fieldGoalsMade17_39"] = "FG17-39",
+        ["derived.fieldGoalsMissed17_39"] = "FG Miss",
+        ["derived.fieldGoalsMade40_49"] = "FG40-49",
+        ["derived.fieldGoalsMissed40_49"] = "FG Miss",
+        ["derived.fieldGoalsMade50_59"] = "FG50-59",
+        ["derived.fieldGoalsMade60Plus"] = "FG60+",
+    };
+}

--- a/src/SportsData.Api/Application/UI/PlayerLineups/Scoring/PlayerPickemScoringEngine.cs
+++ b/src/SportsData.Api/Application/UI/PlayerLineups/Scoring/PlayerPickemScoringEngine.cs
@@ -1,6 +1,10 @@
-using SportsData.Api.Infrastructure.Data.Entities;
-
 namespace SportsData.Api.Application.UI.PlayerLineups.Scoring;
+
+/// <summary>
+/// Read-model of one scoring rule — the engine consumes this, never the
+/// persistence entity (EF reads project into it).
+/// </summary>
+public readonly record struct ScoringRule(string StatKey, decimal Points, decimal PerUnits);
 
 /// <summary>
 /// Applies a scoring matrix to a flattened statline. The engine owns the
@@ -16,7 +20,7 @@ public static class PlayerPickemScoringEngine
     public readonly record struct SlotScore(decimal Points, IReadOnlyList<StatContribution> Contributions);
 
     public static SlotScore Score(
-        IReadOnlyCollection<PlayerScoringRule> rules,
+        IReadOnlyCollection<ScoringRule> rules,
         IReadOnlyDictionary<string, decimal> stats)
     {
         var enriched = WithDerived(stats);

--- a/src/SportsData.Api/Infrastructure/Data/AppDataContext.cs
+++ b/src/SportsData.Api/Infrastructure/Data/AppDataContext.cs
@@ -28,6 +28,10 @@ public class AppDataContext : DbContext
 
     public DbSet<PlayerLineup> PlayerLineups { get; set; }
 
+    public DbSet<PlayerScoringRuleSet> PlayerScoringRuleSets { get; set; }
+
+    public DbSet<PlayerScoringRule> PlayerScoringRules { get; set; }
+
     public DbSet<PlayerLineupSlot> PlayerLineupSlots { get; set; }
 
     public DbSet<PickemGroupMember> PickemGroupMembers { get; set; }

--- a/src/SportsData.Api/Infrastructure/Data/Entities/PlayerScoringRuleSet.cs
+++ b/src/SportsData.Api/Infrastructure/Data/Entities/PlayerScoringRuleSet.cs
@@ -1,0 +1,282 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+using SportsData.Core.Infrastructure.Data.Entities;
+
+namespace SportsData.Api.Infrastructure.Data.Entities
+{
+    /// <summary>
+    /// A named Player Pick'em scoring matrix. The MATRIX is data, the
+    /// engine is code: rules are flat stat→points rows so operators can
+    /// tune values without a deploy, and per-league selection later is a
+    /// nullable FK on PickemGroup (absent → the IsDefault set).
+    /// See docs/features/player-pickem/scoring.md.
+    /// </summary>
+    public class PlayerScoringRuleSet : CanonicalEntityBase<Guid>
+    {
+        /// <summary>Stable seed identity for the default "Standard" matrix (operator's chart, 2026-08-27).</summary>
+        public static readonly Guid StandardRuleSetId = new("15c1e173-57ad-5c7e-99a1-c182d4c043ea");
+
+        internal static readonly DateTime SeedStamp = new(2026, 8, 27, 0, 0, 0, DateTimeKind.Utc);
+        public required string Name { get; set; }
+
+        /// <summary>Exactly one set is the fallback for leagues without an explicit selection.</summary>
+        public bool IsDefault { get; set; }
+
+        public ICollection<PlayerScoringRule> Rules { get; set; } = [];
+
+        public class EntityConfiguration : IEntityTypeConfiguration<PlayerScoringRuleSet>
+        {
+            public void Configure(EntityTypeBuilder<PlayerScoringRuleSet> builder)
+            {
+                builder.ToTable(nameof(PlayerScoringRuleSet));
+                builder.HasKey(x => x.Id);
+                builder.Property(x => x.Name).HasMaxLength(100);
+
+                builder.HasMany(x => x.Rules)
+                    .WithOne(x => x.RuleSet)
+                    .HasForeignKey(x => x.RuleSetId)
+                    .OnDelete(DeleteBehavior.Cascade);
+
+                // Seeded default matrix — the operator's standard chart
+                // (docs/features/player-pickem/scoring.md). Stable ids so
+                // re-running migrations never duplicates; value tuning
+                // happens with data updates, not schema changes.
+                builder.HasData(new
+                {
+                    Id = PlayerScoringRuleSet.StandardRuleSetId,
+                    Name = "Standard",
+                    IsDefault = true,
+                    CreatedUtc = PlayerScoringRuleSet.SeedStamp,
+                    CreatedBy = Guid.Empty,
+                });
+            }
+        }
+    }
+
+    /// <summary>
+    /// One scored stat: <c>points = value * Points / PerUnits</c>
+    /// (fractional, rounded to 2dp by the engine). StatKey is the
+    /// canonical <c>category.statName</c> from the Producer statline, or
+    /// a <c>derived.*</c> key the engine computes (missed kicks, FG
+    /// distance buckets) — derivations are structural and live in code;
+    /// point VALUES live here.
+    /// </summary>
+    public class PlayerScoringRule : CanonicalEntityBase<Guid>
+    {
+        public Guid RuleSetId { get; set; }
+
+        public PlayerScoringRuleSet RuleSet { get; set; } = null!;
+
+        public required string StatKey { get; set; }
+
+        public decimal Points { get; set; }
+
+        public decimal PerUnits { get; set; } = 1m;
+
+        public class EntityConfiguration : IEntityTypeConfiguration<PlayerScoringRule>
+        {
+            public void Configure(EntityTypeBuilder<PlayerScoringRule> builder)
+            {
+                builder.ToTable(nameof(PlayerScoringRule));
+                builder.HasKey(x => x.Id);
+                builder.Property(x => x.StatKey).HasMaxLength(100);
+                builder.Property(x => x.Points).HasPrecision(8, 2);
+                builder.Property(x => x.PerUnits).HasPrecision(8, 2);
+                builder.HasIndex(x => new { x.RuleSetId, x.StatKey }).IsUnique();
+
+                builder.HasData(
+                new
+                {
+                    Id = new Guid("807b8c25-7215-5f1c-98e8-464686858cd4"),
+                    RuleSetId = PlayerScoringRuleSet.StandardRuleSetId,
+                    StatKey = "passing.passingYards",
+                    Points = 1m,
+                    PerUnits = 25m,
+                    CreatedUtc = PlayerScoringRuleSet.SeedStamp,
+                    CreatedBy = Guid.Empty,
+                },
+                new
+                {
+                    Id = new Guid("8f721f96-3c86-595f-896b-1e34ec3a0656"),
+                    RuleSetId = PlayerScoringRuleSet.StandardRuleSetId,
+                    StatKey = "passing.passingTouchdowns",
+                    Points = 6m,
+                    PerUnits = 1m,
+                    CreatedUtc = PlayerScoringRuleSet.SeedStamp,
+                    CreatedBy = Guid.Empty,
+                },
+                new
+                {
+                    Id = new Guid("e263379b-de5d-5fc8-8179-8914e67f8442"),
+                    RuleSetId = PlayerScoringRuleSet.StandardRuleSetId,
+                    StatKey = "passing.interceptions",
+                    Points = -2m,
+                    PerUnits = 1m,
+                    CreatedUtc = PlayerScoringRuleSet.SeedStamp,
+                    CreatedBy = Guid.Empty,
+                },
+                new
+                {
+                    Id = new Guid("7e0e7e54-1fef-5e87-85fb-4485e1aca75c"),
+                    RuleSetId = PlayerScoringRuleSet.StandardRuleSetId,
+                    StatKey = "passing.twoPtPass",
+                    Points = 2m,
+                    PerUnits = 1m,
+                    CreatedUtc = PlayerScoringRuleSet.SeedStamp,
+                    CreatedBy = Guid.Empty,
+                },
+                new
+                {
+                    Id = new Guid("56c9694e-079d-5b02-b955-5566f86e74f2"),
+                    RuleSetId = PlayerScoringRuleSet.StandardRuleSetId,
+                    StatKey = "rushing.rushingYards",
+                    Points = 1m,
+                    PerUnits = 10m,
+                    CreatedUtc = PlayerScoringRuleSet.SeedStamp,
+                    CreatedBy = Guid.Empty,
+                },
+                new
+                {
+                    Id = new Guid("c7d3e6da-6cf1-5d77-bab5-a5d798c5cec2"),
+                    RuleSetId = PlayerScoringRuleSet.StandardRuleSetId,
+                    StatKey = "rushing.rushingTouchdowns",
+                    Points = 6m,
+                    PerUnits = 1m,
+                    CreatedUtc = PlayerScoringRuleSet.SeedStamp,
+                    CreatedBy = Guid.Empty,
+                },
+                new
+                {
+                    Id = new Guid("ea6842c9-d160-5acd-8587-100f54d4ec51"),
+                    RuleSetId = PlayerScoringRuleSet.StandardRuleSetId,
+                    StatKey = "rushing.twoPtRush",
+                    Points = 2m,
+                    PerUnits = 1m,
+                    CreatedUtc = PlayerScoringRuleSet.SeedStamp,
+                    CreatedBy = Guid.Empty,
+                },
+                new
+                {
+                    Id = new Guid("ccc857a3-3b83-52f7-ab39-8c4c6739b3b8"),
+                    RuleSetId = PlayerScoringRuleSet.StandardRuleSetId,
+                    StatKey = "receiving.receivingYards",
+                    Points = 1m,
+                    PerUnits = 10m,
+                    CreatedUtc = PlayerScoringRuleSet.SeedStamp,
+                    CreatedBy = Guid.Empty,
+                },
+                new
+                {
+                    Id = new Guid("559bcedf-28e3-5466-8be3-d8d70ee6c529"),
+                    RuleSetId = PlayerScoringRuleSet.StandardRuleSetId,
+                    StatKey = "receiving.receivingTouchdowns",
+                    Points = 6m,
+                    PerUnits = 1m,
+                    CreatedUtc = PlayerScoringRuleSet.SeedStamp,
+                    CreatedBy = Guid.Empty,
+                },
+                new
+                {
+                    Id = new Guid("d1c1bbec-7dd3-5a0f-bd7f-0a84597168f4"),
+                    RuleSetId = PlayerScoringRuleSet.StandardRuleSetId,
+                    StatKey = "receiving.twoPtReception",
+                    Points = 2m,
+                    PerUnits = 1m,
+                    CreatedUtc = PlayerScoringRuleSet.SeedStamp,
+                    CreatedBy = Guid.Empty,
+                },
+                new
+                {
+                    Id = new Guid("b8a73ff8-3494-5459-838f-11e1e07f8720"),
+                    RuleSetId = PlayerScoringRuleSet.StandardRuleSetId,
+                    StatKey = "fumbles.fumblesLost",
+                    Points = -2m,
+                    PerUnits = 1m,
+                    CreatedUtc = PlayerScoringRuleSet.SeedStamp,
+                    CreatedBy = Guid.Empty,
+                },
+                new
+                {
+                    Id = new Guid("6f215f20-0471-54d3-bee9-a26f1e66d1de"),
+                    RuleSetId = PlayerScoringRuleSet.StandardRuleSetId,
+                    StatKey = "kicking.extraPointsMade",
+                    Points = 1m,
+                    PerUnits = 1m,
+                    CreatedUtc = PlayerScoringRuleSet.SeedStamp,
+                    CreatedBy = Guid.Empty,
+                },
+                new
+                {
+                    Id = new Guid("5ad10eb5-739c-5a5a-afaa-7db306e03a6a"),
+                    RuleSetId = PlayerScoringRuleSet.StandardRuleSetId,
+                    StatKey = "derived.missedExtraPoints",
+                    Points = -2m,
+                    PerUnits = 1m,
+                    CreatedUtc = PlayerScoringRuleSet.SeedStamp,
+                    CreatedBy = Guid.Empty,
+                },
+                new
+                {
+                    Id = new Guid("c7d7861c-d887-586b-9788-d927009a1cc0"),
+                    RuleSetId = PlayerScoringRuleSet.StandardRuleSetId,
+                    StatKey = "derived.fieldGoalsMade17_39",
+                    Points = 3m,
+                    PerUnits = 1m,
+                    CreatedUtc = PlayerScoringRuleSet.SeedStamp,
+                    CreatedBy = Guid.Empty,
+                },
+                new
+                {
+                    Id = new Guid("568ce9f4-6213-5254-81c1-d43e53f6e207"),
+                    RuleSetId = PlayerScoringRuleSet.StandardRuleSetId,
+                    StatKey = "derived.fieldGoalsMissed17_39",
+                    Points = -2m,
+                    PerUnits = 1m,
+                    CreatedUtc = PlayerScoringRuleSet.SeedStamp,
+                    CreatedBy = Guid.Empty,
+                },
+                new
+                {
+                    Id = new Guid("666e3ffd-3d39-597a-9eb5-364003a9b997"),
+                    RuleSetId = PlayerScoringRuleSet.StandardRuleSetId,
+                    StatKey = "derived.fieldGoalsMade40_49",
+                    Points = 4m,
+                    PerUnits = 1m,
+                    CreatedUtc = PlayerScoringRuleSet.SeedStamp,
+                    CreatedBy = Guid.Empty,
+                },
+                new
+                {
+                    Id = new Guid("33a100db-526d-5496-8c6e-f478226ab7c6"),
+                    RuleSetId = PlayerScoringRuleSet.StandardRuleSetId,
+                    StatKey = "derived.fieldGoalsMissed40_49",
+                    Points = -1m,
+                    PerUnits = 1m,
+                    CreatedUtc = PlayerScoringRuleSet.SeedStamp,
+                    CreatedBy = Guid.Empty,
+                },
+                new
+                {
+                    Id = new Guid("629e7224-863f-5ec4-8f4c-4cbd89eb79f1"),
+                    RuleSetId = PlayerScoringRuleSet.StandardRuleSetId,
+                    StatKey = "derived.fieldGoalsMade50_59",
+                    Points = 5m,
+                    PerUnits = 1m,
+                    CreatedUtc = PlayerScoringRuleSet.SeedStamp,
+                    CreatedBy = Guid.Empty,
+                },
+                new
+                {
+                    Id = new Guid("9ec911b7-d2d0-58cb-b99e-1b112752d462"),
+                    RuleSetId = PlayerScoringRuleSet.StandardRuleSetId,
+                    StatKey = "derived.fieldGoalsMade60Plus",
+                    Points = 6m,
+                    PerUnits = 1m,
+                    CreatedUtc = PlayerScoringRuleSet.SeedStamp,
+                    CreatedBy = Guid.Empty,
+                });
+            }
+        }
+    }
+}

--- a/src/SportsData.Api/Infrastructure/Data/Entities/PlayerScoringRuleSet.cs
+++ b/src/SportsData.Api/Infrastructure/Data/Entities/PlayerScoringRuleSet.cs
@@ -33,6 +33,13 @@ namespace SportsData.Api.Infrastructure.Data.Entities
                 builder.HasKey(x => x.Id);
                 builder.Property(x => x.Name).HasMaxLength(100);
 
+                // AT MOST one default: the scoring path loads rules from
+                // every IsDefault set, so a second default would silently
+                // merge two matrices into every lineup score.
+                builder.HasIndex(x => x.IsDefault)
+                    .IsUnique()
+                    .HasFilter("\"IsDefault\"");
+
                 builder.HasMany(x => x.Rules)
                     .WithOne(x => x.RuleSet)
                     .HasForeignKey(x => x.RuleSetId)

--- a/src/SportsData.Api/Migrations/20260827180503_PlayerScoringMatrix.Designer.cs
+++ b/src/SportsData.Api/Migrations/20260827180503_PlayerScoringMatrix.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SportsData.Api.Infrastructure.Data;
@@ -11,9 +12,11 @@ using SportsData.Api.Infrastructure.Data;
 namespace SportsData.Api.Migrations
 {
     [DbContext(typeof(AppDataContext))]
-    partial class AppDataContextModelSnapshot : ModelSnapshot
+    [Migration("20260827180503_PlayerScoringMatrix")]
+    partial class PlayerScoringMatrix
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/SportsData.Api/Migrations/20260827180503_PlayerScoringMatrix.cs
+++ b/src/SportsData.Api/Migrations/20260827180503_PlayerScoringMatrix.cs
@@ -1,0 +1,106 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+#pragma warning disable CA1814 // Prefer jagged arrays over multidimensional
+
+namespace SportsData.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class PlayerScoringMatrix : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "PlayerScoringRuleSet",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    Name = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    IsDefault = table.Column<bool>(type: "boolean", nullable: false),
+                    CreatedUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    ModifiedUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    CreatedBy = table.Column<Guid>(type: "uuid", nullable: false),
+                    ModifiedBy = table.Column<Guid>(type: "uuid", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PlayerScoringRuleSet", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "PlayerScoringRule",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    RuleSetId = table.Column<Guid>(type: "uuid", nullable: false),
+                    StatKey = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    Points = table.Column<decimal>(type: "numeric(8,2)", precision: 8, scale: 2, nullable: false),
+                    PerUnits = table.Column<decimal>(type: "numeric(8,2)", precision: 8, scale: 2, nullable: false),
+                    CreatedUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    ModifiedUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    CreatedBy = table.Column<Guid>(type: "uuid", nullable: false),
+                    ModifiedBy = table.Column<Guid>(type: "uuid", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PlayerScoringRule", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_PlayerScoringRule_PlayerScoringRuleSet_RuleSetId",
+                        column: x => x.RuleSetId,
+                        principalTable: "PlayerScoringRuleSet",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.InsertData(
+                table: "PlayerScoringRuleSet",
+                columns: new[] { "Id", "CreatedBy", "CreatedUtc", "IsDefault", "ModifiedBy", "ModifiedUtc", "Name" },
+                values: new object[] { new Guid("15c1e173-57ad-5c7e-99a1-c182d4c043ea"), new Guid("00000000-0000-0000-0000-000000000000"), new DateTime(2026, 8, 27, 0, 0, 0, 0, DateTimeKind.Utc), true, null, null, "Standard" });
+
+            migrationBuilder.InsertData(
+                table: "PlayerScoringRule",
+                columns: new[] { "Id", "CreatedBy", "CreatedUtc", "ModifiedBy", "ModifiedUtc", "PerUnits", "Points", "RuleSetId", "StatKey" },
+                values: new object[,]
+                {
+                    { new Guid("33a100db-526d-5496-8c6e-f478226ab7c6"), new Guid("00000000-0000-0000-0000-000000000000"), new DateTime(2026, 8, 27, 0, 0, 0, 0, DateTimeKind.Utc), null, null, 1m, -1m, new Guid("15c1e173-57ad-5c7e-99a1-c182d4c043ea"), "derived.fieldGoalsMissed40_49" },
+                    { new Guid("559bcedf-28e3-5466-8be3-d8d70ee6c529"), new Guid("00000000-0000-0000-0000-000000000000"), new DateTime(2026, 8, 27, 0, 0, 0, 0, DateTimeKind.Utc), null, null, 1m, 6m, new Guid("15c1e173-57ad-5c7e-99a1-c182d4c043ea"), "receiving.receivingTouchdowns" },
+                    { new Guid("568ce9f4-6213-5254-81c1-d43e53f6e207"), new Guid("00000000-0000-0000-0000-000000000000"), new DateTime(2026, 8, 27, 0, 0, 0, 0, DateTimeKind.Utc), null, null, 1m, -2m, new Guid("15c1e173-57ad-5c7e-99a1-c182d4c043ea"), "derived.fieldGoalsMissed17_39" },
+                    { new Guid("56c9694e-079d-5b02-b955-5566f86e74f2"), new Guid("00000000-0000-0000-0000-000000000000"), new DateTime(2026, 8, 27, 0, 0, 0, 0, DateTimeKind.Utc), null, null, 10m, 1m, new Guid("15c1e173-57ad-5c7e-99a1-c182d4c043ea"), "rushing.rushingYards" },
+                    { new Guid("5ad10eb5-739c-5a5a-afaa-7db306e03a6a"), new Guid("00000000-0000-0000-0000-000000000000"), new DateTime(2026, 8, 27, 0, 0, 0, 0, DateTimeKind.Utc), null, null, 1m, -2m, new Guid("15c1e173-57ad-5c7e-99a1-c182d4c043ea"), "derived.missedExtraPoints" },
+                    { new Guid("629e7224-863f-5ec4-8f4c-4cbd89eb79f1"), new Guid("00000000-0000-0000-0000-000000000000"), new DateTime(2026, 8, 27, 0, 0, 0, 0, DateTimeKind.Utc), null, null, 1m, 5m, new Guid("15c1e173-57ad-5c7e-99a1-c182d4c043ea"), "derived.fieldGoalsMade50_59" },
+                    { new Guid("666e3ffd-3d39-597a-9eb5-364003a9b997"), new Guid("00000000-0000-0000-0000-000000000000"), new DateTime(2026, 8, 27, 0, 0, 0, 0, DateTimeKind.Utc), null, null, 1m, 4m, new Guid("15c1e173-57ad-5c7e-99a1-c182d4c043ea"), "derived.fieldGoalsMade40_49" },
+                    { new Guid("6f215f20-0471-54d3-bee9-a26f1e66d1de"), new Guid("00000000-0000-0000-0000-000000000000"), new DateTime(2026, 8, 27, 0, 0, 0, 0, DateTimeKind.Utc), null, null, 1m, 1m, new Guid("15c1e173-57ad-5c7e-99a1-c182d4c043ea"), "kicking.extraPointsMade" },
+                    { new Guid("7e0e7e54-1fef-5e87-85fb-4485e1aca75c"), new Guid("00000000-0000-0000-0000-000000000000"), new DateTime(2026, 8, 27, 0, 0, 0, 0, DateTimeKind.Utc), null, null, 1m, 2m, new Guid("15c1e173-57ad-5c7e-99a1-c182d4c043ea"), "passing.twoPtPass" },
+                    { new Guid("807b8c25-7215-5f1c-98e8-464686858cd4"), new Guid("00000000-0000-0000-0000-000000000000"), new DateTime(2026, 8, 27, 0, 0, 0, 0, DateTimeKind.Utc), null, null, 25m, 1m, new Guid("15c1e173-57ad-5c7e-99a1-c182d4c043ea"), "passing.passingYards" },
+                    { new Guid("8f721f96-3c86-595f-896b-1e34ec3a0656"), new Guid("00000000-0000-0000-0000-000000000000"), new DateTime(2026, 8, 27, 0, 0, 0, 0, DateTimeKind.Utc), null, null, 1m, 6m, new Guid("15c1e173-57ad-5c7e-99a1-c182d4c043ea"), "passing.passingTouchdowns" },
+                    { new Guid("9ec911b7-d2d0-58cb-b99e-1b112752d462"), new Guid("00000000-0000-0000-0000-000000000000"), new DateTime(2026, 8, 27, 0, 0, 0, 0, DateTimeKind.Utc), null, null, 1m, 6m, new Guid("15c1e173-57ad-5c7e-99a1-c182d4c043ea"), "derived.fieldGoalsMade60Plus" },
+                    { new Guid("b8a73ff8-3494-5459-838f-11e1e07f8720"), new Guid("00000000-0000-0000-0000-000000000000"), new DateTime(2026, 8, 27, 0, 0, 0, 0, DateTimeKind.Utc), null, null, 1m, -2m, new Guid("15c1e173-57ad-5c7e-99a1-c182d4c043ea"), "fumbles.fumblesLost" },
+                    { new Guid("c7d3e6da-6cf1-5d77-bab5-a5d798c5cec2"), new Guid("00000000-0000-0000-0000-000000000000"), new DateTime(2026, 8, 27, 0, 0, 0, 0, DateTimeKind.Utc), null, null, 1m, 6m, new Guid("15c1e173-57ad-5c7e-99a1-c182d4c043ea"), "rushing.rushingTouchdowns" },
+                    { new Guid("c7d7861c-d887-586b-9788-d927009a1cc0"), new Guid("00000000-0000-0000-0000-000000000000"), new DateTime(2026, 8, 27, 0, 0, 0, 0, DateTimeKind.Utc), null, null, 1m, 3m, new Guid("15c1e173-57ad-5c7e-99a1-c182d4c043ea"), "derived.fieldGoalsMade17_39" },
+                    { new Guid("ccc857a3-3b83-52f7-ab39-8c4c6739b3b8"), new Guid("00000000-0000-0000-0000-000000000000"), new DateTime(2026, 8, 27, 0, 0, 0, 0, DateTimeKind.Utc), null, null, 10m, 1m, new Guid("15c1e173-57ad-5c7e-99a1-c182d4c043ea"), "receiving.receivingYards" },
+                    { new Guid("d1c1bbec-7dd3-5a0f-bd7f-0a84597168f4"), new Guid("00000000-0000-0000-0000-000000000000"), new DateTime(2026, 8, 27, 0, 0, 0, 0, DateTimeKind.Utc), null, null, 1m, 2m, new Guid("15c1e173-57ad-5c7e-99a1-c182d4c043ea"), "receiving.twoPtReception" },
+                    { new Guid("e263379b-de5d-5fc8-8179-8914e67f8442"), new Guid("00000000-0000-0000-0000-000000000000"), new DateTime(2026, 8, 27, 0, 0, 0, 0, DateTimeKind.Utc), null, null, 1m, -2m, new Guid("15c1e173-57ad-5c7e-99a1-c182d4c043ea"), "passing.interceptions" },
+                    { new Guid("ea6842c9-d160-5acd-8587-100f54d4ec51"), new Guid("00000000-0000-0000-0000-000000000000"), new DateTime(2026, 8, 27, 0, 0, 0, 0, DateTimeKind.Utc), null, null, 1m, 2m, new Guid("15c1e173-57ad-5c7e-99a1-c182d4c043ea"), "rushing.twoPtRush" }
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PlayerScoringRule_RuleSetId_StatKey",
+                table: "PlayerScoringRule",
+                columns: new[] { "RuleSetId", "StatKey" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "PlayerScoringRule");
+
+            migrationBuilder.DropTable(
+                name: "PlayerScoringRuleSet");
+        }
+    }
+}

--- a/src/SportsData.Api/Migrations/20260827195036_PlayerScoringDefaultUnique.Designer.cs
+++ b/src/SportsData.Api/Migrations/20260827195036_PlayerScoringDefaultUnique.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SportsData.Api.Infrastructure.Data;
@@ -11,9 +12,11 @@ using SportsData.Api.Infrastructure.Data;
 namespace SportsData.Api.Migrations
 {
     [DbContext(typeof(AppDataContext))]
-    partial class AppDataContextModelSnapshot : ModelSnapshot
+    [Migration("20260827195036_PlayerScoringDefaultUnique")]
+    partial class PlayerScoringDefaultUnique
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/SportsData.Api/Migrations/20260827195036_PlayerScoringDefaultUnique.cs
+++ b/src/SportsData.Api/Migrations/20260827195036_PlayerScoringDefaultUnique.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SportsData.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class PlayerScoringDefaultUnique : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "IX_PlayerScoringRuleSet_IsDefault",
+                table: "PlayerScoringRuleSet",
+                column: "IsDefault",
+                unique: true,
+                filter: "\"IsDefault\"");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_PlayerScoringRuleSet_IsDefault",
+                table: "PlayerScoringRuleSet");
+        }
+    }
+}

--- a/src/SportsData.Api/Migrations/20260827195036_PlayerScoringDefaultUnique.cs
+++ b/src/SportsData.Api/Migrations/20260827195036_PlayerScoringDefaultUnique.cs
@@ -10,6 +10,20 @@ namespace SportsData.Api.Migrations
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
+            // Reconcile any pre-existing duplicate defaults so the filtered
+            // unique index can build: keep the OLDEST default (ties broken
+            // by Id for determinism), clear the rest. Rule-set edits are
+            // operator SQL by design, so a hand-inserted second default is
+            // not impossible on an existing database.
+            migrationBuilder.Sql("""
+                UPDATE "PlayerScoringRuleSet" SET "IsDefault" = false
+                WHERE "IsDefault" AND "Id" <> (
+                    SELECT "Id" FROM "PlayerScoringRuleSet"
+                    WHERE "IsDefault"
+                    ORDER BY "CreatedUtc", "Id"
+                    LIMIT 1);
+                """);
+
             migrationBuilder.CreateIndex(
                 name: "IX_PlayerScoringRuleSet_IsDefault",
                 table: "PlayerScoringRuleSet",

--- a/src/SportsData.Core/Dtos/Canonical/AthleteStatlineDto.cs
+++ b/src/SportsData.Core/Dtos/Canonical/AthleteStatlineDto.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Collections.Generic;
+
+namespace SportsData.Core.Dtos.Canonical
+{
+    /// <summary>
+    /// Flattened per-athlete per-contest box-score statline: canonical
+    /// stat identity is <c>category.statName</c> (e.g.
+    /// "passing.passingYards") → value. Powers Player Pick'em scoring —
+    /// the scoring matrix keys on the same names, so the engine applies
+    /// rules without knowing category structure.
+    /// </summary>
+    public class AthleteStatlineDto
+    {
+        public Guid AthleteSeasonId { get; set; }
+
+        public Guid ContestId { get; set; }
+
+        public Dictionary<string, decimal> Stats { get; set; } = [];
+    }
+
+    /// <summary>Batch request body for the statlines endpoint.</summary>
+    public record GetAthleteStatlinesRequest(Guid[] ContestIds, Guid[] AthleteSeasonIds);
+}

--- a/src/SportsData.Core/Infrastructure/Clients/Athlete/AthleteClient.cs
+++ b/src/SportsData.Core/Infrastructure/Clients/Athlete/AthleteClient.cs
@@ -5,6 +5,8 @@ using SportsData.Core.Dtos.Canonical;
 using SportsData.Core.Middleware.Health;
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
@@ -18,6 +20,9 @@ public interface IProvideAthletes : IProvideHealthChecks
 
     /// <summary>Athletes at a position with their week opponent, the opponent's defensive allowance per game, and current/previous season stat blocks.</summary>
     Task<Result<AthleteMatchupSummariesDto>> GetAthleteMatchupSummaries(string position, int seasonYear, int week, int seasonPhaseTypeCode = 2, CancellationToken cancellationToken = default);
+
+    /// <summary>Batch box-score statlines (category.statName → value) per (athleteSeason, contest) — one call per lineup for scoring.</summary>
+    Task<Result<List<AthleteStatlineDto>>> GetAthleteStatlines(List<Guid> contestIds, List<Guid> athleteSeasonIds, CancellationToken cancellationToken = default);
 }
 
 /// <summary>
@@ -60,5 +65,22 @@ public class AthleteClient : ClientBase, IProvideAthletes
             new AthleteMatchupSummariesDto(),
             entityName: "AthleteMatchupSummaries",
             cancellationToken: cancellationToken);
+    }
+
+    public async Task<Result<List<AthleteStatlineDto>>> GetAthleteStatlines(
+        List<Guid> contestIds,
+        List<Guid> athleteSeasonIds,
+        CancellationToken cancellationToken = default)
+    {
+        if (contestIds is null || contestIds.Count == 0 ||
+            athleteSeasonIds is null || athleteSeasonIds.Count == 0)
+        {
+            return new Success<List<AthleteStatlineDto>>([]);
+        }
+
+        var request = new GetAthleteStatlinesRequest(contestIds.ToArray(), athleteSeasonIds.ToArray());
+        var result = await PostOrDefaultAsync<List<AthleteStatlineDto>, GetAthleteStatlinesRequest>(
+            "athletes/statlines", request, [], cancellationToken);
+        return new Success<List<AthleteStatlineDto>>(result);
     }
 }

--- a/src/SportsData.Producer/Application/Athletes/AthleteController.cs
+++ b/src/SportsData.Producer/Application/Athletes/AthleteController.cs
@@ -46,6 +46,22 @@ public class AthleteController : ControllerBase
     /// data is game-agnostic athlete/matchup data.
     /// Example: GET /api/athletes/matchup-summaries?position=QB&amp;seasonYear=2026&amp;week=1
     /// </summary>
+    [HttpGet("matchup-summaries")]
+    public async Task<ActionResult<AthleteMatchupSummariesDto>> GetAthleteMatchupSummaries(
+        [FromQuery] string position,
+        [FromQuery] int seasonYear,
+        [FromQuery] int week,
+        // Nullable so an omitted param cannot bind to 0 and match no phase.
+        [FromQuery] int? phaseTypeCode,
+        [FromServices] IGetAthleteMatchupSummariesQueryHandler handler,
+        CancellationToken cancellationToken)
+    {
+        var result = await handler.ExecuteAsync(
+            new GetAthleteMatchupSummariesQuery(position, seasonYear, week, phaseTypeCode ?? 2),
+            cancellationToken);
+        return result.ToActionResult();
+    }
+
     /// <summary>
     /// Batch box-score statlines for Player Pick'em scoring: one call per
     /// lineup, returning category.statName → value maps per
@@ -61,22 +77,6 @@ public class AthleteController : ControllerBase
         var result = await handler.ExecuteAsync(
             new Queries.GetAthleteStatlines.GetAthleteStatlinesQuery(
                 request.ContestIds, request.AthleteSeasonIds),
-            cancellationToken);
-        return result.ToActionResult();
-    }
-
-    [HttpGet("matchup-summaries")]
-    public async Task<ActionResult<AthleteMatchupSummariesDto>> GetAthleteMatchupSummaries(
-        [FromQuery] string position,
-        [FromQuery] int seasonYear,
-        [FromQuery] int week,
-        // Nullable so an omitted param cannot bind to 0 and match no phase.
-        [FromQuery] int? phaseTypeCode,
-        [FromServices] IGetAthleteMatchupSummariesQueryHandler handler,
-        CancellationToken cancellationToken)
-    {
-        var result = await handler.ExecuteAsync(
-            new GetAthleteMatchupSummariesQuery(position, seasonYear, week, phaseTypeCode ?? 2),
             cancellationToken);
         return result.ToActionResult();
     }

--- a/src/SportsData.Producer/Application/Athletes/AthleteController.cs
+++ b/src/SportsData.Producer/Application/Athletes/AthleteController.cs
@@ -46,6 +46,25 @@ public class AthleteController : ControllerBase
     /// data is game-agnostic athlete/matchup data.
     /// Example: GET /api/athletes/matchup-summaries?position=QB&amp;seasonYear=2026&amp;week=1
     /// </summary>
+    /// <summary>
+    /// Batch box-score statlines for Player Pick'em scoring: one call per
+    /// lineup, returning category.statName → value maps per
+    /// (athleteSeason, contest). POST because the identity is two id
+    /// lists (same convention as contests/matchups/by-ids).
+    /// </summary>
+    [HttpPost("statlines")]
+    public async Task<ActionResult<List<AthleteStatlineDto>>> GetAthleteStatlines(
+        [FromBody] GetAthleteStatlinesRequest request,
+        [FromServices] Queries.GetAthleteStatlines.IGetAthleteStatlinesQueryHandler handler,
+        CancellationToken cancellationToken)
+    {
+        var result = await handler.ExecuteAsync(
+            new Queries.GetAthleteStatlines.GetAthleteStatlinesQuery(
+                request.ContestIds, request.AthleteSeasonIds),
+            cancellationToken);
+        return result.ToActionResult();
+    }
+
     [HttpGet("matchup-summaries")]
     public async Task<ActionResult<AthleteMatchupSummariesDto>> GetAthleteMatchupSummaries(
         [FromQuery] string position,

--- a/src/SportsData.Producer/Application/Athletes/Queries/GetAthleteStatlines/GetAthleteStatlinesQuery.cs
+++ b/src/SportsData.Producer/Application/Athletes/Queries/GetAthleteStatlines/GetAthleteStatlinesQuery.cs
@@ -1,0 +1,12 @@
+namespace SportsData.Producer.Application.Athletes.Queries.GetAthleteStatlines;
+
+/// <summary>
+/// Batch statline lookup for Player Pick'em scoring: every
+/// (athleteSeason, contest) statline where the athlete is in
+/// <see cref="AthleteSeasonIds"/> AND the contest is in
+/// <see cref="ContestIds"/>. Callers pass a lineup's anchored slots in
+/// ONE call.
+/// </summary>
+public record GetAthleteStatlinesQuery(
+    IReadOnlyList<Guid> ContestIds,
+    IReadOnlyList<Guid> AthleteSeasonIds);

--- a/src/SportsData.Producer/Application/Athletes/Queries/GetAthleteStatlines/GetAthleteStatlinesQueryHandler.cs
+++ b/src/SportsData.Producer/Application/Athletes/Queries/GetAthleteStatlines/GetAthleteStatlinesQueryHandler.cs
@@ -1,0 +1,85 @@
+using FluentValidation;
+
+using Microsoft.EntityFrameworkCore;
+
+using SportsData.Core.Common;
+using SportsData.Core.Dtos.Canonical;
+using SportsData.Producer.Infrastructure.Data.Common;
+
+namespace SportsData.Producer.Application.Athletes.Queries.GetAthleteStatlines;
+
+public interface IGetAthleteStatlinesQueryHandler
+{
+    Task<Result<List<AthleteStatlineDto>>> ExecuteAsync(
+        GetAthleteStatlinesQuery query,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Flattens AthleteCompetitionStatistic (unique per athlete-season +
+/// competition; kept live-fresh by the play-driven refresh debounce)
+/// into <c>category.statName → value</c> maps, scoped to the box-score
+/// categories the scoring matrix draws from. Contest resolves through
+/// Competition (1:1 by design).
+/// </summary>
+public class GetAthleteStatlinesQueryHandler : IGetAthleteStatlinesQueryHandler
+{
+    /// <summary>Categories the scoring matrix draws from — everything else (kick returns, defense until the DEF slot) stays out of the payload.</summary>
+    private static readonly string[] ScoringCategories =
+        ["passing", "rushing", "receiving", "fumbles", "kicking"];
+
+    private readonly TeamSportDataContext _dataContext;
+    private readonly IValidator<GetAthleteStatlinesQuery> _validator;
+
+    public GetAthleteStatlinesQueryHandler(
+        TeamSportDataContext dataContext,
+        IValidator<GetAthleteStatlinesQuery> validator)
+    {
+        _dataContext = dataContext;
+        _validator = validator;
+    }
+
+    public async Task<Result<List<AthleteStatlineDto>>> ExecuteAsync(
+        GetAthleteStatlinesQuery query,
+        CancellationToken cancellationToken = default)
+    {
+        var validation = await _validator.ValidateAsync(query, cancellationToken);
+        if (!validation.IsValid)
+        {
+            return new Failure<List<AthleteStatlineDto>>(
+                default!, ResultStatus.Validation, validation.Errors);
+        }
+
+        var rows = await (
+                from acs in _dataContext.AthleteCompetitionStatistics.AsNoTracking()
+                join comp in _dataContext.Competitions.AsNoTracking()
+                    on acs.CompetitionId equals comp.Id
+                where query.ContestIds.Contains(comp.ContestId) &&
+                      query.AthleteSeasonIds.Contains(acs.AthleteSeasonId)
+                from cat in acs.Categories
+                where ScoringCategories.Contains(cat.Name)
+                from stat in cat.Stats
+                where stat.Value != null
+                select new
+                {
+                    acs.AthleteSeasonId,
+                    comp.ContestId,
+                    Category = cat.Name,
+                    Stat = stat.Name,
+                    Value = stat.Value!.Value,
+                })
+            .ToListAsync(cancellationToken);
+
+        var statlines = rows
+            .GroupBy(r => (r.AthleteSeasonId, r.ContestId))
+            .Select(g => new AthleteStatlineDto
+            {
+                AthleteSeasonId = g.Key.AthleteSeasonId,
+                ContestId = g.Key.ContestId,
+                Stats = g.ToDictionary(r => $"{r.Category}.{r.Stat}", r => r.Value),
+            })
+            .ToList();
+
+        return new Success<List<AthleteStatlineDto>>(statlines);
+    }
+}

--- a/src/SportsData.Producer/Application/Athletes/Queries/GetAthleteStatlines/GetAthleteStatlinesQueryValidator.cs
+++ b/src/SportsData.Producer/Application/Athletes/Queries/GetAthleteStatlines/GetAthleteStatlinesQueryValidator.cs
@@ -11,14 +11,17 @@ public class GetAthleteStatlinesQueryValidator : AbstractValidator<GetAthleteSta
 {
     public GetAthleteStatlinesQueryValidator()
     {
+        // Null-guarded predicates: FluentValidation runs the whole chain
+        // even after NotEmpty fails, so a null body list must not NRE
+        // inside Must.
         RuleFor(x => x.ContestIds)
             .NotEmpty()
-            .Must(x => x.Count <= 100)
+            .Must(x => x is null || x.Count <= 100)
             .WithMessage("ContestIds must contain between 1 and 100 entries");
 
         RuleFor(x => x.AthleteSeasonIds)
             .NotEmpty()
-            .Must(x => x.Count <= 100)
+            .Must(x => x is null || x.Count <= 100)
             .WithMessage("AthleteSeasonIds must contain between 1 and 100 entries");
     }
 }

--- a/src/SportsData.Producer/Application/Athletes/Queries/GetAthleteStatlines/GetAthleteStatlinesQueryValidator.cs
+++ b/src/SportsData.Producer/Application/Athletes/Queries/GetAthleteStatlines/GetAthleteStatlinesQueryValidator.cs
@@ -1,0 +1,24 @@
+using FluentValidation;
+
+namespace SportsData.Producer.Application.Athletes.Queries.GetAthleteStatlines;
+
+/// <summary>
+/// Bounded batch: a lineup has single-digit slots; 100 is generous
+/// headroom for future league-wide scoring sweeps while keeping the
+/// IN-clauses sane.
+/// </summary>
+public class GetAthleteStatlinesQueryValidator : AbstractValidator<GetAthleteStatlinesQuery>
+{
+    public GetAthleteStatlinesQueryValidator()
+    {
+        RuleFor(x => x.ContestIds)
+            .NotEmpty()
+            .Must(x => x.Count <= 100)
+            .WithMessage("ContestIds must contain between 1 and 100 entries");
+
+        RuleFor(x => x.AthleteSeasonIds)
+            .NotEmpty()
+            .Must(x => x.Count <= 100)
+            .WithMessage("AthleteSeasonIds must contain between 1 and 100 entries");
+    }
+}

--- a/src/SportsData.Producer/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Producer/DependencyInjection/ServiceRegistration.cs
@@ -285,6 +285,10 @@ namespace SportsData.Producer.DependencyInjection
             services.AddScoped<IGetAthleteByIdQueryHandler, GetAthleteByIdQueryHandler>();
             services.AddScoped<IGetAthleteMatchupSummariesQueryHandler, GetAthleteMatchupSummariesQueryHandler>();
             services.AddScoped<IValidator<GetAthleteMatchupSummariesQuery>, GetAthleteMatchupSummariesQueryValidator>();
+            services.AddScoped<Application.Athletes.Queries.GetAthleteStatlines.IGetAthleteStatlinesQueryHandler,
+                Application.Athletes.Queries.GetAthleteStatlines.GetAthleteStatlinesQueryHandler>();
+            services.AddScoped<IValidator<Application.Athletes.Queries.GetAthleteStatlines.GetAthleteStatlinesQuery>,
+                Application.Athletes.Queries.GetAthleteStatlines.GetAthleteStatlinesQueryValidator>();
 
             // Athlete Commands
             services.AddScoped<IRequestAthleteSeasonStatisticsSourcingCommandHandler, RequestAthleteSeasonStatisticsSourcingCommandHandler>();

--- a/src/UI/sd-ui/src/components/pickem/players/PlayerRosterBuilder.css
+++ b/src/UI/sd-ui/src/components/pickem/players/PlayerRosterBuilder.css
@@ -345,3 +345,15 @@
 .roster-grid-status--error {
   color: var(--error, #e05d5d);
 }
+
+/* Live fantasy points on a filled slot chip (title = scored stat line). */
+.roster-slot-points {
+  display: block;
+  font-size: 0.78rem;
+  font-weight: 700;
+  color: var(--accent, #e0a52e);
+}
+
+.roster-total-points {
+  color: var(--accent, #e0a52e);
+}

--- a/src/UI/sd-ui/src/components/pickem/players/PlayerRosterBuilder.jsx
+++ b/src/UI/sd-ui/src/components/pickem/players/PlayerRosterBuilder.jsx
@@ -1,5 +1,6 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { Link, useParams } from 'react-router-dom';
+import { useContestUpdates } from '../../../contexts/ContestUpdatesContext';
 import PlayerPickemApi from '../../../api/playerPickemApi';
 import LeaguesApi from '../../../api/leagues/leaguesApi';
 import {
@@ -98,6 +99,13 @@ function PlayerRosterBuilder() {
   const seasonWeek = Number.isInteger(routeWeekNum) && routeWeekNum > 0 ? routeWeekNum : WEEK;
   const seasonPhase = routePhaseParam ?? 'regular';
   const [roster, setRoster] = useState({});
+  // Live lineup total from the server's read-time scoring (matrix-priced
+  // statlines, refreshed with the play-driven stat pipeline). Null until
+  // any anchored slot has a statline.
+  const [totalPoints, setTotalPoints] = useState(null);
+  // Live-refresh tickle: bumping this re-runs the lineup fetch WITHOUT
+  // the loading/reset churn of a league change (see the effect below).
+  const [refreshTick, setRefreshTick] = useState(0);
   // The user's PlayerPickem-type leagues (null = still loading). The
   // SPORT isn't a free choice — it's a fact of these leagues: the page
   // auto-selects the first sport with a player league, and the toggle
@@ -149,13 +157,21 @@ function PlayerRosterBuilder() {
   // Resolve the target league for the selected sport, then load the
   // server lineup (whose first read of a new week performs the lazy
   // carry-over clone server-side).
+  const lastRefreshTickRef = useRef(0);
   useEffect(() => {
     if (playerLeagues === null) return undefined; // leagues still loading
 
     let ignore = false;
-    setRosterLoading(true);
-    setSaveError(null);
-    setRoster({});
+    // A live-refresh rerun (refreshTick bumped) keeps the current roster
+    // on screen and silently swaps in fresh points; only a real
+    // league/week change resets the surface.
+    const isLiveRefresh = refreshTick !== lastRefreshTickRef.current;
+    lastRefreshTickRef.current = refreshTick;
+    if (!isLiveRefresh) {
+      setRosterLoading(true);
+      setSaveError(null);
+      setRoster({});
+    }
 
     const sport = LEAGUES.find((l) => l.id === league)?.sport;
     const routed = routeLeagueId
@@ -173,6 +189,7 @@ function PlayerRosterBuilder() {
       .then((response) => {
         if (ignore) return;
         setRoster(rosterFromLineup(response.data));
+        setTotalPoints(response.data?.totalPoints ?? null);
       })
       .catch(() => {
         if (!ignore) setSaveError('Could not load your roster.');
@@ -184,7 +201,49 @@ function PlayerRosterBuilder() {
     return () => {
       ignore = true;
     };
-  }, [league, playerLeagues, routeLeagueId, seasonWeek]);
+  }, [league, playerLeagues, routeLeagueId, seasonWeek, refreshTick]);
+
+  // ── Live scoring refresh (Phase 1 — see scoring.md) ─────────────────
+  // The play-completed SignalR events already flowing into
+  // ContestUpdatesContext stamp contests[id].lastUpdated. When activity
+  // lands on a contest one of OUR slots is anchored to, refetch the
+  // lineup twice: once shortly after the play (fast feedback) and once
+  // after the Producer stat-document debounce window (~3 min) so the
+  // numbers catch up. No polling: quiet games cost zero requests.
+  const { contests: liveContests } = useContestUpdates();
+  const anchoredActivity = useMemo(
+    () =>
+      Object.values(roster)
+        .filter((slot) => slot?.contestId)
+        .reduce(
+          (latest, slot) =>
+            Math.max(latest, liveContests[slot.contestId]?.lastUpdated ?? 0),
+          0
+        ),
+    [roster, liveContests]
+  );
+  const refreshTimersRef = useRef([]);
+  useEffect(() => {
+    if (anchoredActivity === 0) return undefined;
+    if (refreshTimersRef.current.length > 0) return undefined; // pair already pending
+
+    const bump = () => setRefreshTick((t) => t + 1);
+    refreshTimersRef.current = [
+      setTimeout(bump, 45 * 1000),
+      setTimeout(() => {
+        bump();
+        refreshTimersRef.current = [];
+      }, 240 * 1000),
+    ];
+    return undefined;
+  }, [anchoredActivity]);
+  useEffect(
+    () => () => {
+      refreshTimersRef.current.forEach(clearTimeout);
+      refreshTimersRef.current = [];
+    },
+    []
+  );
 
   const positions = useMemo(
     () => eligiblePositions(activeSlotId),
@@ -336,6 +395,9 @@ function PlayerRosterBuilder() {
         {pickemLeague ? (
           <> &middot; <strong>{pickemLeague.name}</strong></>
         ) : null}
+        {totalPoints != null && totalPoints !== 0 ? (
+          <> &middot; <strong className="roster-total-points">{totalPoints.toFixed(1)} pts</strong></>
+        ) : null}
       </p>
 
       {/* The sport is a fact of the user's player leagues, not a free
@@ -411,6 +473,11 @@ function PlayerRosterBuilder() {
                       ? 'Soon'
                       : '—'}
                 </span>
+                {filled && filled.points != null ? (
+                  <span className="roster-slot-points" title={filled.statLine || undefined}>
+                    {filled.points.toFixed(1)}
+                  </span>
+                ) : null}
               </button>
               {/* Locked slots hide the remove affordance — the server
                   would reject it anyway; don't offer a dead button. */}

--- a/src/UI/sd-ui/src/components/pickem/players/PlayerRosterBuilder.jsx
+++ b/src/UI/sd-ui/src/components/pickem/players/PlayerRosterBuilder.jsx
@@ -171,6 +171,7 @@ function PlayerRosterBuilder() {
       setRosterLoading(true);
       setSaveError(null);
       setRoster({});
+      setTotalPoints(null); // never show a total for a roster we cleared
     }
 
     const sport = LEAGUES.find((l) => l.id === league)?.sport;
@@ -361,6 +362,9 @@ function PlayerRosterBuilder() {
         pickemLeague.id, pickemLeague.seasonYear ?? SEASON_YEAR, seasonWeek, activeSlotId, athlete
       );
       setRoster((prev) => ({ ...prev, [activeSlotId]: response.data }));
+      // Slot points and the total must come from one server response —
+      // pull a silent refresh so they can't drift.
+      setRefreshTick((t) => t + 1);
     } catch (err) {
       setSaveError(errorMessage(err, 'Could not save that pick.'));
     }
@@ -376,6 +380,8 @@ function PlayerRosterBuilder() {
         delete next[slotId];
         return next;
       });
+      setRefreshTick((t) => t + 1); // re-sync total with the server
+
     } catch (err) {
       setSaveError(errorMessage(err, 'Could not clear that slot.'));
     }

--- a/test/unit/SportsData.Api.Tests.Unit/Application/UI/PlayerLineups/PlayerPickemScoringEngineTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/UI/PlayerLineups/PlayerPickemScoringEngineTests.cs
@@ -1,0 +1,123 @@
+using FluentAssertions;
+
+using SportsData.Api.Application.UI.PlayerLineups.Scoring;
+using SportsData.Api.Infrastructure.Data.Entities;
+
+using Xunit;
+
+namespace SportsData.Api.Tests.Unit.Application.UI.PlayerLineups;
+
+/// <summary>
+/// The scoring engine: per-unit math, derived kicker keys, and the
+/// matrix-is-data contract (values come from rules; structure from
+/// code). Rules here mirror the seeded Standard set where relevant.
+/// </summary>
+public class PlayerPickemScoringEngineTests
+{
+    private static PlayerScoringRule Rule(string key, decimal points, decimal perUnits = 1m) => new()
+    {
+        Id = Guid.NewGuid(),
+        RuleSetId = Guid.NewGuid(),
+        StatKey = key,
+        Points = points,
+        PerUnits = perUnits,
+    };
+
+    [Fact]
+    public void QbLine_ScoresFractionalYards_AndCountsNegatives()
+    {
+        // 187 pass yds @ 1/25 = 7.48; 2 pass TD = 12; 1 INT = -2 → 17.48
+        var rules = new[]
+        {
+            Rule("passing.passingYards", 1m, 25m),
+            Rule("passing.passingTouchdowns", 6m),
+            Rule("passing.interceptions", -2m),
+        };
+        var stats = new Dictionary<string, decimal>
+        {
+            ["passing.passingYards"] = 187m,
+            ["passing.passingTouchdowns"] = 2m,
+            ["passing.interceptions"] = 1m,
+        };
+
+        var score = PlayerPickemScoringEngine.Score(rules, stats);
+
+        score.Points.Should().Be(17.48m);
+        score.Contributions.Should().HaveCount(3);
+    }
+
+    [Fact]
+    public void KickerBuckets_DeriveFromRawStats()
+    {
+        // 2 XP made of 3 attempts (-2 for the miss), one 33-yarder made
+        // (3 pts via the 17-39 tier), one 45-yarder missed (-1).
+        var rules = new[]
+        {
+            Rule("kicking.extraPointsMade", 1m),
+            Rule("derived.missedExtraPoints", -2m),
+            Rule("derived.fieldGoalsMade17_39", 3m),
+            Rule("derived.fieldGoalsMissed40_49", -1m),
+        };
+        var stats = new Dictionary<string, decimal>
+        {
+            ["kicking.extraPointsMade"] = 2m,
+            ["kicking.extraPointAttempts"] = 3m,
+            ["kicking.fieldGoalsMade30_39"] = 1m,
+            ["kicking.fieldGoalAttempts30_39"] = 1m,
+            ["kicking.fieldGoalAttempts40_49"] = 1m,
+            ["kicking.fieldGoalsMade40_49"] = 0m,
+        };
+
+        var score = PlayerPickemScoringEngine.Score(rules, stats);
+
+        // 2 XP + (-2 miss) + 3 FG + (-1 missed 40-49) = 2
+        score.Points.Should().Be(2m);
+    }
+
+    [Fact]
+    public void UnscoredStats_AndZeroValues_ContributeNothing()
+    {
+        var rules = new[] { Rule("rushing.rushingYards", 1m, 10m) };
+        var stats = new Dictionary<string, decimal>
+        {
+            ["rushing.rushingYards"] = 0m,
+            ["receiving.receivingYards"] = 85m, // no rule for it in this set
+        };
+
+        var score = PlayerPickemScoringEngine.Score(rules, stats);
+
+        score.Points.Should().Be(0m);
+        score.Contributions.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ZeroPerUnitsRule_IsIgnored_NeverDivides()
+    {
+        var rules = new[] { Rule("rushing.rushingYards", 1m, 0m) };
+        var stats = new Dictionary<string, decimal> { ["rushing.rushingYards"] = 50m };
+
+        var score = PlayerPickemScoringEngine.Score(rules, stats);
+
+        score.Points.Should().Be(0m);
+    }
+
+    [Fact]
+    public void StatLine_MatchesScoredContributions()
+    {
+        var rules = new[]
+        {
+            Rule("passing.passingYards", 1m, 25m),
+            Rule("passing.passingTouchdowns", 6m),
+        };
+        var stats = new Dictionary<string, decimal>
+        {
+            ["passing.passingYards"] = 187m,
+            ["passing.passingTouchdowns"] = 2m,
+        };
+
+        var score = PlayerPickemScoringEngine.Score(rules, stats);
+        var line = PlayerPickemScoringEngine.BuildStatLine(score.Contributions);
+
+        line.Should().Be("187 PaYd · 2 PaTD");
+    }
+}

--- a/test/unit/SportsData.Api.Tests.Unit/Application/UI/PlayerLineups/PlayerPickemScoringEngineTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/UI/PlayerLineups/PlayerPickemScoringEngineTests.cs
@@ -1,7 +1,6 @@
 using FluentAssertions;
 
 using SportsData.Api.Application.UI.PlayerLineups.Scoring;
-using SportsData.Api.Infrastructure.Data.Entities;
 
 using Xunit;
 
@@ -14,14 +13,8 @@ namespace SportsData.Api.Tests.Unit.Application.UI.PlayerLineups;
 /// </summary>
 public class PlayerPickemScoringEngineTests
 {
-    private static PlayerScoringRule Rule(string key, decimal points, decimal perUnits = 1m) => new()
-    {
-        Id = Guid.NewGuid(),
-        RuleSetId = Guid.NewGuid(),
-        StatKey = key,
-        Points = points,
-        PerUnits = perUnits,
-    };
+    private static ScoringRule Rule(string key, decimal points, decimal perUnits = 1m) =>
+        new(key, points, perUnits);
 
     [Fact]
     public void QbLine_ScoresFractionalYards_AndCountsNegatives()


### PR DESCRIPTION
## Scoring v1

Performance-points scoring for Player Pick'em, targeting private prod testing during NFL preseason. Design doc: `docs/features/player-pickem/scoring.md`.

**The matrix is data, the engine is code:**
- `PlayerScoringRuleSet` + `PlayerScoringRule`: each rule is `{StatKey, Points, PerUnits}`; `points = value × Points / PerUnits` (fractional, 2dp). The operator's standard chart is **seeded as the default set via migration** (stable ids) — tuning a value is a data update, no deploy. Per-league rule-set selection is a later nullable FK on `PickemGroup`.
- `PlayerPickemScoringEngine` owns only structure: derived kicker keys (missed XP = attempts − made; the chart's FG 17–39 tier = ESPN's 1-19/20-29/30-39 buckets summed), per-unit math, and a stat-line builder whose display always matches the scored points.

**Flow (read-time, fail-open):**
- Producer: `POST athletes/statlines` — batch flattened `category.statName → value` maps per (athleteSeason, contest), scoped to box-score categories, live-fresh via the play-driven stat refresh (#677).
- API: `GetMyPlayerLineup` prices anchored slots with the `IsDefault` rule set in one statline batch; slots gain `points` + `statLine`, the lineup gains `totalPoints`. A scoring failure never 500s the roster.
- Web: points on each filled slot chip (hover = the scored stat line) + lineup total.

**Refresh triggers — no polling, no background jobs:**
- **Phase 1 (this PR)**: the play-completed SignalR events already stamping `ContestUpdatesContext` drive a silent refetch pair (~45s + ~4min after activity on an *anchored* contest). Quiet games and idle tabs cost zero requests; live refetches keep the roster on screen (no loading flash).
- **Phase 2 (next PR, with persistence + standings)**: `AthleteCompetitionStatsUpdated` from the stat document processor → shovel → API consumer → persist + league SignalR broadcast; finals ride the contest-finalized chain.

## Deploy notes

- Migration (+ matrix seed) rides API startup; applied and verified on local `sdApi.All` (19 rules).
- Producer images needed for the statlines endpoint.

## Validation

- API 751/751 (5 new engine tests incl. the QB 17.48 worked example and kicker bucket derivation)
- Solution-wide build zero errors; web 83/83 vitest + eslint + prod build

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnJySMvfUPeQSMufNNcKSK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added live Player Pick’em scoring using stat-based rules and a Standard scoring format.
  * Player rosters now display individual player points, total lineup points, and readable stat details.
  * Roster scores refresh automatically following relevant contest activity.
  * Added batch athlete statline retrieval to support timely scoring updates.

* **Documentation**
  * Added v1 documentation covering scoring rules, refresh behavior, and current limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->