### PR TITLE
perf(producer): index every ExternalId table on SourceUrlHash

### DIFF
--- a/src/SportsData.Producer/Infrastructure/Data/Baseball/BaseballDataContext.cs
+++ b/src/SportsData.Producer/Infrastructure/Data/Baseball/BaseballDataContext.cs
@@ -59,6 +59,9 @@ namespace SportsData.Producer.Infrastructure.Data.Baseball
             modelBuilder.ApplyConfiguration(new BaseballCompetitionStatusFeaturedAthlete.EntityConfiguration());
             modelBuilder.ApplyConfiguration(new AthleteSeasonHotZone.EntityConfiguration());
             modelBuilder.ApplyConfiguration(new AthleteSeasonHotZoneEntry.EntityConfiguration());
+
+            // Last: sees every ExternalId entity registered above (base + baseball).
+            ApplyExternalIdSourceUrlHashIndexes(modelBuilder);
         }
     }
 }

--- a/src/SportsData.Producer/Infrastructure/Data/Common/BaseDataContext.cs
+++ b/src/SportsData.Producer/Infrastructure/Data/Common/BaseDataContext.cs
@@ -125,5 +125,28 @@ namespace SportsData.Producer.Infrastructure.Data.Common
                 cfg.ToTable(nameof(OutboxMessage));
             });
         }
+
+        /// <summary>
+        /// Indexes every ExternalId table on SourceUrlHash — the document
+        /// identity-resolution predicate (Provider + SourceUrlHash EXISTS)
+        /// that runs for EVERY processed document. Without it those lookups
+        /// sequential-scan tables of up to 14M rows; on 2026-08-28 (NCAAFB
+        /// kickoff) 80+ concurrent multi-second scans saturated the shared
+        /// PG box and queued every other query (UI matchups hit 30s) behind
+        /// outbox lock pileups. MUST be called at the END of each concrete
+        /// context's OnModelCreating — sport-specific ExternalId entities
+        /// aren't in the model yet when the base method runs.
+        /// </summary>
+        protected static void ApplyExternalIdSourceUrlHashIndexes(ModelBuilder modelBuilder)
+        {
+            foreach (var entityType in modelBuilder.Model.GetEntityTypes())
+            {
+                if (typeof(ExternalId).IsAssignableFrom(entityType.ClrType))
+                {
+                    modelBuilder.Entity(entityType.ClrType)
+                        .HasIndex(nameof(ExternalId.SourceUrlHash));
+                }
+            }
+        }
     }
 }

--- a/src/SportsData.Producer/Infrastructure/Data/Football/FootballDataContext.cs
+++ b/src/SportsData.Producer/Infrastructure/Data/Football/FootballDataContext.cs
@@ -53,6 +53,9 @@ namespace SportsData.Producer.Infrastructure.Data.Football
             modelBuilder.ApplyConfiguration(new FootballCompetitionStatus.EntityConfiguration());
             modelBuilder.ApplyConfiguration(new CompetitionDrive.EntityConfiguration());
             modelBuilder.ApplyConfiguration(new CompetitionDriveExternalId.EntityConfiguration());
+
+            // Last: sees every ExternalId entity registered above (base + football).
+            ApplyExternalIdSourceUrlHashIndexes(modelBuilder);
         }
     }
 }

--- a/src/SportsData.Producer/Migrations/Baseball/20260829083106_ExternalIdSourceUrlHashIndexes.Designer.cs
+++ b/src/SportsData.Producer/Migrations/Baseball/20260829083106_ExternalIdSourceUrlHashIndexes.Designer.cs
@@ -3,18 +3,21 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
-using SportsData.Producer.Infrastructure.Data.Football;
+using SportsData.Producer.Infrastructure.Data.Baseball;
 
 #nullable disable
 
