### PR TITLE
fix(api,provider): Hangfire DCE interface placement + ESPN known-bad URI suppression

### DIFF
--- a/src/SportsData.Api/Application/Scoring/LeagueWeekScoringProcessor.cs
+++ b/src/SportsData.Api/Application/Scoring/LeagueWeekScoringProcessor.cs
@@ -8,6 +8,14 @@ namespace SportsData.Api.Application.Scoring;
 
 public interface IScoreLeagueWeeks
 {
+    // The DCE attribute MUST live here, not on the implementing class:
+    // callers enqueue via Enqueue<IScoreLeagueWeeks>(...), so Hangfire
+    // stores the job against this interface method and resolves job
+    // filters from it — attributes on the implementation are never seen.
+    // Prod proof (2026-08-28): four simultaneous finalizations ran twelve
+    // concurrent Process invocations and revived the 23505 race the
+    // class-level attribute was meant to kill.
+    [DisableConcurrentExecution(60)]
     Task Process(Guid leagueId, int seasonYear, int seasonWeek, Guid correlationId);
 }
 
@@ -19,8 +27,9 @@ public interface IScoreLeagueWeeks
 /// racing on the <c>PickemGroupWeekResult</c> unique index.
 ///
 /// Two-layer safety:
-///   1. <see cref="DisableConcurrentExecutionAttribute"/> serializes invocations
-///      of <see cref="Process"/> across the cluster — eliminates the 23505 race.
+///   1. <see cref="DisableConcurrentExecutionAttribute"/> on
+///      <see cref="IScoreLeagueWeeks.Process"/> serializes invocations
+///      across the cluster — eliminates the 23505 race.
 ///   2. A staleness short-circuit collapses N queued runs into 1 actual rescore:
 ///      the first run does the work; the rest find fresh state and exit.
 ///
@@ -28,7 +37,6 @@ public interface IScoreLeagueWeeks
 /// Acceptable while per-run work is sub-second; revisit with a per-tuple
 /// server filter or pg_advisory lock if contention grows.
 /// </summary>
-[DisableConcurrentExecution(60)]
 public class LeagueWeekScoringProcessor : IScoreLeagueWeeks
 {
     private readonly ILogger<LeagueWeekScoringProcessor> _logger;

--- a/src/SportsData.Api/Application/Scoring/LeagueWeekScoringProcessor.cs
+++ b/src/SportsData.Api/Application/Scoring/LeagueWeekScoringProcessor.cs
@@ -29,7 +29,11 @@ public interface IScoreLeagueWeeks
 /// Two-layer safety:
 ///   1. <see cref="DisableConcurrentExecutionAttribute"/> on
 ///      <see cref="IScoreLeagueWeeks.Process"/> serializes invocations
-///      across the cluster — eliminates the 23505 race.
+///      across the cluster. Best-effort: a broken storage connection can
+///      release the lock without notice, so this reduces the probability
+///      of the 23505 race rather than eliminating it — the check-then-
+///      insert in ScoreLeagueWeekAsync plus Hangfire retry (which finds
+///      the existing row and updates) remain the backstop.
 ///   2. A staleness short-circuit collapses N queued runs into 1 actual rescore:
 ///      the first run does the work; the rest find fresh state and exit.
 ///

--- a/src/SportsData.Provider/Application/Documents/DocumentRequestedHandler.cs
+++ b/src/SportsData.Provider/Application/Documents/DocumentRequestedHandler.cs
@@ -11,6 +11,7 @@ using SportsData.Core.Infrastructure.DataSources.Espn;
 using SportsData.Core.Infrastructure.DataSources.Espn.Dtos;
 using SportsData.Core.Processing;
 using SportsData.Provider.Application.Processors;
+using SportsData.Provider.Infrastructure.Providers.Espn;
 
 using System.Text.Json;
 
@@ -22,17 +23,20 @@ public class DocumentRequestedHandler : IConsumer<DocumentRequested>
     private readonly ILogger<DocumentRequestedHandler> _logger;
     private readonly IProvideBackgroundJobs _backgroundJobProvider;
     private readonly CommonConfig _commonConfig;
+    private readonly IKnownBadUriCache _knownBadUris;
 
     public DocumentRequestedHandler(
         IProvideEspnApiData espnApi,
         ILogger<DocumentRequestedHandler> logger,
         IProvideBackgroundJobs backgroundJobProvider,
-        IOptions<CommonConfig> commonConfig)
+        IOptions<CommonConfig> commonConfig,
+        IKnownBadUriCache knownBadUris)
     {
         _espnApi = espnApi;
         _logger = logger;
         _backgroundJobProvider = backgroundJobProvider;
         _commonConfig = commonConfig.Value;
+        _knownBadUris = knownBadUris;
     }
 
     public async Task Consume(ConsumeContext<DocumentRequested> context)
