### PR TITLE
fix(core): IDateTimeProvider singleton lifetime — Provider startup crash from #683

### DIFF
--- a/src/SportsData.Core/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Core/DependencyInjection/ServiceRegistration.cs
@@ -271,7 +271,10 @@ namespace SportsData.Core.DependencyInjection
             services.AddScoped<IDecodeDocumentProvidersAndTypes, DocumentProviderAndTypeDecoder>();
             services.Configure<CommonConfig>(configuration.GetSection("CommonConfig"));
             services.AddSingleton<IValidateOptions<CommonConfig>, CommonConfigValidator>();
-            services.AddScoped<IDateTimeProvider, DateTimeProvider>();
+            // Singleton, not scoped: the clock is stateless, and singletons
+            // (e.g. Provider's KnownBadUriCache) must be able to consume it —
+            // a scoped registration fails DI validation at container startup.
+            services.AddSingleton<IDateTimeProvider, DateTimeProvider>();
             services.AddSingleton<IAppMode>(new AppMode(mode));
             services.AddScoped<IGenerateRoutingKeys, RoutingKeyGenerator>();
             services.AddScoped<IJsonHashCalculator, JsonHashCalculator>();


### PR DESCRIPTION
## Summary

**Prod-down hotfix.** #683's `KnownBadUriCache` is a singleton that injects `IDateTimeProvider`, which Core registers **scoped** — a singleton consuming a scoped service fails DI validation, so Provider crashes at `WebApplicationBuilder.Build()` before serving anything:

```
Cannot consume scoped service 'SportsData.Core.Common.IDateTimeProvider'
from singleton 'SportsData.Provider.Infrastructure.Providers.Espn.IKnownBadUriCache'.
```

## Fix

One line: `AddScoped` → `AddSingleton` for `IDateTimeProvider` in Core's shared registration. The clock is stateless (`DateTime.UtcNow` passthrough), so singleton is the correct lifetime; scoped consumers are unaffected — injecting a singleton into a scoped service is always legal, so this cannot introduce new validation failures anywhere.

## Why tests didn't catch it

Unit tests build handlers via AutoMocker, bypassing the container entirely; lifetime violations only surface when the real service provider validates at startup. Follow-up worth considering (separate PR): a DI smoke test per service that builds the real `ServiceCollection` with `ValidateOnBuild`/`ValidateScopes` so this class of bug fails in CI instead of in a container.

## Validation

- Full solution build: 0 errors
- All unit suites green: API 756, Producer 625, Core 265, Notification 122, Provider 87

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnJySMvfUPeQSMufNNcKSK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved application-wide date and time service consistency by updating its registration lifetime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->