-namespace SportsData.Producer.Migrations.Football
+namespace SportsData.Producer.Migrations.Baseball
 {
-    [DbContext(typeof(FootballDataContext))]
-    partial class FootballDataContextModelSnapshot : ModelSnapshot
+    [DbContext(typeof(BaseballDataContext))]
+    [Migration("20260829083106_ExternalIdSourceUrlHashIndexes")]
+    partial class ExternalIdSourceUrlHashIndexes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -412,6 +415,269 @@ namespace SportsData.Producer.Migrations.Football
                     b.HasIndex("Created");
 
                     b.ToTable("OutboxState", (string)null);
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.AthleteSeasonHotZone", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .HasColumnType("uuid");
+
+                    b.Property<bool>("Active")
+                        .HasColumnType("boolean");
+
+                    b.Property<Guid>("AthleteSeasonId")
+                        .HasColumnType("uuid");
+
+                    b.Property<int>("ConfigurationId")
+                        .HasColumnType("integer");
+
+                    b.Property<Guid>("CreatedBy")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime>("CreatedUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<Guid?>("ModifiedBy")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime?>("ModifiedUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("Name")
+                        .HasMaxLength(50)
+                        .HasColumnType("character varying(50)");
+
+                    b.Property<int>("Season")
+                        .HasColumnType("integer");
+
+                    b.Property<int>("SeasonType")
+                        .HasColumnType("integer");
+
+                    b.Property<int>("SplitTypeId")
+                        .HasColumnType("integer");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("AthleteSeasonId", "ConfigurationId", "Season", "SeasonType");
+
+                    b.ToTable("AthleteSeasonHotZone", (string)null);
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.AthleteSeasonHotZoneEntry", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .HasColumnType("uuid");
+
+                    b.Property<int?>("AtBats")
+                        .HasColumnType("integer");
+
+                    b.Property<Guid>("AthleteSeasonHotZoneId")
+                        .HasColumnType("uuid");
+
+                    b.Property<double?>("BattingAvg")
+                        .HasPrecision(7, 4)
+                        .HasColumnType("double precision");
+
+                    b.Property<double?>("BattingAvgScore")
+                        .HasPrecision(7, 4)
+                        .HasColumnType("double precision");
+
+                    b.Property<Guid>("CreatedBy")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime>("CreatedUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<int?>("Hits")
+                        .HasColumnType("integer");
+
+                    b.Property<Guid?>("ModifiedBy")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime?>("ModifiedUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<double?>("Slugging")
+                        .HasPrecision(7, 4)
+                        .HasColumnType("double precision");
+
+                    b.Property<double?>("SluggingScore")
+                        .HasPrecision(7, 4)
+                        .HasColumnType("double precision");
+
+                    b.Property<double>("XMax")
+                        .HasPrecision(7, 2)
+                        .HasColumnType("double precision");
+
+                    b.Property<double>("XMin")
+                        .HasPrecision(7, 2)
+                        .HasColumnType("double precision");
+
+                    b.Property<double>("YMax")
+                        .HasPrecision(7, 2)
+                        .HasColumnType("double precision");
+
+                    b.Property<double>("YMin")
+                        .HasPrecision(7, 2)
+                        .HasColumnType("double precision");
+
+                    b.Property<int>("ZoneId")
+                        .HasColumnType("integer");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("AthleteSeasonHotZoneId");
+
+                    b.ToTable("AthleteSeasonHotZoneEntry", (string)null);
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionSituationNote", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid");
+
+                    b.Property<Guid>("CreatedBy")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime>("CreatedUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<Guid?>("ModifiedBy")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime?>("ModifiedUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<Guid>("SituationId")
+                        .HasColumnType("uuid");
+
+                    b.Property<string>("Text")
+                        .HasMaxLength(512)
+                        .HasColumnType("character varying(512)");
+
+                    b.Property<string>("Type")
+                        .HasMaxLength(64)
+                        .HasColumnType("character varying(64)");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("SituationId");
+
+                    b.ToTable("BaseballCompetitionSituationNote", (string)null);
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionStatusFeaturedAthlete", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid");
+
+                    b.Property<string>("Abbreviation")
+                        .HasMaxLength(20)
+                        .HasColumnType("character varying(20)");
+
+                    b.Property<string>("AthleteRef")
+                        .HasColumnType("text");
+
+                    b.Property<Guid>("CompetitionStatusId")
+                        .HasColumnType("uuid");
+
+                    b.Property<Guid>("CreatedBy")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime>("CreatedUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("DisplayName")
+                        .HasMaxLength(100)
+                        .HasColumnType("character varying(100)");
+
+                    b.Property<Guid?>("ModifiedBy")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime?>("ModifiedUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("Name")
+                        .HasMaxLength(100)
+                        .HasColumnType("character varying(100)");
+
+                    b.Property<int>("Ordinal")
+                        .HasColumnType("integer");
+
+                    b.Property<int>("PlayerId")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("ShortDisplayName")
+                        .HasMaxLength(50)
+                        .HasColumnType("character varying(50)");
+
+                    b.Property<string>("StatisticsRef")
+                        .HasColumnType("text");
+
+                    b.Property<string>("TeamRef")
+                        .HasColumnType("text");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("CompetitionStatusId");
+
+                    b.ToTable("BaseballCompetitionStatusFeaturedAthlete", (string)null);
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.CompetitionCompetitorProbable", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid");
+
+                    b.Property<string>("Abbreviation")
+                        .HasMaxLength(10)
+                        .HasColumnType("character varying(10)");
+
+                    b.Property<Guid>("AthleteSeasonId")
+                        .HasColumnType("uuid");
+
+                    b.Property<Guid>("CompetitionCompetitorId")
+                        .HasColumnType("uuid");
+
+                    b.Property<Guid>("CreatedBy")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime>("CreatedUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("DisplayName")
+                        .HasMaxLength(100)
+                        .HasColumnType("character varying(100)");
+
+                    b.Property<int>("EspnPlayerId")
+                        .HasColumnType("integer");
+
+                    b.Property<Guid?>("ModifiedBy")
+                        .HasColumnType("uuid");
+
+                    b.Property<DateTime?>("ModifiedUtc")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("Name")
+                        .IsRequired()
+                        .HasMaxLength(50)
+                        .HasColumnType("character varying(50)");
+
+                    b.Property<string>("ShortDisplayName")
+                        .HasMaxLength(50)
+                        .HasColumnType("character varying(50)");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("AthleteSeasonId");
+
+                    b.HasIndex("CompetitionCompetitorId", "Name")
+                        .IsUnique();
+
+                    b.ToTable("CompetitionCompetitorProbable", (string)null);
                 });
 
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.CompetitionStream", b =>
@@ -3071,208 +3337,6 @@ namespace SportsData.Producer.Migrations.Football
                     b.HasIndex("CompetitionCompetitorStatisticCategoryId");
 
                     b.ToTable("CompetitionCompetitorStatisticStats");
-                });
-
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionDrive", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("uuid");
-
-                    b.Property<Guid>("CompetitionId")
-                        .HasColumnType("uuid");
-
-                    b.Property<Guid>("CreatedBy")
-                        .HasColumnType("uuid");
-
-                    b.Property<DateTime>("CreatedUtc")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<string>("Description")
-                        .IsRequired()
-                        .HasMaxLength(250)
-                        .HasColumnType("character varying(250)");
-
-                    b.Property<string>("DisplayResult")
-                        .HasMaxLength(150)
-                        .HasColumnType("character varying(150)");
-
-                    b.Property<string>("EndClockDisplayValue")
-                        .HasMaxLength(20)
-                        .HasColumnType("character varying(20)");
-
-                    b.Property<double?>("EndClockValue")
-                        .HasColumnType("double precision");
-
-                    b.Property<int?>("EndDistance")
-                        .HasColumnType("integer");
-
-                    b.Property<int?>("EndDown")
-                        .HasColumnType("integer");
-
-                    b.Property<string>("EndDownDistanceText")
-                        .HasMaxLength(50)
-                        .HasColumnType("character varying(50)");
-
-                    b.Property<Guid?>("EndFranchiseSeasonId")
-                        .HasColumnType("uuid");
-
-                    b.Property<int?>("EndPeriodNumber")
-                        .HasColumnType("integer");
-
-                    b.Property<string>("EndPeriodType")
-                        .HasColumnType("text");
-
-                    b.Property<string>("EndShortDownDistanceText")
-                        .HasMaxLength(50)
-                        .HasColumnType("character varying(50)");
-
-                    b.Property<string>("EndText")
-                        .HasMaxLength(100)
-                        .HasColumnType("character varying(100)");
-
-                    b.Property<int?>("EndYardLine")
-                        .HasColumnType("integer");
-
-                    b.Property<int?>("EndYardsToEndzone")
-                        .HasColumnType("integer");
-
-                    b.Property<bool>("IsScore")
-                        .HasColumnType("boolean");
-
-                    b.Property<Guid?>("ModifiedBy")
-                        .HasColumnType("uuid");
-
-                    b.Property<DateTime?>("ModifiedUtc")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<int>("OffensivePlays")
-                        .HasColumnType("integer");
-
-                    b.Property<int>("Ordinal")
-                        .HasColumnType("integer");
-
-                    b.Property<string>("Result")
-                        .HasMaxLength(150)
-                        .HasColumnType("character varying(150)");
-
-                    b.Property<string>("SequenceNumber")
-                        .IsRequired()
-                        .HasMaxLength(20)
-                        .HasColumnType("character varying(20)");
-
-                    b.Property<string>("ShortDisplayResult")
-                        .HasMaxLength(150)
-                        .HasColumnType("character varying(150)");
-
-                    b.Property<string>("SourceDescription")
-                        .HasMaxLength(100)
-                        .HasColumnType("character varying(100)");
-
-                    b.Property<string>("SourceId")
-                        .HasMaxLength(20)
-                        .HasColumnType("character varying(20)");
-
-                    b.Property<string>("StartClockDisplayValue")
-                        .HasMaxLength(20)
-                        .HasColumnType("character varying(20)");
-
-                    b.Property<double?>("StartClockValue")
-                        .HasColumnType("double precision");
-
-                    b.Property<int?>("StartDistance")
-                        .HasColumnType("integer");
-
-                    b.Property<int?>("StartDown")
-                        .HasColumnType("integer");
-
-                    b.Property<string>("StartDownDistanceText")
-                        .HasMaxLength(50)
-                        .HasColumnType("character varying(50)");
-
-                    b.Property<Guid?>("StartFranchiseSeasonId")
-                        .HasColumnType("uuid");
-
-                    b.Property<int?>("StartPeriodNumber")
-                        .HasColumnType("integer");
-
-                    b.Property<string>("StartPeriodType")
-                        .HasColumnType("text");
-
-                    b.Property<string>("StartShortDownDistanceText")
-                        .HasMaxLength(50)
-                        .HasColumnType("character varying(50)");
-
-                    b.Property<string>("StartText")
-                        .HasMaxLength(100)
-                        .HasColumnType("character varying(100)");
-
-                    b.Property<int?>("StartYardLine")
-                        .HasColumnType("integer");
-
-                    b.Property<int?>("StartYardsToEndzone")
-                        .HasColumnType("integer");
-
-                    b.Property<string>("TimeElapsedDisplay")
-                        .HasMaxLength(20)
-                        .HasColumnType("character varying(20)");
-
-                    b.Property<double?>("TimeElapsedValue")
-                        .HasColumnType("double precision");
-
-                    b.Property<int>("Yards")
-                        .HasColumnType("integer");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("CompetitionId");
-
-                    b.ToTable("CompetitionDrive", (string)null);
-                });
-
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionDriveExternalId", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("uuid");
-
-                    b.Property<Guid>("CreatedBy")
-                        .HasColumnType("uuid");
-
-                    b.Property<DateTime>("CreatedUtc")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<Guid>("DriveId")
-                        .HasColumnType("uuid");
-
-                    b.Property<Guid?>("ModifiedBy")
-                        .HasColumnType("uuid");
-
-                    b.Property<DateTime?>("ModifiedUtc")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<int>("Provider")
-                        .HasColumnType("integer");
-
-                    b.Property<string>("SourceUrl")
-                        .IsRequired()
-                        .HasColumnType("text");
-
-                    b.Property<string>("SourceUrlHash")
-                        .IsRequired()
-                        .HasColumnType("text");
-
-                    b.Property<string>("Value")
-                        .IsRequired()
-                        .HasColumnType("text");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("DriveId");
-
-                    b.HasIndex("SourceUrlHash");
-
-                    b.ToTable("CompetitionDriveExternalId", (string)null);
                 });
 
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionExternalId", b =>
@@ -8140,9 +8204,17 @@ namespace SportsData.Producer.Migrations.Football
                     b.ToTable("VenueImage", (string)null);
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballAthlete", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballAthlete", b =>
                 {
                     b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.AthleteBase");
+
+                    b.Property<string>("BatsAbbreviation")
+                        .HasMaxLength(5)
+                        .HasColumnType("character varying(5)");
+
+                    b.Property<string>("BatsType")
+                        .HasMaxLength(20)
+                        .HasColumnType("character varying(20)");
 
                     b.Property<Guid?>("FranchiseId")
                         .HasColumnType("uuid");
@@ -8150,188 +8222,293 @@ namespace SportsData.Producer.Migrations.Football
                     b.Property<Guid?>("FranchiseSeasonId")
                         .HasColumnType("uuid");
 
-                    b.Property<string>("HandAbbreviation")
-                        .HasMaxLength(10)
-                        .HasColumnType("character varying(10)");
-
-                    b.Property<string>("HandDisplayValue")
-                        .HasMaxLength(20)
-                        .HasColumnType("character varying(20)");
-
-                    b.Property<string>("HandType")
-                        .HasMaxLength(20)
-                        .HasColumnType("character varying(20)");
-
                     b.Property<Guid?>("PositionId")
                         .HasColumnType("uuid");
 
+                    b.Property<string>("ThrowsAbbreviation")
+                        .HasMaxLength(5)
+                        .HasColumnType("character varying(5)");
+
+                    b.Property<string>("ThrowsType")
+                        .HasMaxLength(20)
+                        .HasColumnType("character varying(20)");
+
                     b.HasIndex("PositionId");
 
-                    b.HasDiscriminator().HasValue("FootballAthlete");
+                    b.HasDiscriminator().HasValue("BaseballAthlete");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballAthleteSeason", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballAthleteSeason", b =>
                 {
                     b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.AthleteSeason");
 
-                    b.HasDiscriminator().HasValue("FootballAthleteSeason");
+                    b.HasDiscriminator().HasValue("BaseballAthleteSeason");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetition", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetition", b =>
                 {
                     b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.CompetitionBase");
 
-                    b.HasDiscriminator().HasValue("FootballCompetition");
+                    b.Property<int?>("CurrentSeriesAwayTies")
+                        .HasColumnType("integer");
+
+                    b.Property<int?>("CurrentSeriesAwayWins")
+                        .HasColumnType("integer");
+
+                    b.Property<bool?>("CurrentSeriesCompleted")
+                        .HasColumnType("boolean");
+
+                    b.Property<int?>("CurrentSeriesHomeTies")
+                        .HasColumnType("integer");
+
+                    b.Property<int?>("CurrentSeriesHomeWins")
+                        .HasColumnType("integer");
+
+                    b.Property<DateTimeOffset?>("CurrentSeriesStartDate")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("CurrentSeriesSummary")
+                        .HasColumnType("text");
+
+                    b.Property<int?>("CurrentSeriesTotalCompetitions")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("Duration")
+                        .HasColumnType("text");
+
+                    b.Property<string>("EspnSeriesId")
+                        .HasColumnType("text");
+
+                    b.Property<bool?>("Necessary")
+                        .HasColumnType("boolean");
+
+                    b.Property<int?>("SeasonSeriesAwayTies")
+                        .HasColumnType("integer");
+
+                    b.Property<int?>("SeasonSeriesAwayWins")
+                        .HasColumnType("integer");
+
+                    b.Property<bool?>("SeasonSeriesCompleted")
+                        .HasColumnType("boolean");
+
+                    b.Property<int?>("SeasonSeriesHomeTies")
+                        .HasColumnType("integer");
+
+                    b.Property<int?>("SeasonSeriesHomeWins")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("SeasonSeriesSummary")
+                        .HasColumnType("text");
+
+                    b.Property<int?>("SeasonSeriesTotalCompetitions")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("TimeOfDay")
+                        .HasColumnType("text");
+
+                    b.Property<bool?>("WasSuspended")
+                        .HasColumnType("boolean");
+
+                    b.HasIndex("EspnSeriesId");
+
+                    b.HasDiscriminator().HasValue("BaseballCompetition");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetitionCompetitor", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionCompetitor", b =>
                 {
                     b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.CompetitionCompetitorBase");
 
-                    b.Property<int?>("CuratedRankCurrent")
-                        .HasColumnType("integer");
-
-                    b.HasDiscriminator().HasValue("FootballCompetitionCompetitor");
+                    b.HasDiscriminator().HasValue("BaseballCompetitionCompetitor");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetitionPlay", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionPlay", b =>
                 {
                     b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.CompetitionPlayBase");
 
-                    b.Property<string>("ClockDisplayValue")
+                    b.Property<Guid?>("AtBatAthleteSeasonId")
+                        .HasColumnType("uuid");
+
+                    b.Property<string>("AtBatId")
                         .HasMaxLength(32)
                         .HasColumnType("character varying(32)");
 
-                    b.Property<double>("ClockValue")
+                    b.Property<int?>("AtBatPitchNumber")
+                        .HasColumnType("integer");
+
+                    b.Property<int>("AwayErrors")
+                        .HasColumnType("integer");
+
+                    b.Property<int>("AwayHits")
+                        .HasColumnType("integer");
+
+                    b.Property<int?>("BatOrder")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("BatsAbbreviation")
+                        .HasMaxLength(5)
+                        .HasColumnType("character varying(5)");
+
+                    b.Property<string>("BatsType")
+                        .HasMaxLength(20)
+                        .HasColumnType("character varying(20)");
+
+                    b.Property<string>("HalfInning")
+                        .HasMaxLength(8)
+                        .HasColumnType("character varying(8)");
+
+                    b.Property<double?>("HitCoordinateX")
+                        .HasPrecision(7, 2)
                         .HasColumnType("double precision");
 
-                    b.Property<Guid?>("DriveId")
-                        .HasColumnType("uuid");
+                    b.Property<double?>("HitCoordinateY")
+                        .HasPrecision(7, 2)
+                        .HasColumnType("double precision");
 
-                    b.Property<int?>("EndDistance")
+                    b.Property<int>("HomeErrors")
                         .HasColumnType("integer");
 
-                    b.Property<int?>("EndDown")
+                    b.Property<int>("HomeHits")
                         .HasColumnType("integer");
 
-                    b.Property<Guid?>("EndFranchiseSeasonId")
-                        .HasColumnType("uuid");
+                    b.Property<bool>("IsDoublePlay")
+                        .HasColumnType("boolean");
 
-                    b.Property<int?>("EndYardLine")
+                    b.Property<bool>("IsTriplePlay")
+                        .HasColumnType("boolean");
+
+                    b.Property<bool>("IsValid")
+                        .HasColumnType("boolean");
+
+                    b.Property<int?>("Outs")
                         .HasColumnType("integer");
 
-                    b.Property<int?>("EndYardsToEndzone")
+                    b.Property<double?>("PitchCoordinateX")
+                        .HasPrecision(7, 2)
+                        .HasColumnType("double precision");
+
+                    b.Property<double?>("PitchCoordinateY")
+                        .HasPrecision(7, 2)
+                        .HasColumnType("double precision");
+
+                    b.Property<int?>("PitchCountBalls")
                         .HasColumnType("integer");
 
-                    b.Property<string>("PointAfterAttemptAbbreviation")
-                        .HasMaxLength(20)
-                        .HasColumnType("character varying(20)");
-
-                    b.Property<int?>("PointAfterAttemptId")
+                    b.Property<int?>("PitchCountStrikes")
                         .HasColumnType("integer");
 
-                    b.Property<string>("PointAfterAttemptText")
-                        .HasMaxLength(100)
-                        .HasColumnType("character varying(100)");
+                    b.Property<string>("PitchTypeAbbreviation")
+                        .HasMaxLength(10)
+                        .HasColumnType("character varying(10)");
 
-                    b.Property<int?>("PointAfterAttemptValue")
-                        .HasColumnType("integer");
+                    b.Property<string>("PitchTypeId")
+                        .HasMaxLength(10)
+                        .HasColumnType("character varying(10)");
 
-                    b.Property<string>("ScoringTypeAbbreviation")
-                        .HasMaxLength(20)
-                        .HasColumnType("character varying(20)");
-
-                    b.Property<string>("ScoringTypeDisplayName")
-                        .HasMaxLength(100)
-                        .HasColumnType("character varying(100)");
-
-                    b.Property<string>("ScoringTypeName")
+                    b.Property<string>("PitchTypeText")
                         .HasMaxLength(50)
                         .HasColumnType("character varying(50)");
 
-                    b.Property<int?>("StartDistance")
+                    b.Property<int?>("PitchVelocity")
                         .HasColumnType("integer");
 
-                    b.Property<int?>("StartDown")
+                    b.Property<string>("PitchesAbbreviation")
+                        .HasMaxLength(5)
+                        .HasColumnType("character varying(5)");
+
+                    b.Property<string>("PitchesType")
+                        .HasMaxLength(20)
+                        .HasColumnType("character varying(20)");
+
+                    b.Property<Guid?>("PitchingAthleteSeasonId")
+                        .HasColumnType("uuid");
+
+                    b.Property<int>("RbiCount")
                         .HasColumnType("integer");
 
-                    b.Property<int?>("StartYardLine")
+                    b.Property<int?>("ResultCountBalls")
                         .HasColumnType("integer");
 
-                    b.Property<int?>("StartYardsToEndzone")
+                    b.Property<int?>("ResultCountStrikes")
                         .HasColumnType("integer");
 
-                    b.Property<int>("StatYardage")
-                        .HasColumnType("integer");
+                    b.Property<string>("StrikeType")
+                        .HasMaxLength(20)
+                        .HasColumnType("character varying(20)");
+
+                    b.Property<string>("SummaryType")
+                        .HasMaxLength(5)
+                        .HasColumnType("character varying(5)");
+
+                    b.Property<string>("Trajectory")
+                        .HasMaxLength(5)
+                        .HasColumnType("character varying(5)");
 
                     b.Property<DateTime?>("Wallclock")
                         .HasColumnType("timestamp with time zone");
 
-                    b.HasIndex("DriveId");
-
-                    b.HasDiscriminator().HasValue("FootballCompetitionPlay");
+                    b.HasDiscriminator().HasValue("BaseballCompetitionPlay");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetitionPlayParticipant", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionPlayParticipant", b =>
                 {
                     b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.CompetitionPlayParticipantBase");
 
-                    b.HasDiscriminator().HasValue("FootballCompetitionPlayParticipant");
+                    b.HasDiscriminator().HasValue("BaseballCompetitionPlayParticipant");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetitionSituation", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionSituation", b =>
                 {
                     b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.CompetitionSituationBase");
 
-                    b.Property<int>("AwayTimeouts")
+                    b.Property<int>("Balls")
                         .HasColumnType("integer");
 
-                    b.Property<int>("Distance")
+                    b.Property<Guid?>("OnFirstAthleteSeasonId")
+                        .HasColumnType("uuid");
+
+                    b.Property<Guid?>("OnSecondAthleteSeasonId")
+                        .HasColumnType("uuid");
+
+                    b.Property<Guid?>("OnThirdAthleteSeasonId")
+                        .HasColumnType("uuid");
+
+                    b.Property<int>("Outs")
                         .HasColumnType("integer");
 
-                    b.Property<int>("Down")
+                    b.Property<int>("Strikes")
                         .HasColumnType("integer");
 
-                    b.Property<int>("HomeTimeouts")
-                        .HasColumnType("integer");
+                    b.HasIndex("OnFirstAthleteSeasonId");
 
-                    b.Property<bool>("IsRedZone")
-                        .HasColumnType("boolean");
+                    b.HasIndex("OnSecondAthleteSeasonId");
 
-                    b.Property<int>("YardLine")
-                        .HasColumnType("integer");
+                    b.HasIndex("OnThirdAthleteSeasonId");
 
-                    b.ToTable(t =>
-                        {
-                            t.HasCheckConstraint("CK_CompetitionSituation_AwayTimeouts", "\"AwayTimeouts\" >= 0");
-
-                            t.HasCheckConstraint("CK_CompetitionSituation_Distance", "\"Distance\" >= -110");
-
-                            t.HasCheckConstraint("CK_CompetitionSituation_Down", "\"Down\" BETWEEN -1 AND 4");
-
-                            t.HasCheckConstraint("CK_CompetitionSituation_HomeTimeouts", "\"HomeTimeouts\" >= 0");
-
-                            t.HasCheckConstraint("CK_CompetitionSituation_YardLine", "\"YardLine\" BETWEEN 0 AND 100");
-                        });
-
-                    b.HasDiscriminator().HasValue("FootballCompetitionSituation");
+                    b.HasDiscriminator().HasValue("BaseballCompetitionSituation");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetitionStatus", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionStatus", b =>
                 {
                     b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.CompetitionStatusBase");
+
+                    b.Property<int?>("HalfInning")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("PeriodPrefix")
+                        .HasMaxLength(10)
+                        .HasColumnType("character varying(10)");
 
                     b.HasIndex("CompetitionId")
                         .IsUnique();
 
-                    b.HasDiscriminator().HasValue("FootballCompetitionStatus");
+                    b.HasDiscriminator().HasValue("BaseballCompetitionStatus");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballContest", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballContest", b =>
                 {
                     b.HasBaseType("SportsData.Producer.Infrastructure.Data.Entities.ContestBase");
 
-                    b.HasDiscriminator().HasValue("FootballContest");
+                    b.HasDiscriminator().HasValue("BaseballContest");
                 });
 
             modelBuilder.Entity("CompetitionOdds", b =>
@@ -8364,6 +8541,58 @@ namespace SportsData.Producer.Migrations.Football
                         .WithMany()
                         .HasForeignKey("InboxMessageId", "InboxConsumerId")
                         .HasPrincipalKey("MessageId", "ConsumerId");
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.AthleteSeasonHotZoneEntry", b =>
+                {
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Baseball.Entities.AthleteSeasonHotZone", "HotZone")
+                        .WithMany("Entries")
+                        .HasForeignKey("AthleteSeasonHotZoneId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("HotZone");
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionSituationNote", b =>
+                {
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionSituation", "Situation")
+                        .WithMany("Notes")
+                        .HasForeignKey("SituationId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("Situation");
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionStatusFeaturedAthlete", b =>
+                {
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionStatus", "CompetitionStatus")
+                        .WithMany("FeaturedAthletes")
+                        .HasForeignKey("CompetitionStatusId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("CompetitionStatus");
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.CompetitionCompetitorProbable", b =>
+                {
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Entities.AthleteSeason", "AthleteSeason")
+                        .WithMany()
+                        .HasForeignKey("AthleteSeasonId")
+                        .OnDelete(DeleteBehavior.Restrict)
+                        .IsRequired();
+
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionCompetitor", "CompetitionCompetitor")
+                        .WithMany("Probables")
+                        .HasForeignKey("CompetitionCompetitorId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("AthleteSeason");
+
+                    b.Navigation("CompetitionCompetitor");
                 });
 
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.CompetitionStream", b =>
@@ -8948,34 +9177,6 @@ namespace SportsData.Producer.Migrations.Football
                         .IsRequired();
 
                     b.Navigation("CompetitionCompetitorStatisticCategory");
-                });
-
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionDrive", b =>
-                {
-                    b.HasOne("SportsData.Producer.Infrastructure.Data.Entities.CompetitionBase", "Competition")
-                        .WithMany()
-                        .HasForeignKey("CompetitionId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.HasOne("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetition", null)
-                        .WithMany("Drives")
-                        .HasForeignKey("CompetitionId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.Navigation("Competition");
-                });
-
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionDriveExternalId", b =>
-                {
-                    b.HasOne("SportsData.Producer.Infrastructure.Data.Entities.CompetitionDrive", "Drive")
-                        .WithMany("ExternalIds")
-                        .HasForeignKey("DriveId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.Navigation("Drive");
                 });
 
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionExternalId", b =>
@@ -9910,7 +10111,7 @@ namespace SportsData.Producer.Migrations.Football
                         .IsRequired();
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballAthlete", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballAthlete", b =>
                 {
                     b.HasOne("SportsData.Producer.Infrastructure.Data.Entities.AthletePosition", "Position")
                         .WithMany()
@@ -9919,34 +10120,27 @@ namespace SportsData.Producer.Migrations.Football
                     b.Navigation("Position");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetition", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetition", b =>
                 {
-                    b.HasOne("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballContest", null)
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballContest", null)
                         .WithMany("Competitions")
                         .HasForeignKey("ContestId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetitionPlay", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionPlay", b =>
                 {
-                    b.HasOne("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetition", null)
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetition", null)
                         .WithMany("Plays")
                         .HasForeignKey("CompetitionId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
-
-                    b.HasOne("SportsData.Producer.Infrastructure.Data.Entities.CompetitionDrive", "Drive")
-                        .WithMany("Plays")
-                        .HasForeignKey("DriveId")
-                        .OnDelete(DeleteBehavior.Cascade);
-
-                    b.Navigation("Drive");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetitionPlayParticipant", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionPlayParticipant", b =>
                 {
-                    b.HasOne("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetitionPlay", "CompetitionPlay")
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionPlay", "CompetitionPlay")
                         .WithMany("Participants")
                         .HasForeignKey("CompetitionPlayId")
                         .OnDelete(DeleteBehavior.Cascade)
@@ -9955,11 +10149,35 @@ namespace SportsData.Producer.Migrations.Football
                     b.Navigation("CompetitionPlay");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetitionStatus", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionSituation", b =>
                 {
-                    b.HasOne("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetition", null)
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Entities.AthleteSeason", "OnFirstAthleteSeason")
+                        .WithMany()
+                        .HasForeignKey("OnFirstAthleteSeasonId")
+                        .OnDelete(DeleteBehavior.Restrict);
+
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Entities.AthleteSeason", "OnSecondAthleteSeason")
+                        .WithMany()
+                        .HasForeignKey("OnSecondAthleteSeasonId")
+                        .OnDelete(DeleteBehavior.Restrict);
+
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Entities.AthleteSeason", "OnThirdAthleteSeason")
+                        .WithMany()
+                        .HasForeignKey("OnThirdAthleteSeasonId")
+                        .OnDelete(DeleteBehavior.Restrict);
+
+                    b.Navigation("OnFirstAthleteSeason");
+
+                    b.Navigation("OnSecondAthleteSeason");
+
+                    b.Navigation("OnThirdAthleteSeason");
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionStatus", b =>
+                {
+                    b.HasOne("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetition", null)
                         .WithOne("Status")
-                        .HasForeignKey("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetitionStatus", "CompetitionId")
+                        .HasForeignKey("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionStatus", "CompetitionId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
                 });
@@ -9971,6 +10189,11 @@ namespace SportsData.Producer.Migrations.Football
                     b.Navigation("Links");
 
                     b.Navigation("Teams");
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.AthleteSeasonHotZone", b =>
+                {
+                    b.Navigation("Entries");
                 });
 
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.AthleteBase", b =>
@@ -10124,13 +10347,6 @@ namespace SportsData.Producer.Migrations.Football
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionCompetitorStatisticCategory", b =>
                 {
                     b.Navigation("Stats");
-                });
-
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionDrive", b =>
-                {
-                    b.Navigation("ExternalIds");
-
-                    b.Navigation("Plays");
                 });
 
             modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Entities.CompetitionLeader", b =>
@@ -10323,21 +10539,34 @@ namespace SportsData.Producer.Migrations.Football
                     b.Navigation("Images");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetition", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetition", b =>
                 {
-                    b.Navigation("Drives");
-
                     b.Navigation("Plays");
 
                     b.Navigation("Status");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballCompetitionPlay", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionCompetitor", b =>
+                {
+                    b.Navigation("Probables");
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionPlay", b =>
                 {
                     b.Navigation("Participants");
                 });
 
-            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Football.Entities.FootballContest", b =>
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionSituation", b =>
+                {
+                    b.Navigation("Notes");
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballCompetitionStatus", b =>
+                {
+                    b.Navigation("FeaturedAthletes");
+                });
+
+            modelBuilder.Entity("SportsData.Producer.Infrastructure.Data.Baseball.Entities.BaseballContest", b =>
                 {
                     b.Navigation("Competitions");
                 });

--- a/src/SportsData.Producer/Migrations/Baseball/20260829083106_ExternalIdSourceUrlHashIndexes.cs
+++ b/src/SportsData.Producer/Migrations/Baseball/20260829083106_ExternalIdSourceUrlHashIndexes.cs
@@ -1,0 +1,220 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SportsData.Producer.Migrations.Baseball
+{
+    /// <inheritdoc />
+    public partial class ExternalIdSourceUrlHashIndexes : Migration
+    {
+        /// <inheritdoc />
+        /// <remarks>
+        /// Raw IF NOT EXISTS rather than CreateIndex: prod got these same
+        /// indexes via CREATE INDEX CONCURRENTLY on 2026-08-29 (emergency
+        /// remediation for the game-day seq-scan saturation), so the
+        /// migration must be a no-op where an index already exists.
+        /// </remarks>
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(
+                @"CREATE INDEX IF NOT EXISTS ""IX_VenueExternalId_SourceUrlHash"" ON public.""VenueExternalId"" (""SourceUrlHash"");");
+
+            migrationBuilder.Sql(
+                @"CREATE INDEX IF NOT EXISTS ""IX_SeasonWeekExternalId_SourceUrlHash"" ON public.""SeasonWeekExternalId"" (""SourceUrlHash"");");
+
+            migrationBuilder.Sql(
+                @"CREATE INDEX IF NOT EXISTS ""IX_SeasonPollWeekExternalId_SourceUrlHash"" ON public.""SeasonPollWeekExternalId"" (""SourceUrlHash"");");
+
+            migrationBuilder.Sql(
+                @"CREATE INDEX IF NOT EXISTS ""IX_SeasonPollExternalId_SourceUrlHash"" ON public.""SeasonPollExternalId"" (""SourceUrlHash"");");
+
+            migrationBuilder.Sql(
+                @"CREATE INDEX IF NOT EXISTS ""IX_SeasonPhaseExternalId_SourceUrlHash"" ON public.""SeasonPhaseExternalId"" (""SourceUrlHash"");");
+
+            migrationBuilder.Sql(
+                @"CREATE INDEX IF NOT EXISTS ""IX_SeasonFutureExternalId_SourceUrlHash"" ON public.""SeasonFutureExternalId"" (""SourceUrlHash"");");
+
+            migrationBuilder.Sql(
+                @"CREATE INDEX IF NOT EXISTS ""IX_SeasonExternalId_SourceUrlHash"" ON public.""SeasonExternalId"" (""SourceUrlHash"");");
+
+            migrationBuilder.Sql(
+                @"CREATE INDEX IF NOT EXISTS ""IX_GroupSeasonExternalId_SourceUrlHash"" ON public.""GroupSeasonExternalId"" (""SourceUrlHash"");");
+
+            migrationBuilder.Sql(
+                @"CREATE INDEX IF NOT EXISTS ""IX_FranchiseSeasonRankingExternalId_SourceUrlHash"" ON public.""FranchiseSeasonRankingExternalId"" (""SourceUrlHash"");");
+
+            migrationBuilder.Sql(
+                @"CREATE INDEX IF NOT EXISTS ""IX_FranchiseSeasonExternalId_SourceUrlHash"" ON public.""FranchiseSeasonExternalId"" (""SourceUrlHash"");");
+
+            migrationBuilder.Sql(
+                @"CREATE INDEX IF NOT EXISTS ""IX_FranchiseExternalId_SourceUrlHash"" ON public.""FranchiseExternalId"" (""SourceUrlHash"");");
+
+            migrationBuilder.Sql(
+                @"CREATE INDEX IF NOT EXISTS ""IX_ContestExternalId_SourceUrlHash"" ON public.""ContestExternalId"" (""SourceUrlHash"");");
+
+            migrationBuilder.Sql(
+                @"CREATE INDEX IF NOT EXISTS ""IX_CompetitionStatusExternalId_SourceUrlHash"" ON public.""CompetitionStatusExternalId"" (""SourceUrlHash"");");
+
+            migrationBuilder.Sql(
+                @"CREATE INDEX IF NOT EXISTS ""IX_CompetitionProbabilityExternalId_SourceUrlHash"" ON public.""CompetitionProbabilityExternalId"" (""SourceUrlHash"");");
+
+            migrationBuilder.Sql(
+                @"CREATE INDEX IF NOT EXISTS ""IX_CompetitionPowerIndexExternalId_SourceUrlHash"" ON public.""CompetitionPowerIndexExternalId"" (""SourceUrlHash"");");
+
+            migrationBuilder.Sql(
+                @"CREATE INDEX IF NOT EXISTS ""IX_CompetitionPlayExternalId_SourceUrlHash"" ON public.""CompetitionPlayExternalId"" (""SourceUrlHash"");");
+
+            migrationBuilder.Sql(
+                @"CREATE INDEX IF NOT EXISTS ""IX_CompetitionOddsExternalId_SourceUrlHash"" ON public.""CompetitionOddsExternalId"" (""SourceUrlHash"");");
+
+            migrationBuilder.Sql(
+                @"CREATE INDEX IF NOT EXISTS ""IX_CompetitionExternalId_SourceUrlHash"" ON public.""CompetitionExternalId"" (""SourceUrlHash"");");
+
+            migrationBuilder.Sql(
+                @"CREATE INDEX IF NOT EXISTS ""IX_CompetitionCompetitorScoreExternalIds_SourceUrlHash"" ON public.""CompetitionCompetitorScoreExternalIds"" (""SourceUrlHash"");");
+
+            migrationBuilder.Sql(
+                @"CREATE INDEX IF NOT EXISTS ""IX_CompetitionCompetitorLineScoreExternalId_SourceUrlHash"" ON public.""CompetitionCompetitorLineScoreExternalId"" (""SourceUrlHash"");");
+
+            migrationBuilder.Sql(
+                @"CREATE INDEX IF NOT EXISTS ""IX_CompetitionCompetitorExternalIds_SourceUrlHash"" ON public.""CompetitionCompetitorExternalIds"" (""SourceUrlHash"");");
+
+            migrationBuilder.Sql(
+                @"CREATE INDEX IF NOT EXISTS ""IX_CoachSeasonRecordExternalId_SourceUrlHash"" ON public.""CoachSeasonRecordExternalId"" (""SourceUrlHash"");");
+
+            migrationBuilder.Sql(
+                @"CREATE INDEX IF NOT EXISTS ""IX_CoachRecordExternalId_SourceUrlHash"" ON public.""CoachRecordExternalId"" (""SourceUrlHash"");");
+
+            migrationBuilder.Sql(
+                @"CREATE INDEX IF NOT EXISTS ""IX_CoachExternalId_SourceUrlHash"" ON public.""CoachExternalId"" (""SourceUrlHash"");");
+
+            migrationBuilder.Sql(
+                @"CREATE INDEX IF NOT EXISTS ""IX_AwardExternalId_SourceUrlHash"" ON public.""AwardExternalId"" (""SourceUrlHash"");");
+
+            migrationBuilder.Sql(
+                @"CREATE INDEX IF NOT EXISTS ""IX_AthleteSeasonExternalId_SourceUrlHash"" ON public.""AthleteSeasonExternalId"" (""SourceUrlHash"");");
+
+            migrationBuilder.Sql(
+                @"CREATE INDEX IF NOT EXISTS ""IX_AthletePositionExternalId_SourceUrlHash"" ON public.""AthletePositionExternalId"" (""SourceUrlHash"");");
+
+            migrationBuilder.Sql(
+                @"CREATE INDEX IF NOT EXISTS ""IX_AthleteExternalId_SourceUrlHash"" ON public.""AthleteExternalId"" (""SourceUrlHash"");");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_VenueExternalId_SourceUrlHash",
+                table: "VenueExternalId");
+
+            migrationBuilder.DropIndex(
+                name: "IX_SeasonWeekExternalId_SourceUrlHash",
+                table: "SeasonWeekExternalId");
+
+            migrationBuilder.DropIndex(
+                name: "IX_SeasonPollWeekExternalId_SourceUrlHash",
+                table: "SeasonPollWeekExternalId");
+
+            migrationBuilder.DropIndex(
+                name: "IX_SeasonPollExternalId_SourceUrlHash",
+                table: "SeasonPollExternalId");
+
+            migrationBuilder.DropIndex(
+                name: "IX_SeasonPhaseExternalId_SourceUrlHash",
+                table: "SeasonPhaseExternalId");
+
+            migrationBuilder.DropIndex(
+                name: "IX_SeasonFutureExternalId_SourceUrlHash",
+                table: "SeasonFutureExternalId");
+
+            migrationBuilder.DropIndex(
+                name: "IX_SeasonExternalId_SourceUrlHash",
+                table: "SeasonExternalId");
+
+            migrationBuilder.DropIndex(
+                name: "IX_GroupSeasonExternalId_SourceUrlHash",
+                table: "GroupSeasonExternalId");
+
+            migrationBuilder.DropIndex(
+                name: "IX_FranchiseSeasonRankingExternalId_SourceUrlHash",
+                table: "FranchiseSeasonRankingExternalId");
+
+            migrationBuilder.DropIndex(
+                name: "IX_FranchiseSeasonExternalId_SourceUrlHash",
+                table: "FranchiseSeasonExternalId");
+
+            migrationBuilder.DropIndex(
+                name: "IX_FranchiseExternalId_SourceUrlHash",
+                table: "FranchiseExternalId");
+
+            migrationBuilder.DropIndex(
+                name: "IX_ContestExternalId_SourceUrlHash",
+                table: "ContestExternalId");
+
+            migrationBuilder.DropIndex(
+                name: "IX_CompetitionStatusExternalId_SourceUrlHash",
+                table: "CompetitionStatusExternalId");
+
+            migrationBuilder.DropIndex(
+                name: "IX_CompetitionProbabilityExternalId_SourceUrlHash",
+                table: "CompetitionProbabilityExternalId");
+
+            migrationBuilder.DropIndex(
+                name: "IX_CompetitionPowerIndexExternalId_SourceUrlHash",
+                table: "CompetitionPowerIndexExternalId");
+
+            migrationBuilder.DropIndex(
+                name: "IX_CompetitionPlayExternalId_SourceUrlHash",
+                table: "CompetitionPlayExternalId");
+
+            migrationBuilder.DropIndex(
+                name: "IX_CompetitionOddsExternalId_SourceUrlHash",
+                table: "CompetitionOddsExternalId");
+
+            migrationBuilder.DropIndex(
+                name: "IX_CompetitionExternalId_SourceUrlHash",
+                table: "CompetitionExternalId");
+
+            migrationBuilder.DropIndex(
+                name: "IX_CompetitionCompetitorScoreExternalIds_SourceUrlHash",
+                table: "CompetitionCompetitorScoreExternalIds");
+
+            migrationBuilder.DropIndex(
+                name: "IX_CompetitionCompetitorLineScoreExternalId_SourceUrlHash",
+                table: "CompetitionCompetitorLineScoreExternalId");
+
+            migrationBuilder.DropIndex(
+                name: "IX_CompetitionCompetitorExternalIds_SourceUrlHash",
+                table: "CompetitionCompetitorExternalIds");
+
+            migrationBuilder.DropIndex(
+                name: "IX_CoachSeasonRecordExternalId_SourceUrlHash",
+                table: "CoachSeasonRecordExternalId");
+
+            migrationBuilder.DropIndex(
+                name: "IX_CoachRecordExternalId_SourceUrlHash",
+                table: "CoachRecordExternalId");
+
+            migrationBuilder.DropIndex(
+                name: "IX_CoachExternalId_SourceUrlHash",
+                table: "CoachExternalId");
+
+            migrationBuilder.DropIndex(
+                name: "IX_AwardExternalId_SourceUrlHash",
+                table: "AwardExternalId");
+
+            migrationBuilder.DropIndex(
+                name: "IX_AthleteSeasonExternalId_SourceUrlHash",
+                table: "AthleteSeasonExternalId");
+
+            migrationBuilder.DropIndex(
+                name: "IX_AthletePositionExternalId_SourceUrlHash",
+                table: "AthletePositionExternalId");
+
+            migrationBuilder.DropIndex(
+                name: "IX_AthleteExternalId_SourceUrlHash",
+                table: "AthleteExternalId");
+        }
+    }
+}

--- a/src/SportsData.Producer/Migrations/Baseball/BaseballDataContextModelSnapshot.cs
+++ b/src/SportsData.Producer/Migrations/Baseball/BaseballDataContextModelSnapshot.cs
@@ -1284,6 +1284,8 @@ namespace SportsData.Producer.Migrations.Baseball
 
                     b.HasIndex("AthleteId");
 
+                    b.HasIndex("SourceUrlHash");
+
                     b.ToTable("AthleteExternalId", (string)null);
                 });
 
@@ -1424,6 +1426,8 @@ namespace SportsData.Producer.Migrations.Baseball
                     b.HasKey("Id");
 
                     b.HasIndex("AthletePositionId");
+
+                    b.HasIndex("SourceUrlHash");
 
                     b.ToTable("AthletePositionExternalId", (string)null);
                 });
@@ -1571,6 +1575,8 @@ namespace SportsData.Producer.Migrations.Baseball
                     b.HasKey("Id");
 
                     b.HasIndex("AthleteSeasonId");
+
+                    b.HasIndex("SourceUrlHash");
 
                     b.ToTable("AthleteSeasonExternalId", (string)null);
                 });
@@ -1989,6 +1995,8 @@ namespace SportsData.Producer.Migrations.Baseball
 
                     b.HasIndex("AwardId");
 
+                    b.HasIndex("SourceUrlHash");
+
                     b.ToTable("AwardExternalId", (string)null);
                 });
 
@@ -2078,6 +2086,8 @@ namespace SportsData.Producer.Migrations.Baseball
                     b.HasKey("Id");
 
                     b.HasIndex("CoachId");
+
+                    b.HasIndex("SourceUrlHash");
 
                     b.ToTable("CoachExternalId", (string)null);
                 });
@@ -2171,6 +2181,8 @@ namespace SportsData.Producer.Migrations.Baseball
                     b.HasKey("Id");
 
                     b.HasIndex("CoachRecordId");
+
+                    b.HasIndex("SourceUrlHash");
 
                     b.ToTable("CoachRecordExternalId");
                 });
@@ -2360,6 +2372,8 @@ namespace SportsData.Producer.Migrations.Baseball
                     b.HasKey("Id");
 
                     b.HasIndex("CoachSeasonRecordId");
+
+                    b.HasIndex("SourceUrlHash");
 
                     b.ToTable("CoachSeasonRecordExternalId");
                 });
@@ -2845,6 +2859,8 @@ namespace SportsData.Producer.Migrations.Baseball
 
                     b.HasIndex("CompetitionCompetitorId");
 
+                    b.HasIndex("SourceUrlHash");
+
                     b.ToTable("CompetitionCompetitorExternalIds");
                 });
 