@@ -235,6 +239,14 @@ public class DocumentRequestedHandler : IConsumer<DocumentRequested>
 
     private async Task ProcessResourceIndex(Uri uri, DocumentRequested evt)
     {
+        if (await _knownBadUris.IsKnownBadAsync(uri))
+        {
+            _logger.LogDebug(
+                "Skipping known-bad URI (previous ESPN 400). Uri={Uri}",
+                uri);
+            return;
+        }
+
         var seenPages = new HashSet<string>();
         var enqueuedAnyRefs = false;
         var totalItemsEnqueued = 0;
@@ -250,6 +262,19 @@ public class DocumentRequestedHandler : IConsumer<DocumentRequested>
 
             if (!result.IsSuccess)
             {
+                if (result.Status == ResultStatus.BadRequest)
+                {
+                    // ESPN 400 = the resource is unsupported (permanent),
+                    // e.g. no win-probability model for this competition.
+                    // Remember it so the live streamers' fixed-cadence
+                    // re-requests short-circuit instead of re-hitting ESPN.
+                    await _knownBadUris.MarkBadAsync(uri);
+                    _logger.LogWarning(
+                        "ESPN returned BadRequest; marking URI known-bad and suppressing refetches. PageUri={PageUri}",
+                        uri);
+                    return;
+                }
+
                 _logger.LogError(
                     "Failed to fetch resource index: Status={Status}, PageUri={PageUri}",
                     result.Status,

--- a/src/SportsData.Provider/Application/Jobs/IProcessResourceIndexes.cs
+++ b/src/SportsData.Provider/Application/Jobs/IProcessResourceIndexes.cs
@@ -1,8 +1,15 @@
-﻿using SportsData.Provider.Application.Jobs.Definitions;
+using Hangfire;
+
+using SportsData.Provider.Application.Jobs.Definitions;
 
 namespace SportsData.Provider.Application.Jobs;
 
 public interface IProcessResourceIndexes
 {
+    // The DCE attribute MUST live here, not on ResourceIndexJob: jobs are
+    // enqueued via Enqueue<IProcessResourceIndexes>(...), so Hangfire stores
+    // the job against this interface method and resolves job filters from
+    // it — attributes on the implementing class are never seen.
+    [DisableConcurrentExecution(300)] // 5 minutes (outer gate)
     Task ExecuteAsync(DocumentJobDefinition jobDefinition);
 }

--- a/src/SportsData.Provider/Application/Jobs/ResourceIndexJob.cs
+++ b/src/SportsData.Provider/Application/Jobs/ResourceIndexJob.cs
@@ -1,6 +1,4 @@
-﻿using Hangfire;
-
-using Microsoft.EntityFrameworkCore;
+﻿using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 
 using SportsData.Core.Common;
@@ -16,7 +14,10 @@ using SportsData.Provider.Infrastructure.Data;
 
 namespace SportsData.Provider.Application.Jobs
 {
-    [DisableConcurrentExecution(300)] // 5 minutes (outer gate)
+    // Concurrency gate: [DisableConcurrentExecution] lives on
+    // IProcessResourceIndexes.ExecuteAsync — jobs enqueue via the
+    // interface, and Hangfire resolves filters from the stored job's
+    // (interface) method, never from the implementing class.
     public class ResourceIndexJob : IProcessResourceIndexes
     {
         private readonly ILogger<ResourceIndexJob> _logger;

--- a/src/SportsData.Provider/Application/Processors/ResourceIndexItemProcessor.cs
+++ b/src/SportsData.Provider/Application/Processors/ResourceIndexItemProcessor.cs
@@ -9,6 +9,7 @@ using SportsData.Core.Infrastructure.DataSources.Espn;
 using SportsData.Provider.Application.Services;
 using SportsData.Provider.Infrastructure.Data;
 using SportsData.Provider.Infrastructure.Data.Entities;
+using SportsData.Provider.Infrastructure.Providers.Espn;
 
 using System.Diagnostics.Metrics;
 
@@ -31,6 +32,7 @@ namespace SportsData.Provider.Application.Processors
         private readonly IGenerateExternalRefIdentities _identityGenerator;
         private readonly IDocumentInclusionService _documentInclusionService;
         private readonly IDateTimeProvider _dateTimeProvider;
+        private readonly IKnownBadUriCache _knownBadUris;
 
         private readonly Counter<long> _mongoCacheHitCounter;
         private readonly Counter<long> _espnLiveFetchCounter;
@@ -46,6 +48,7 @@ namespace SportsData.Provider.Application.Processors
             IGenerateExternalRefIdentities identityGenerator,
             IDocumentInclusionService documentInclusionService,
             IDateTimeProvider dateTimeProvider,
+            IKnownBadUriCache knownBadUris,
             IMeterFactory meterFactory)
         {
             _logger = logger;
@@ -58,6 +61,7 @@ namespace SportsData.Provider.Application.Processors
             _identityGenerator = identityGenerator;
             _documentInclusionService = documentInclusionService;
             _dateTimeProvider = dateTimeProvider;
+            _knownBadUris = knownBadUris;
 
             var meter = meterFactory.Create("SportsData.Provider.Espn");
             _mongoCacheHitCounter = meter.CreateCounter<long>("espn.cache.hit", description: "Documents served from MongoDB cache (no ESPN API call)");
@@ -276,6 +280,14 @@ namespace SportsData.Provider.Application.Processors
             }
             else
             {
+                if (await _knownBadUris.IsKnownBadAsync(command.Uri))
+                {
+                    _logger.LogDebug(
+                        "Skipping known-bad URI (previous ESPN 400). Uri={Uri}",
+                        command.Uri);
+                    return;
+                }
+
                 _espnLiveFetchCounter.Add(1);
                 _logger.LogInformation(
                     "ESPN {CacheResult}. UrlHash={UrlHash}, Uri={Uri}",
@@ -285,6 +297,18 @@ namespace SportsData.Provider.Application.Processors
 
                 if (!result.IsSuccess)
                 {
+                    if (result.Status == ResultStatus.BadRequest)
+                    {
+                        // ESPN 400 = permanently unsupported resource (unlike
+                        // 404 = not yet published, which must keep retrying).
+                        // Suppress the live streamers' fixed-cadence refetches.
+                        await _knownBadUris.MarkBadAsync(command.Uri);
+                        _logger.LogWarning(
+                            "ESPN returned BadRequest; marking URI known-bad and suppressing refetches. Uri={Uri}",
+                            command.Uri);
+                        return;
+                    }
+
                     _logger.LogError(
                         "ESPN request failed: Status={Status}, Uri={Uri}",
                         result.Status,

--- a/src/SportsData.Provider/Application/ResourceIndex/ResourceIndexController.cs
+++ b/src/SportsData.Provider/Application/ResourceIndex/ResourceIndexController.cs
@@ -64,7 +64,9 @@ namespace SportsData.Provider.Application.ResourceIndex
                     string.Join(", ", request.IncludeLinkedDocumentTypes).Sanitize());
             }
 
-            var result = _backgroundJobProvider.Enqueue<ResourceIndexJob>(x => x.ExecuteAsync(jobDef));
+            // Interface-typed enqueue so the [DisableConcurrentExecution] filter
+            // on IProcessResourceIndexes.ExecuteAsync applies to this job too.
+            var result = _backgroundJobProvider.Enqueue<IProcessResourceIndexes>(x => x.ExecuteAsync(jobDef));
 
             return Accepted(result);
         }

--- a/src/SportsData.Provider/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Provider/DependencyInjection/ServiceRegistration.cs
@@ -14,6 +14,7 @@ using SportsData.Provider.Application.Services;
 using SportsData.Provider.Application.Sourcing.Historical;
 using SportsData.Provider.Application.Sourcing.Historical.Saga;
 using SportsData.Provider.Infrastructure.Data;
+using SportsData.Provider.Infrastructure.Providers.Espn;
 
 using System.Net;
 using System.Net.Security;
@@ -36,6 +37,13 @@ namespace SportsData.Provider.DependencyInjection
             services.AddScoped<IResourceIndexItemParser, ResourceIndexItemParser>();
             services.AddScoped<IProvideBackgroundJobs, BackgroundJobProvider>();
             services.AddScoped<IDocumentInclusionService, DocumentInclusionService>();
+
+            // Singleton: ESPN URIs that returned 400 (permanently
+            // unsupported resources) so fixed-cadence re-requests
+            // short-circuit instead of re-hitting ESPN. In-memory for the
+            // hot path, backed by the EspnKnownBadUri table (hydrate at
+            // first use, write-through) so fresh pods inherit the knowledge.
+            services.AddSingleton<IKnownBadUriCache, KnownBadUriCache>();
 
             // Historical sourcing services
             services.AddOptions<HistoricalSourcingConfig>()

--- a/src/SportsData.Provider/Infrastructure/Data/AppDataContext.cs
+++ b/src/SportsData.Provider/Infrastructure/Data/AppDataContext.cs
@@ -19,6 +19,8 @@ namespace SportsData.Provider.Infrastructure.Data
 
         public DbSet<HistoricalSeasonSourcingState> HistoricalSourcingSagas { get; set; }
 
+        public DbSet<EspnKnownBadUri> EspnKnownBadUris { get; set; }
+
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
             base.OnModelCreating(modelBuilder);

--- a/src/SportsData.Provider/Infrastructure/Data/Entities/EspnKnownBadUri.cs
+++ b/src/SportsData.Provider/Infrastructure/Data/Entities/EspnKnownBadUri.cs
@@ -1,0 +1,49 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+using System;
+
+namespace SportsData.Provider.Infrastructure.Data.Entities
+{
+    /// <summary>
+    /// An ESPN URI that returned 400 BadRequest — a permanent "unsupported
+    /// resource" verdict (e.g. "Probabilities are not supported for ...
+    /// competition: X"). Persisted so the suppression survives pod restarts
+    /// and KEDA scale-ups: <see cref="Providers.Espn.KnownBadUriCache"/>
+    /// hydrates from this table at startup and writes through on new 400s.
+    /// Rows expire via <see cref="ExpiresUtc"/> so a resource that gains
+    /// support is eventually re-probed. Doubles as an operator view of
+    /// everything ESPN refuses to serve.
+    /// </summary>
+    public class EspnKnownBadUri
+    {
+        /// <summary>
+        /// SHA-256 of the normalized URL (scheme+host+path, lowercased, no
+        /// query string) via <c>HashProvider.GenerateHashFromUri</c> — query
+        /// variants (paging, lang/region) collapse to one row.
+        /// </summary>
+        public required string UrlHash { get; set; }
+
+        public required Uri Uri { get; set; }
+
+        public DateTime CreatedUtc { get; set; }
+
+        public DateTime ExpiresUtc { get; set; }
+
+        public class EntityConfiguration : IEntityTypeConfiguration<EspnKnownBadUri>
+        {
+            public void Configure(EntityTypeBuilder<EspnKnownBadUri> builder)
+            {
+                builder.ToTable(nameof(EspnKnownBadUri));
+
+                builder.HasKey(t => t.UrlHash);
+
+                builder.Property(x => x.UrlHash)
+                    .HasMaxLength(64);
+
+                builder.Property(p => p.Uri)
+                    .HasMaxLength(512);
+            }
+        }
+    }
+}

--- a/src/SportsData.Provider/Infrastructure/Providers/Espn/KnownBadUriCache.cs
+++ b/src/SportsData.Provider/Infrastructure/Providers/Espn/KnownBadUriCache.cs
@@ -1,0 +1,166 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+using SportsData.Core.Common;
+using SportsData.Core.Common.Hashing;
+using SportsData.Provider.Infrastructure.Data;
+using SportsData.Provider.Infrastructure.Data.Entities;
+
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SportsData.Provider.Infrastructure.Providers.Espn
+{
+    /// <summary>
+    /// Remembers ESPN URIs that returned 400 BadRequest so repeat requests
+    /// short-circuit instead of re-hitting ESPN. A 400 is a permanent
+    /// "unsupported" answer (e.g. "Probabilities are not supported for ...
+    /// competition: X") — unlike 404 (dependency not yet published; must
+    /// keep retrying) or 403 (rate limiting; handled by the retry policy).
+    /// Producer's live streamers re-request child documents on a fixed
+    /// cadence for the whole game, so without this an unsupported document
+    /// is refetched every cycle.
+    ///
+    /// Two layers: an in-memory dictionary serves the per-fetch check with
+    /// zero DB reads; the <see cref="EspnKnownBadUri"/> table makes the
+    /// knowledge durable — hydrated once at first use (so a fresh KEDA pod
+    /// starts already knowing what every previous pod learned) and written
+    /// through on each new 400.
+    /// </summary>
+    public interface IKnownBadUriCache
+    {
+        Task<bool> IsKnownBadAsync(Uri uri);
+        Task MarkBadAsync(Uri uri);
+    }
+
+    public class KnownBadUriCache : IKnownBadUriCache
+    {
+        private static readonly TimeSpan Ttl = TimeSpan.FromHours(12);
+
+        private readonly IServiceScopeFactory _scopeFactory;
+        private readonly IDateTimeProvider _dateTimeProvider;
+        private readonly ILogger<KnownBadUriCache> _logger;
+        private readonly ConcurrentDictionary<string, DateTime> _expiryByKey = new();
+        private readonly SemaphoreSlim _hydrateLock = new(1, 1);
+        private volatile bool _hydrated;
+
+        public KnownBadUriCache(
+            IServiceScopeFactory scopeFactory,
+            IDateTimeProvider dateTimeProvider,
+            ILogger<KnownBadUriCache> logger)
+        {
+            _scopeFactory = scopeFactory;
+            _dateTimeProvider = dateTimeProvider;
+            _logger = logger;
+        }
+
+        public async Task<bool> IsKnownBadAsync(Uri uri)
+        {
+            await EnsureHydratedAsync();
+
+            var key = HashProvider.GenerateHashFromUri(uri);
+            if (!_expiryByKey.TryGetValue(key, out var expiry))
+                return false;
+
+            if (expiry > _dateTimeProvider.UtcNow())
+                return true;
+
+            _expiryByKey.TryRemove(key, out _);
+            return false;
+        }
+
+        public async Task MarkBadAsync(Uri uri)
+        {
+            var now = _dateTimeProvider.UtcNow();
+            var key = HashProvider.GenerateHashFromUri(uri);
+            var expiresUtc = now.Add(Ttl);
+
+            // Memory first — suppression works even if the write below fails.
+            _expiryByKey[key] = expiresUtc;
+
+            try
+            {
+                using var scope = _scopeFactory.CreateScope();
+                var dataContext = scope.ServiceProvider.GetRequiredService<AppDataContext>();
+
+                var row = await dataContext.EspnKnownBadUris
+                    .FirstOrDefaultAsync(x => x.UrlHash == key);
+                if (row is null)
+                {
+                    dataContext.EspnKnownBadUris.Add(new EspnKnownBadUri
+                    {
+                        UrlHash = key,
+                        Uri = uri,
+                        CreatedUtc = now,
+                        ExpiresUtc = expiresUtc,
+                    });
+                }
+                else
+                {
+                    row.ExpiresUtc = expiresUtc;
+                }
+
+                // The table stays tiny; prune expired rows opportunistically.
+                var expired = await dataContext.EspnKnownBadUris
+                    .Where(x => x.ExpiresUtc <= now)
+                    .ToListAsync();
+                dataContext.EspnKnownBadUris.RemoveRange(expired);
+
+                await dataContext.SaveChangesAsync();
+            }
+            catch (DbUpdateException ex)
+            {
+                // Another pod raced us to the same insert — its row is as
+                // good as ours; memory is already updated.
+                _logger.LogDebug(ex, "Concurrent EspnKnownBadUri write; keeping existing row. Uri={Uri}", uri);
+            }
+        }
+
+        private async Task EnsureHydratedAsync()
+        {
+            if (_hydrated) return;
+
+            await _hydrateLock.WaitAsync();
+            try
+            {
+                if (_hydrated) return;
+
+                using var scope = _scopeFactory.CreateScope();
+                var dataContext = scope.ServiceProvider.GetRequiredService<AppDataContext>();
+
+                var now = _dateTimeProvider.UtcNow();
+                var rows = await dataContext.EspnKnownBadUris
+                    .AsNoTracking()
+                    .Where(x => x.ExpiresUtc > now)
+                    .Select(x => new { x.UrlHash, x.ExpiresUtc })
+                    .ToListAsync();
+
+                foreach (var row in rows)
+                    _expiryByKey.TryAdd(row.UrlHash, row.ExpiresUtc);
+
+                _hydrated = true;
+
+                if (rows.Count > 0)
+                {
+                    _logger.LogInformation(
+                        "Hydrated {Count} known-bad ESPN URIs from the database.",
+                        rows.Count);
+                }
+            }
+            catch (Exception ex)
+            {
+                // Leave _hydrated false so the next call retries; suppression
+                // still works for anything learned in-process meanwhile.
+                _logger.LogWarning(ex, "Failed to hydrate known-bad URI cache; will retry on next check.");
+            }
+            finally
+            {
+                _hydrateLock.Release();
+            }
+        }
+    }
+}

--- a/src/SportsData.Provider/Migrations/20260828101916_EspnKnownBadUri.Designer.cs
+++ b/src/SportsData.Provider/Migrations/20260828101916_EspnKnownBadUri.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SportsData.Provider.Infrastructure.Data;
@@ -11,9 +12,11 @@ using SportsData.Provider.Infrastructure.Data;
 namespace SportsData.Provider.Migrations
 {
     [DbContext(typeof(AppDataContext))]
-    partial class AppDataContextModelSnapshot : ModelSnapshot
+    [Migration("20260828101916_EspnKnownBadUri")]
+    partial class EspnKnownBadUri
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/SportsData.Provider/Migrations/20260828101916_EspnKnownBadUri.cs
+++ b/src/SportsData.Provider/Migrations/20260828101916_EspnKnownBadUri.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SportsData.Provider.Migrations
+{
+    /// <inheritdoc />
+    public partial class EspnKnownBadUri : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<uint>(
+                name: "xmin",
+                table: "HistoricalSourcingSagas",
+                type: "xid",
+                rowVersion: true,
+                nullable: false,
+                defaultValue: 0u);
+
+            migrationBuilder.CreateTable(
+                name: "EspnKnownBadUri",
+                columns: table => new
+                {
+                    UrlHash = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    Uri = table.Column<string>(type: "character varying(512)", maxLength: 512, nullable: false),
+                    CreatedUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    ExpiresUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_EspnKnownBadUri", x => x.UrlHash);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "EspnKnownBadUri");
+
+            migrationBuilder.DropColumn(
+                name: "xmin",
+                table: "HistoricalSourcingSagas");
+        }
+    }
+}

--- a/test/unit/SportsData.Provider.Tests.Unit/Application/Documents/DocumentRequestedHandlerTests.cs
+++ b/test/unit/SportsData.Provider.Tests.Unit/Application/Documents/DocumentRequestedHandlerTests.cs
@@ -713,4 +713,64 @@ public class DocumentRequestedHandlerTests : ProviderTestBase<DocumentRequestedH
         command.Uri.Should().Be(leafUri);
         command.BypassCache.Should().Be(expectBypass);
     }
+
+    private static readonly Uri ProbabilitiesUri = new(
+        "http://sports.core.api.espn.com/v2/sports/football/leagues/college-football/events/401866615/competitions/401866615/probabilities?lang=en&region=us");
+
+    private static DocumentRequested ProbabilitiesRequest(IFixture fixture) =>
+        fixture.Build<DocumentRequested>()
+            .With(x => x.Uri, ProbabilitiesUri)
+            .With(x => x.DocumentType, DocumentType.EventCompetitionProbability)
+            .With(x => x.SourceDataProvider, SourceDataProvider.Espn)
+            .With(x => x.Sport, Sport.FootballNcaa)
+            .OmitAutoProperties()
+            .Create();
+
+    [Fact]
+    public async Task WhenEspnReturnsBadRequest_MarksUriKnownBad_AndEnqueuesNothing()
+    {
+        // arrange — ESPN 400s the probabilities index (permanently
+        // unsupported for this competition).
+        Mocker.GetMock<IProvideEspnApiData>()
+            .Setup(x => x.GetResource(It.IsAny<Uri>(), true, false))
+            .ReturnsAsync(new Failure<string>(string.Empty, ResultStatus.BadRequest, []));
+
+        var knownBad = Mocker.GetMock<IKnownBadUriCache>();
+        var background = Mocker.GetMock<IProvideBackgroundJobs>();
+        var handler = Mocker.CreateInstance<DocumentRequestedHandler>();
+
+        var msg = ProbabilitiesRequest(Fixture);
+        var ctx = Mock.Of<ConsumeContext<DocumentRequested>>(x => x.Message == msg);
+
+        // act
+        await handler.Consume(ctx);
+
+        // assert
+        knownBad.Verify(x => x.MarkBadAsync(ProbabilitiesUri), Times.Once);
+        background.Verify(x => x.Enqueue<IProcessResourceIndexItems>(
+            It.IsAny<Expression<Func<IProcessResourceIndexItems, Task>>>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task WhenUriIsKnownBad_SkipsEspnFetch()
+    {
+        // arrange — the URI 400'd earlier; re-requests must not hit ESPN.
+        Mocker.GetMock<IKnownBadUriCache>()
+            .Setup(x => x.IsKnownBadAsync(It.IsAny<Uri>()))
+            .ReturnsAsync(true);
+
+        var espnApi = Mocker.GetMock<IProvideEspnApiData>();
+        var handler = Mocker.CreateInstance<DocumentRequestedHandler>();
+
+        var msg = ProbabilitiesRequest(Fixture);
+        var ctx = Mock.Of<ConsumeContext<DocumentRequested>>(x => x.Message == msg);
+
+        // act
+        await handler.Consume(ctx);
+
+        // assert
+        espnApi.Verify(
+            x => x.GetResource(It.IsAny<Uri>(), It.IsAny<bool>(), It.IsAny<bool>()),
+            Times.Never);
+    }
 }

--- a/test/unit/SportsData.Provider.Tests.Unit/Infrastructure/Providers/KnownBadUriCacheTests.cs
+++ b/test/unit/SportsData.Provider.Tests.Unit/Infrastructure/Providers/KnownBadUriCacheTests.cs
@@ -1,0 +1,130 @@
+using FluentAssertions;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+
+using Moq;
+
+using SportsData.Core.Common;
+using SportsData.Provider.Infrastructure.Data;
+using SportsData.Provider.Infrastructure.Providers.Espn;
+
+using Xunit;
+
+namespace SportsData.Provider.Tests.Unit.Infrastructure.Providers;
+
+/// <summary>
+/// Negative cache for ESPN 400s: marked URIs are suppressed for the TTL,
+/// query-string variants collapse to one entry (paging/lang params vary
+/// per request but ESPN's "unsupported" verdict is per resource), entries
+/// expire so a resource that gains support is re-probed, and the backing
+/// table makes the knowledge durable — a second cache instance (a fresh
+/// pod) hydrates everything the first one learned.
+/// </summary>
+public class KnownBadUriCacheTests
+{
+    private static readonly DateTime FixedNow = new(2026, 8, 28, 12, 0, 0, DateTimeKind.Utc);
+
+    private readonly Mock<IDateTimeProvider> _clock = new();
+    private readonly IServiceScopeFactory _scopeFactory;
+
+    public KnownBadUriCacheTests()
+    {
+        _clock.Setup(x => x.UtcNow()).Returns(FixedNow);
+
+        // Real scope factory over a shared InMemory database so the cache's
+        // scoped AppDataContext resolution works exactly as in production.
+        var dbName = Guid.NewGuid().ToString()[..8];
+        var services = new ServiceCollection();
+        services.AddDbContext<AppDataContext>(o => o.UseInMemoryDatabase(dbName));
+        _scopeFactory = services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>();
+    }
+
+    private KnownBadUriCache CreateCache() => new(
+        _scopeFactory,
+        _clock.Object,
+        NullLogger<KnownBadUriCache>.Instance);
+
+    [Fact]
+    public async Task UnmarkedUri_IsNotKnownBad()
+    {
+        var cache = CreateCache();
+
+        (await cache.IsKnownBadAsync(new Uri("http://sports.core.api.espn.com/v2/anything")))
+            .Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task MarkedUri_IsKnownBad()
+    {
+        var cache = CreateCache();
+        var uri = new Uri("http://sports.core.api.espn.com/v2/sports/football/leagues/college-football/events/401866615/competitions/401866615/probabilities");
+
+        await cache.MarkBadAsync(uri);
+
+        (await cache.IsKnownBadAsync(uri)).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task QueryStringVariants_CollapseToOneEntry()
+    {
+        var cache = CreateCache();
+
+        await cache.MarkBadAsync(new Uri("http://sports.core.api.espn.com/v2/events/1/probabilities?lang=en&region=us"));
+
+        (await cache.IsKnownBadAsync(new Uri("http://sports.core.api.espn.com/v2/events/1/probabilities?lang=en&region=us&page=2")))
+            .Should().BeTrue();
+        (await cache.IsKnownBadAsync(new Uri("http://sports.core.api.espn.com/v2/events/1/probabilities")))
+            .Should().BeTrue();
+        // A different path is a different resource.
+        (await cache.IsKnownBadAsync(new Uri("http://sports.core.api.espn.com/v2/events/2/probabilities")))
+            .Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task MarkedUri_ExpiresAfterTtl()
+    {
+        var cache = CreateCache();
+        var uri = new Uri("http://sports.core.api.espn.com/v2/events/1/probabilities");
+        await cache.MarkBadAsync(uri);
+
+        _clock.Setup(x => x.UtcNow()).Returns(FixedNow.AddHours(13));
+
+        (await cache.IsKnownBadAsync(uri)).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task FreshInstance_HydratesFromDatabase()
+    {
+        // The new-KEDA-pod scenario: pod A learns a bad URI; pod B (a brand
+        // new cache instance over the same database) must know it too.
+        var uri = new Uri("http://sports.core.api.espn.com/v2/events/1/probabilities");
+        await CreateCache().MarkBadAsync(uri);
+
+        var freshPod = CreateCache();
+
+        (await freshPod.IsKnownBadAsync(uri)).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ExpiredRows_AreNotHydrated_AndArePrunedOnWrite()
+    {
+        var expiredUri = new Uri("http://sports.core.api.espn.com/v2/events/1/probabilities");
+        var freshUri = new Uri("http://sports.core.api.espn.com/v2/events/2/probabilities");
+        await CreateCache().MarkBadAsync(expiredUri);
+
+        // 13h later the first entry is expired; a new pod marks a second URI.
+        _clock.Setup(x => x.UtcNow()).Returns(FixedNow.AddHours(13));
+        var freshPod = CreateCache();
+        await freshPod.MarkBadAsync(freshUri);
+
+        (await freshPod.IsKnownBadAsync(expiredUri)).Should().BeFalse();
+        (await freshPod.IsKnownBadAsync(freshUri)).Should().BeTrue();
+
+        // The write pruned the expired row from the table.
+        using var scope = _scopeFactory.CreateScope();
+        var dataContext = scope.ServiceProvider.GetRequiredService<AppDataContext>();
+        (await dataContext.EspnKnownBadUris.CountAsync()).Should().Be(1);
+    }
+}


### PR DESCRIPTION
## Summary

Two prod findings from this morning's Seq sweep, both fixed:

### 1. `[DisableConcurrentExecution]` was silently inert (API + Provider)

Hangfire resolves job filters from the type a job is **enqueued against**. Every enqueue in this codebase goes through interfaces (`Enqueue<IScoreLeagueWeeks>(...)`, `Enqueue<IProcessResourceIndexes>(...)`), so the class-level attributes on `LeagueWeekScoringProcessor` and `ResourceIndexJob` never applied.

Prod proof (2026-08-28 09:32 UTC): four simultaneous contest finalizations ran **twelve concurrent** league-week scoring jobs and revived the `PickemGroupWeekResult` 23505 duplicate-key race the attribute was built to kill (retry heals it, but every burst of finalizations refires it — and tonight is a full slate).

- Attribute moved to `IScoreLeagueWeeks.Process` (60s) and `IProcessResourceIndexes.ExecuteAsync` (300s), with comments documenting the trap.
- `ResourceIndexController`'s lone class-typed enqueue switched to the interface so one attribute covers all call sites.

### 2. ESPN 400s were refetched on a fixed cadence all game long (Provider)

Producer's live competition streamers re-request child documents (e.g. probabilities) every cycle. ESPN answers `400 "Probabilities are not supported for ... competition: X"` — a permanent verdict — and Provider refetched it every cycle for the whole game.

New `KnownBadUriCache`, checked in `DocumentRequestedHandler.ProcessResourceIndex` and `ResourceIndexItemProcessor`'s live-fetch branch:

- In-memory dictionary serves the per-fetch check (zero DB reads).
- Backed by a new `EspnKnownBadUri` table — hash-keyed via the standard URL normalization (query variants collapse), 12h TTL — **hydrated once at first use** so fresh KEDA pods inherit what previous pods learned, written through on each new 400, expired rows pruned opportunistically. Concurrent same-URI inserts from racing pods are expected and swallowed.
- Scope is deliberately narrow: only `BadRequest` is suppressed. 404 keeps its dependency-not-yet-published retry semantics (DLQ flow); 403 stays with the rate-limit policy.
- Bonus: `select * from "EspnKnownBadUri"` is now an operator view of everything ESPN refuses to serve.

## Migration

`20260828101916_EspnKnownBadUri` — applied and verified on all three local Provider databases (FootballNcaa, FootballNfl, BaseballMlb). It also captures the pre-existing `HistoricalSourcingSagas` xmin snapshot drift (the reason `PendingModelChangesWarning` is ignored in `OnConfiguring`); the scripted SQL for that operation is **empty** (Npgsql skips system columns), so the only real DDL is the new table. Rides Provider startup on deploy.

## Tests

- API: 756 passed
- Provider: 87 passed — 6 new `KnownBadUriCacheTests` (mark/skip, query-variant collapse, TTL expiry, **fresh-pod hydration**, prune-on-write) + 2 new `DocumentRequestedHandlerTests` (400 marks the URI and enqueues nothing; known-bad skips ESPN entirely)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnJySMvfUPeQSMufNNcKSK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added durable handling for ESPN URLs that return bad requests, preventing repeated unsuccessful fetches.
  - Normalized URL variants are recognized consistently, with automatic expiration and cleanup.
- **Performance & Reliability**
  - Added safeguards to prevent overlapping scoring and resource-index processing jobs.
  - Improved handling of ESPN request failures while preserving other error responses.
- **Tests**
  - Added coverage for bad-request caching, URL normalization, expiration, persistence, and skipped repeat requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->