@@ -2940,6 +2956,8 @@ namespace SportsData.Producer.Migrations.Baseball
                     b.HasKey("Id");
 
                     b.HasIndex("CompetitionCompetitorLineScoreId");
+
+                    b.HasIndex("SourceUrlHash");
 
                     b.ToTable("CompetitionCompetitorLineScoreExternalId", (string)null);
                 });
@@ -3159,6 +3177,8 @@ namespace SportsData.Producer.Migrations.Baseball
 
                     b.HasIndex("CompetitionCompetitorScoreId");
 
+                    b.HasIndex("SourceUrlHash");
+
                     b.ToTable("CompetitionCompetitorScoreExternalIds");
                 });
 
@@ -3355,6 +3375,8 @@ namespace SportsData.Producer.Migrations.Baseball
                     b.HasKey("Id");
 
                     b.HasIndex("CompetitionId");
+
+                    b.HasIndex("SourceUrlHash");
 
                     b.ToTable("CompetitionExternalId", (string)null);
                 });
@@ -3938,6 +3960,8 @@ namespace SportsData.Producer.Migrations.Baseball
 
                     b.HasIndex("CompetitionOddsId");
 
+                    b.HasIndex("SourceUrlHash");
+
                     b.ToTable("CompetitionOddsExternalId", (string)null);
                 });
 
@@ -4136,6 +4160,8 @@ namespace SportsData.Producer.Migrations.Baseball
 
                     b.HasIndex("CompetitionPlayId");
 
+                    b.HasIndex("SourceUrlHash");
+
                     b.ToTable("CompetitionPlayExternalId", (string)null);
                 });
 
@@ -4285,6 +4311,8 @@ namespace SportsData.Producer.Migrations.Baseball
                     b.HasKey("Id");
 
                     b.HasIndex("CompetitionPowerIndexId");
+
+                    b.HasIndex("SourceUrlHash");
 
                     b.ToTable("CompetitionPowerIndexExternalId", (string)null);
                 });
@@ -4477,6 +4505,8 @@ namespace SportsData.Producer.Migrations.Baseball
                     b.HasKey("Id");
 
                     b.HasIndex("CompetitionProbabilityId");
+
+                    b.HasIndex("SourceUrlHash");
 
                     b.ToTable("CompetitionProbabilityExternalId");
                 });
@@ -4700,6 +4730,8 @@ namespace SportsData.Producer.Migrations.Baseball
 
                     b.HasIndex("CompetitionStatusId");
 
+                    b.HasIndex("SourceUrlHash");
+
                     b.ToTable("CompetitionStatusExternalId", (string)null);
                 });
 
@@ -4859,6 +4891,8 @@ namespace SportsData.Producer.Migrations.Baseball
                     b.HasKey("Id");
 
                     b.HasIndex("ContestId");
+
+                    b.HasIndex("SourceUrlHash");
 
                     b.ToTable("ContestExternalId", (string)null);
                 });
@@ -5161,6 +5195,8 @@ namespace SportsData.Producer.Migrations.Baseball
                     b.HasKey("Id");
 
                     b.HasIndex("FranchiseId");
+
+                    b.HasIndex("SourceUrlHash");
 
                     b.ToTable("FranchiseExternalId", (string)null);
                 });
@@ -5474,6 +5510,8 @@ namespace SportsData.Producer.Migrations.Baseball
                     b.HasKey("Id");
 
                     b.HasIndex("FranchiseSeasonId");
+
+                    b.HasIndex("SourceUrlHash");
 
                     b.ToTable("FranchiseSeasonExternalId", (string)null);
                 });
@@ -5910,6 +5948,8 @@ namespace SportsData.Producer.Migrations.Baseball
                     b.HasKey("Id");
 
                     b.HasIndex("RankingId");
+
+                    b.HasIndex("SourceUrlHash");
 
                     b.ToTable("FranchiseSeasonRankingExternalId");
                 });
@@ -6496,6 +6536,8 @@ namespace SportsData.Producer.Migrations.Baseball
                     b.HasKey("Id");
 
                     b.HasIndex("GroupSeasonId");
+
+                    b.HasIndex("SourceUrlHash");
 
                     b.ToTable("GroupSeasonExternalId", (string)null);
                 });
@@ -7195,6 +7237,8 @@ namespace SportsData.Producer.Migrations.Baseball
 
                     b.HasIndex("SeasonId");
 
+                    b.HasIndex("SourceUrlHash");
+
                     b.ToTable("SeasonExternalId", (string)null);
                 });
 
@@ -7319,6 +7363,8 @@ namespace SportsData.Producer.Migrations.Baseball
                     b.HasKey("Id");
 
                     b.HasIndex("SeasonFutureId");
+
+                    b.HasIndex("SourceUrlHash");
 
                     b.ToTable("SeasonFutureExternalId", (string)null);
                 });
@@ -7469,6 +7515,8 @@ namespace SportsData.Producer.Migrations.Baseball
 
                     b.HasIndex("SeasonPhaseId");
 
+                    b.HasIndex("SourceUrlHash");
+
                     b.ToTable("SeasonPhaseExternalId", (string)null);
                 });
 
@@ -7551,6 +7599,8 @@ namespace SportsData.Producer.Migrations.Baseball
                     b.HasKey("Id");
 
                     b.HasIndex("SeasonPollId");
+
+                    b.HasIndex("SourceUrlHash");
 
                     b.ToTable("SeasonPollExternalId");
                 });
@@ -7823,6 +7873,8 @@ namespace SportsData.Producer.Migrations.Baseball
 
                     b.HasIndex("SeasonPollWeekId");
 
+                    b.HasIndex("SourceUrlHash");
+
                     b.ToTable("SeasonPollWeekExternalId");
                 });
 
@@ -7977,6 +8029,8 @@ namespace SportsData.Producer.Migrations.Baseball
 
                     b.HasIndex("SeasonWeekId");
 
+                    b.HasIndex("SourceUrlHash");
+
                     b.ToTable("SeasonWeekExternalId", (string)null);
                 });
 
@@ -8087,6 +8141,8 @@ namespace SportsData.Producer.Migrations.Baseball
                         .HasColumnType("uuid");
 
                     b.HasKey("Id");
+
+                    b.HasIndex("SourceUrlHash");
 
                     b.HasIndex("VenueId");
 

--- a/src/SportsData.Producer/Migrations/Football/20260829083046_ExternalIdSourceUrlHashIndexes.Designer.cs
+++ b/src/SportsData.Producer/Migrations/Football/20260829083046_ExternalIdSourceUrlHashIndexes.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SportsData.Producer.Infrastructure.Data.Football;
@@ -12,9 +13,11 @@ using SportsData.Producer.Infrastructure.Data.Football;
 namespace SportsData.Producer.Migrations.Football
 {
     [DbContext(typeof(FootballDataContext))]
-    partial class FootballDataContextModelSnapshot : ModelSnapshot
+    [Migration("20260829083046_ExternalIdSourceUrlHashIndexes")]
+    partial class ExternalIdSourceUrlHashIndexes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/SportsData.Producer/Migrations/Football/20260829083046_ExternalIdSourceUrlHashIndexes.cs
+++ b/src/SportsData.Producer/Migrations/Football/20260829083046_ExternalIdSourceUrlHashIndexes.cs
@@ -1,0 +1,227 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SportsData.Producer.Migrations.Football
+{
+    /// <inheritdoc />
+    public partial class ExternalIdSourceUrlHashIndexes : Migration
+    {
+        /// <inheritdoc />
+        /// <remarks>
+        /// Raw IF NOT EXISTS rather than CreateIndex: prod got these same
+        /// indexes via CREATE INDEX CONCURRENTLY on 2026-08-29 (emergency
+        /// remediation for the game-day seq-scan saturation), so the
+        /// migration must be a no-op where an index already exists.
+        /// </remarks>
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(
+                @"CREATE INDEX IF NOT EXISTS ""IX_VenueExternalId_SourceUrlHash"" ON public.""VenueExternalId"" (""SourceUrlHash"");");
+
+            migrationBuilder.Sql(
+                @"CREATE INDEX IF NOT EXISTS ""IX_SeasonWeekExternalId_SourceUrlHash"" ON public.""SeasonWeekExternalId"" (""SourceUrlHash"");");
+
+            migrationBuilder.Sql(
+                @"CREATE INDEX IF NOT EXISTS ""IX_SeasonPollWeekExternalId_SourceUrlHash"" ON public.""SeasonPollWeekExternalId"" (""SourceUrlHash"");");
+
+            migrationBuilder.Sql(
+                @"CREATE INDEX IF NOT EXISTS ""IX_SeasonPollExternalId_SourceUrlHash"" ON public.""SeasonPollExternalId"" (""SourceUrlHash"");");
+
+            migrationBuilder.Sql(
+                @"CREATE INDEX IF NOT EXISTS ""IX_SeasonPhaseExternalId_SourceUrlHash"" ON public.""SeasonPhaseExternalId"" (""SourceUrlHash"");");
+
+            migrationBuilder.Sql(
+                @"CREATE INDEX IF NOT EXISTS ""IX_SeasonFutureExternalId_SourceUrlHash"" ON public.""SeasonFutureExternalId"" (""SourceUrlHash"");");
+
+            migrationBuilder.Sql(
+                @"CREATE INDEX IF NOT EXISTS ""IX_SeasonExternalId_SourceUrlHash"" ON public.""SeasonExternalId"" (""SourceUrlHash"");");
+
+            migrationBuilder.Sql(
+                @"CREATE INDEX IF NOT EXISTS ""IX_GroupSeasonExternalId_SourceUrlHash"" ON public.""GroupSeasonExternalId"" (""SourceUrlHash"");");
+
+            migrationBuilder.Sql(
+                @"CREATE INDEX IF NOT EXISTS ""IX_FranchiseSeasonRankingExternalId_SourceUrlHash"" ON public.""FranchiseSeasonRankingExternalId"" (""SourceUrlHash"");");
+
+            migrationBuilder.Sql(
+                @"CREATE INDEX IF NOT EXISTS ""IX_FranchiseSeasonExternalId_SourceUrlHash"" ON public.""FranchiseSeasonExternalId"" (""SourceUrlHash"");");
+
+            migrationBuilder.Sql(
+                @"CREATE INDEX IF NOT EXISTS ""IX_FranchiseExternalId_SourceUrlHash"" ON public.""FranchiseExternalId"" (""SourceUrlHash"");");
+
+            migrationBuilder.Sql(
+                @"CREATE INDEX IF NOT EXISTS ""IX_ContestExternalId_SourceUrlHash"" ON public.""ContestExternalId"" (""SourceUrlHash"");");
+
+            migrationBuilder.Sql(
+                @"CREATE INDEX IF NOT EXISTS ""IX_CompetitionStatusExternalId_SourceUrlHash"" ON public.""CompetitionStatusExternalId"" (""SourceUrlHash"");");
+
+            migrationBuilder.Sql(
+                @"CREATE INDEX IF NOT EXISTS ""IX_CompetitionProbabilityExternalId_SourceUrlHash"" ON public.""CompetitionProbabilityExternalId"" (""SourceUrlHash"");");
+
+            migrationBuilder.Sql(
+                @"CREATE INDEX IF NOT EXISTS ""IX_CompetitionPowerIndexExternalId_SourceUrlHash"" ON public.""CompetitionPowerIndexExternalId"" (""SourceUrlHash"");");
+
+            migrationBuilder.Sql(
+                @"CREATE INDEX IF NOT EXISTS ""IX_CompetitionPlayExternalId_SourceUrlHash"" ON public.""CompetitionPlayExternalId"" (""SourceUrlHash"");");
+
+            migrationBuilder.Sql(
+                @"CREATE INDEX IF NOT EXISTS ""IX_CompetitionOddsExternalId_SourceUrlHash"" ON public.""CompetitionOddsExternalId"" (""SourceUrlHash"");");
+
+            migrationBuilder.Sql(
+                @"CREATE INDEX IF NOT EXISTS ""IX_CompetitionExternalId_SourceUrlHash"" ON public.""CompetitionExternalId"" (""SourceUrlHash"");");
+
+            migrationBuilder.Sql(
+                @"CREATE INDEX IF NOT EXISTS ""IX_CompetitionDriveExternalId_SourceUrlHash"" ON public.""CompetitionDriveExternalId"" (""SourceUrlHash"");");
+
+            migrationBuilder.Sql(
+                @"CREATE INDEX IF NOT EXISTS ""IX_CompetitionCompetitorScoreExternalIds_SourceUrlHash"" ON public.""CompetitionCompetitorScoreExternalIds"" (""SourceUrlHash"");");
+
+            migrationBuilder.Sql(
+                @"CREATE INDEX IF NOT EXISTS ""IX_CompetitionCompetitorLineScoreExternalId_SourceUrlHash"" ON public.""CompetitionCompetitorLineScoreExternalId"" (""SourceUrlHash"");");
+
+            migrationBuilder.Sql(
+                @"CREATE INDEX IF NOT EXISTS ""IX_CompetitionCompetitorExternalIds_SourceUrlHash"" ON public.""CompetitionCompetitorExternalIds"" (""SourceUrlHash"");");
+
+            migrationBuilder.Sql(
+                @"CREATE INDEX IF NOT EXISTS ""IX_CoachSeasonRecordExternalId_SourceUrlHash"" ON public.""CoachSeasonRecordExternalId"" (""SourceUrlHash"");");
+
+            migrationBuilder.Sql(
+                @"CREATE INDEX IF NOT EXISTS ""IX_CoachRecordExternalId_SourceUrlHash"" ON public.""CoachRecordExternalId"" (""SourceUrlHash"");");
+
+            migrationBuilder.Sql(
+                @"CREATE INDEX IF NOT EXISTS ""IX_CoachExternalId_SourceUrlHash"" ON public.""CoachExternalId"" (""SourceUrlHash"");");
+
+            migrationBuilder.Sql(
+                @"CREATE INDEX IF NOT EXISTS ""IX_AwardExternalId_SourceUrlHash"" ON public.""AwardExternalId"" (""SourceUrlHash"");");
+
+            migrationBuilder.Sql(
+                @"CREATE INDEX IF NOT EXISTS ""IX_AthleteSeasonExternalId_SourceUrlHash"" ON public.""AthleteSeasonExternalId"" (""SourceUrlHash"");");
+
+            migrationBuilder.Sql(
+                @"CREATE INDEX IF NOT EXISTS ""IX_AthletePositionExternalId_SourceUrlHash"" ON public.""AthletePositionExternalId"" (""SourceUrlHash"");");
+
+            migrationBuilder.Sql(
+                @"CREATE INDEX IF NOT EXISTS ""IX_AthleteExternalId_SourceUrlHash"" ON public.""AthleteExternalId"" (""SourceUrlHash"");");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_VenueExternalId_SourceUrlHash",
+                table: "VenueExternalId");
+
+            migrationBuilder.DropIndex(
+                name: "IX_SeasonWeekExternalId_SourceUrlHash",
+                table: "SeasonWeekExternalId");
+
+            migrationBuilder.DropIndex(
+                name: "IX_SeasonPollWeekExternalId_SourceUrlHash",
+                table: "SeasonPollWeekExternalId");
+
+            migrationBuilder.DropIndex(
+                name: "IX_SeasonPollExternalId_SourceUrlHash",
+                table: "SeasonPollExternalId");
+
+            migrationBuilder.DropIndex(
+                name: "IX_SeasonPhaseExternalId_SourceUrlHash",
+                table: "SeasonPhaseExternalId");
+
+            migrationBuilder.DropIndex(
+                name: "IX_SeasonFutureExternalId_SourceUrlHash",
+                table: "SeasonFutureExternalId");
+
+            migrationBuilder.DropIndex(
+                name: "IX_SeasonExternalId_SourceUrlHash",
+                table: "SeasonExternalId");
+
+            migrationBuilder.DropIndex(
+                name: "IX_GroupSeasonExternalId_SourceUrlHash",
+                table: "GroupSeasonExternalId");
+
+            migrationBuilder.DropIndex(
+                name: "IX_FranchiseSeasonRankingExternalId_SourceUrlHash",
+                table: "FranchiseSeasonRankingExternalId");
+
+            migrationBuilder.DropIndex(
+                name: "IX_FranchiseSeasonExternalId_SourceUrlHash",
+                table: "FranchiseSeasonExternalId");
+
+            migrationBuilder.DropIndex(
+                name: "IX_FranchiseExternalId_SourceUrlHash",
+                table: "FranchiseExternalId");
+
+            migrationBuilder.DropIndex(
+                name: "IX_ContestExternalId_SourceUrlHash",
+                table: "ContestExternalId");
+
+            migrationBuilder.DropIndex(
+                name: "IX_CompetitionStatusExternalId_SourceUrlHash",
+                table: "CompetitionStatusExternalId");
+
+            migrationBuilder.DropIndex(
+                name: "IX_CompetitionProbabilityExternalId_SourceUrlHash",
+                table: "CompetitionProbabilityExternalId");
+
+            migrationBuilder.DropIndex(
+                name: "IX_CompetitionPowerIndexExternalId_SourceUrlHash",
+                table: "CompetitionPowerIndexExternalId");
+
+            migrationBuilder.DropIndex(
+                name: "IX_CompetitionPlayExternalId_SourceUrlHash",
+                table: "CompetitionPlayExternalId");
+
+            migrationBuilder.DropIndex(
+                name: "IX_CompetitionOddsExternalId_SourceUrlHash",
+                table: "CompetitionOddsExternalId");
+
+            migrationBuilder.DropIndex(
+                name: "IX_CompetitionExternalId_SourceUrlHash",
+                table: "CompetitionExternalId");
+
+            migrationBuilder.DropIndex(
+                name: "IX_CompetitionDriveExternalId_SourceUrlHash",
+                table: "CompetitionDriveExternalId");
+
+            migrationBuilder.DropIndex(
+                name: "IX_CompetitionCompetitorScoreExternalIds_SourceUrlHash",
+                table: "CompetitionCompetitorScoreExternalIds");
+
+            migrationBuilder.DropIndex(
+                name: "IX_CompetitionCompetitorLineScoreExternalId_SourceUrlHash",
+                table: "CompetitionCompetitorLineScoreExternalId");
+
+            migrationBuilder.DropIndex(
+                name: "IX_CompetitionCompetitorExternalIds_SourceUrlHash",
+                table: "CompetitionCompetitorExternalIds");
+
+            migrationBuilder.DropIndex(
+                name: "IX_CoachSeasonRecordExternalId_SourceUrlHash",
+                table: "CoachSeasonRecordExternalId");
+
+            migrationBuilder.DropIndex(
+                name: "IX_CoachRecordExternalId_SourceUrlHash",
+                table: "CoachRecordExternalId");
+
+            migrationBuilder.DropIndex(
+                name: "IX_CoachExternalId_SourceUrlHash",
+                table: "CoachExternalId");
+
+            migrationBuilder.DropIndex(
+                name: "IX_AwardExternalId_SourceUrlHash",
+                table: "AwardExternalId");
+
+            migrationBuilder.DropIndex(
+                name: "IX_AthleteSeasonExternalId_SourceUrlHash",
+                table: "AthleteSeasonExternalId");
+
+            migrationBuilder.DropIndex(
+                name: "IX_AthletePositionExternalId_SourceUrlHash",
+                table: "AthletePositionExternalId");
+
+            migrationBuilder.DropIndex(
+                name: "IX_AthleteExternalId_SourceUrlHash",
+                table: "AthleteExternalId");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Document identity resolution — the `EXISTS (Provider = $1 AND SourceUrlHash = $2)` lookup that runs for **every processed document** — had no supporting index on **any** of the ExternalId tables. Lookups sequential-scanned tables of up to 14.2M rows (`CompetitionProbabilityExternalId`; `CompetitionPlayExternalId` is 5M).

Prod impact, measured on NCAAFB kickoff night (2026-08-28): 80+ concurrent copies of these lookups at 1.5–5.5s each saturated the shared PG box, stretched worker transactions, queued the MassTransit outbox `FOR UPDATE` sweeps into lock pileups (2,235 blocked×blocker pairs in one snapshot), and pushed innocent UI reads through Producer — the league matchups endpoint mobile hits — from ~300ms to **4–30s**. The endpoint itself was exonerated: the matchups SQL EXPLAIN ANALYZEs at 333ms and Producer answered the identical request in 370–740ms when the box wasn't drowning.

## Mechanism

One generic helper in `BaseDataContext` — `ApplyExternalIdSourceUrlHashIndexes` — adds `HasIndex(SourceUrlHash)` to every `ExternalId`-derived entity in the model, called at the **end** of each concrete context's `OnModelCreating` (sport-specific ExternalId entities must already be registered). No per-entity edits across the 30 ExternalId classes; any future ExternalId entity gets the index automatically.

## Migrations

Football (29 indexes) + Baseball (28 indexes). `Up` bodies are raw `CREATE INDEX IF NOT EXISTS` rather than `CreateIndex`, deliberately:

- Prod received these same indexes out-of-band on 2026-08-29 via `CREATE INDEX CONCURRENTLY` (non-blocking emergency remediation ahead of the Saturday slate). The deploy-time migration must no-op where an index already exists.
- A migration-time plain `CREATE INDEX` would block writes for minutes per large table and stall pod startup into probe-timeout territory; `CONCURRENTLY` can't run inside EF's migration transaction.

`Down` keeps the generated `DropIndex` operations.

## Validation

- Migrations applied to all three local Producer databases against full prod-scale restored data: NCAA (55GB) 98s, NFL 23s, MLB 44s
- Producer suite: 625 passed
- Solution builds clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnJySMvfUPeQSMufNNcKSK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved lookup performance for records identified by external source URLs across baseball and football data.
  * Added database indexes covering external identifiers for athletes, coaches, competitions, franchises, seasons, venues, and related entities.
  * Database updates are safely repeatable without creating duplicate indexes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->