### PR TITLE
fix(provider): escalating-backoff suppression for ESPN 404s

### DIFF
--- a/src/SportsData.Provider/Application/Documents/DocumentRequestedHandler.cs
+++ b/src/SportsData.Provider/Application/Documents/DocumentRequestedHandler.cs
@@ -268,9 +268,21 @@ public class DocumentRequestedHandler : IConsumer<DocumentRequested>
                     // e.g. no win-probability model for this competition.
                     // Remember it so the live streamers' fixed-cadence
                     // re-requests short-circuit instead of re-hitting ESPN.
-                    await _knownBadUris.MarkBadAsync(uri);
+                    await _knownBadUris.MarkBadAsync(uri, KnownBadReason.BadRequest);
                     _logger.LogWarning(
                         "ESPN returned BadRequest; marking URI known-bad and suppressing refetches. PageUri={PageUri}",
+                        uri);
+                    return;
+                }
+
+                if (result.Status == ResultStatus.NotFound)
+                {
+                    // ESPN 404 = doesn't exist NOW, might later (next week's
+                    // poll). Escalating backoff (5m → 6h) so Producer's
+                    // dependency retry loop can't refetch a dead URI forever.
+                    await _knownBadUris.MarkBadAsync(uri, KnownBadReason.NotFound);
+                    _logger.LogWarning(
+                        "ESPN returned NotFound; suppressing refetches with backoff. PageUri={PageUri}",
                         uri);
                     return;
                 }

--- a/src/SportsData.Provider/Application/Processors/ResourceIndexItemProcessor.cs
+++ b/src/SportsData.Provider/Application/Processors/ResourceIndexItemProcessor.cs
@@ -299,12 +299,29 @@ namespace SportsData.Provider.Application.Processors
                 {
                     if (result.Status == ResultStatus.BadRequest)
                     {
-                        // ESPN 400 = permanently unsupported resource (unlike
-                        // 404 = not yet published, which must keep retrying).
+                        // ESPN 400 = permanently unsupported resource.
                         // Suppress the live streamers' fixed-cadence refetches.
-                        await _knownBadUris.MarkBadAsync(command.Uri);
+                        await _knownBadUris.MarkBadAsync(command.Uri, KnownBadReason.BadRequest);
                         _logger.LogWarning(
                             "ESPN returned BadRequest; marking URI known-bad and suppressing refetches. Uri={Uri}",
+                            command.Uri);
+                        return;
+                    }
+
+                    if (result.Status == ResultStatus.NotFound)
+                    {
+                        // ESPN 404 = doesn't exist NOW but might later, so
+                        // escalating backoff (5m → 6h cap) rather than a flat
+                        // long TTL: a live-window race costs minutes, while a
+                        // URI ESPN references but never serves (e.g. a play
+                        // participant whose athlete page doesn't exist —
+                        // observed at ~1,400 refetches/day) decays to a few
+                        // probes a day. Producer's dependency retry keeps its
+                        // DLQ semantics — Provider just answers from memory
+                        // until the window lapses.
+                        await _knownBadUris.MarkBadAsync(command.Uri, KnownBadReason.NotFound);
+                        _logger.LogWarning(
+                            "ESPN returned NotFound; suppressing refetches with backoff. Uri={Uri}",
                             command.Uri);
                         return;
                     }

--- a/src/SportsData.Provider/Infrastructure/Data/Entities/EspnKnownBadUri.cs
+++ b/src/SportsData.Provider/Infrastructure/Data/Entities/EspnKnownBadUri.cs
@@ -26,6 +26,16 @@ namespace SportsData.Provider.Infrastructure.Data.Entities
 
         public required Uri Uri { get; set; }
 
+        /// <summary>"BadRequest" (permanent, flat TTL) or "NotFound" (escalating backoff).</summary>
+        public string Reason { get; set; } = "BadRequest";
+
+        /// <summary>
+        /// Consecutive failures — drives the NotFound backoff (5m doubling
+        /// to a 6h cap). Persisted so a fresh pod continues the escalation
+        /// instead of restarting it at 5 minutes.
+        /// </summary>
+        public int FailureCount { get; set; } = 1;
+
         public DateTime CreatedUtc { get; set; }
 
         public DateTime ExpiresUtc { get; set; }
@@ -43,6 +53,9 @@ namespace SportsData.Provider.Infrastructure.Data.Entities
 
                 builder.Property(p => p.Uri)
                     .HasMaxLength(512);
+
+                builder.Property(x => x.Reason)
+                    .HasMaxLength(16);
             }
         }
     }

--- a/src/SportsData.Provider/Infrastructure/Providers/Espn/KnownBadUriCache.cs
+++ b/src/SportsData.Provider/Infrastructure/Providers/Espn/KnownBadUriCache.cs
@@ -114,7 +114,14 @@ namespace SportsData.Provider.Infrastructure.Providers.Espn
                 var row = await dataContext.EspnKnownBadUris
                     .FirstOrDefaultAsync(x => x.UrlHash == key);
 
-                var failureCount = (row?.FailureCount ?? 0) + 1;
+                // A reason change restarts the escalation: the count only
+                // means "consecutive failures OF THIS KIND" — a URI that
+                // 400'd for weeks then starts 404ing must begin at the
+                // 5-minute base, not inherit a near-cap count.
+                var reasonText = reason.ToString();
+                var failureCount = row is null || row.Reason != reasonText
+                    ? 1
+                    : row.FailureCount + 1;
                 var expiresUtc = now.Add(TtlFor(reason, failureCount));
 
                 if (row is null)
@@ -123,7 +130,7 @@ namespace SportsData.Provider.Infrastructure.Providers.Espn
                     {
                         UrlHash = key,
                         Uri = uri,
-                        Reason = reason.ToString(),
+                        Reason = reasonText,
                         FailureCount = failureCount,
                         CreatedUtc = now,
                         ExpiresUtc = expiresUtc,
@@ -131,7 +138,7 @@ namespace SportsData.Provider.Infrastructure.Providers.Espn
                 }
                 else
                 {
-                    row.Reason = reason.ToString();
+                    row.Reason = reasonText;
                     row.FailureCount = failureCount;
                     row.ExpiresUtc = expiresUtc;
                 }

--- a/src/SportsData.Provider/Infrastructure/Providers/Espn/KnownBadUriCache.cs
+++ b/src/SportsData.Provider/Infrastructure/Providers/Espn/KnownBadUriCache.cs
@@ -15,31 +15,59 @@ using System.Threading.Tasks;
 
 namespace SportsData.Provider.Infrastructure.Providers.Espn
 {
+    /// <summary>Why ESPN refused the URI — drives the suppression policy.</summary>
+    public enum KnownBadReason
+    {
+        /// <summary>
+        /// 400 — a permanent "unsupported resource" verdict (e.g.
+        /// "Probabilities are not supported for ... competition: X").
+        /// Flat 12h suppression.
+        /// </summary>
+        BadRequest,
+
+        /// <summary>
+        /// 404 — the resource doesn't exist NOW but might later (next
+        /// week's AP poll; an athlete page ESPN publishes late). Escalating
+        /// backoff: 5m doubling per consecutive failure to a 6h cap, so a
+        /// live-window race costs minutes while a truly dead URI (an
+        /// athlete ESPN references in plays but never serves) decays to a
+        /// few probes a day instead of one per minute.
+        /// </summary>
+        NotFound,
+    }
+
     /// <summary>
-    /// Remembers ESPN URIs that returned 400 BadRequest so repeat requests
-    /// short-circuit instead of re-hitting ESPN. A 400 is a permanent
-    /// "unsupported" answer (e.g. "Probabilities are not supported for ...
-    /// competition: X") — unlike 404 (dependency not yet published; must
-    /// keep retrying) or 403 (rate limiting; handled by the retry policy).
-    /// Producer's live streamers re-request child documents on a fixed
-    /// cadence for the whole game, so without this an unsupported document
-    /// is refetched every cycle.
+    /// Remembers ESPN URIs that returned 400 or 404 so repeat requests
+    /// short-circuit instead of re-hitting ESPN. Producer's dependency
+    /// retry loop re-requests missing documents indefinitely (by design —
+    /// at-least-once + DLQ), so without this a URI ESPN will never serve
+    /// is refetched forever (observed: one athlete page, ~1,400 asks/day).
+    /// Suppression here does NOT break the DLQ flow: Producer keeps
+    /// retrying its documents; Provider just answers "still nothing" from
+    /// memory until the backoff window lapses and a real probe runs.
     ///
     /// Two layers: an in-memory dictionary serves the per-fetch check with
     /// zero DB reads; the <see cref="EspnKnownBadUri"/> table makes the
     /// knowledge durable — hydrated once at first use (so a fresh KEDA pod
-    /// starts already knowing what every previous pod learned) and written
-    /// through on each new 400.
+    /// starts already knowing what every previous pod learned, including
+    /// backoff escalation) and written through on each new failure.
     /// </summary>
     public interface IKnownBadUriCache
     {
         Task<bool> IsKnownBadAsync(Uri uri);
-        Task MarkBadAsync(Uri uri);
+        Task MarkBadAsync(Uri uri, KnownBadReason reason);
     }
 
     public class KnownBadUriCache : IKnownBadUriCache
     {
-        private static readonly TimeSpan Ttl = TimeSpan.FromHours(12);
+        private static readonly TimeSpan BadRequestTtl = TimeSpan.FromHours(12);
+        private static readonly TimeSpan NotFoundBaseTtl = TimeSpan.FromMinutes(5);
+        private static readonly TimeSpan NotFoundMaxTtl = TimeSpan.FromHours(6);
+
+        // Expired rows are kept this long so the NotFound FailureCount
+        // survives between probes (pruning at expiry would reset every
+        // backoff to 5 minutes on its next failure).
+        private static readonly TimeSpan PruneGrace = TimeSpan.FromDays(7);
 
         private readonly IServiceScopeFactory _scopeFactory;
         private readonly IDateTimeProvider _dateTimeProvider;
@@ -73,14 +101,10 @@ namespace SportsData.Provider.Infrastructure.Providers.Espn
             return false;
         }
 
-        public async Task MarkBadAsync(Uri uri)
+        public async Task MarkBadAsync(Uri uri, KnownBadReason reason)
         {
             var now = _dateTimeProvider.UtcNow();
             var key = HashProvider.GenerateHashFromUri(uri);
-            var expiresUtc = now.Add(Ttl);
-
-            // Memory first — suppression works even if the write below fails.
-            _expiryByKey[key] = expiresUtc;
 
             try
             {
@@ -89,24 +113,41 @@ namespace SportsData.Provider.Infrastructure.Providers.Espn
 
                 var row = await dataContext.EspnKnownBadUris
                     .FirstOrDefaultAsync(x => x.UrlHash == key);
+
+                var failureCount = (row?.FailureCount ?? 0) + 1;
+                var expiresUtc = now.Add(TtlFor(reason, failureCount));
+
                 if (row is null)
                 {
                     dataContext.EspnKnownBadUris.Add(new EspnKnownBadUri
                     {
                         UrlHash = key,
                         Uri = uri,
+                        Reason = reason.ToString(),
+                        FailureCount = failureCount,
                         CreatedUtc = now,
                         ExpiresUtc = expiresUtc,
                     });
                 }
                 else
                 {
+                    row.Reason = reason.ToString();
+                    row.FailureCount = failureCount;
                     row.ExpiresUtc = expiresUtc;
                 }
 
-                // The table stays tiny; prune expired rows opportunistically.
+                // Memory before SaveChanges so suppression holds even if the
+                // write races another pod; corrected below on failure paths.
+                _expiryByKey[key] = expiresUtc;
+
+                // Prune rows expired past the grace window (NOT at expiry —
+                // FailureCount must survive between probes for the backoff
+                // to escalate). The current key can't match: its ExpiresUtc
+                // was just set in the future, and EF's identity map returns
+                // the tracked, updated instance.
+                var pruneBefore = now - PruneGrace;
                 var expired = await dataContext.EspnKnownBadUris
-                    .Where(x => x.ExpiresUtc <= now)
+                    .Where(x => x.ExpiresUtc <= pruneBefore && x.UrlHash != key)
                     .ToListAsync();
                 dataContext.EspnKnownBadUris.RemoveRange(expired);
 
@@ -115,9 +156,28 @@ namespace SportsData.Provider.Infrastructure.Providers.Espn
             catch (DbUpdateException ex)
             {
                 // Another pod raced us to the same insert — its row is as
-                // good as ours; memory is already updated.
+                // good as ours; keep a base-TTL memory entry.
+                _expiryByKey[key] = now.Add(TtlFor(reason, 1));
                 _logger.LogDebug(ex, "Concurrent EspnKnownBadUri write; keeping existing row. Uri={Uri}", uri);
             }
+            catch (Exception ex)
+            {
+                // DB unavailable — suppress in-memory at base TTL anyway;
+                // durability catches up on the next failure after recovery.
+                _expiryByKey[key] = now.Add(TtlFor(reason, 1));
+                _logger.LogWarning(ex, "Failed to persist known-bad URI; suppressing in-memory only. Uri={Uri}", uri);
+            }
+        }
+
+        private static TimeSpan TtlFor(KnownBadReason reason, int failureCount)
+        {
+            if (reason == KnownBadReason.BadRequest)
+                return BadRequestTtl;
+
+            // 5m, 10m, 20m, 40m, 80m, 160m, 320m, then capped at 6h.
+            var exponent = Math.Clamp(failureCount - 1, 0, 30);
+            var ticks = NotFoundBaseTtl.Ticks * (1L << exponent);
+            return ticks >= NotFoundMaxTtl.Ticks ? NotFoundMaxTtl : TimeSpan.FromTicks(ticks);
         }
 
         private async Task EnsureHydratedAsync()

--- a/src/SportsData.Provider/Migrations/20260829090704_EspnKnownBadUriReasonBackoff.Designer.cs
+++ b/src/SportsData.Provider/Migrations/20260829090704_EspnKnownBadUriReasonBackoff.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SportsData.Provider.Infrastructure.Data;
@@ -11,9 +12,11 @@ using SportsData.Provider.Infrastructure.Data;
 namespace SportsData.Provider.Migrations
 {
     [DbContext(typeof(AppDataContext))]
-    partial class AppDataContextModelSnapshot : ModelSnapshot
+    [Migration("20260829090704_EspnKnownBadUriReasonBackoff")]
+    partial class EspnKnownBadUriReasonBackoff
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/SportsData.Provider/Migrations/20260829090704_EspnKnownBadUriReasonBackoff.cs
+++ b/src/SportsData.Provider/Migrations/20260829090704_EspnKnownBadUriReasonBackoff.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SportsData.Provider.Migrations
+{
+    /// <inheritdoc />
+    public partial class EspnKnownBadUriReasonBackoff : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "FailureCount",
+                table: "EspnKnownBadUri",
+                type: "integer",
+                nullable: false,
+                defaultValue: 1);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Reason",
+                table: "EspnKnownBadUri",
+                type: "character varying(16)",
+                maxLength: 16,
+                nullable: false,
+                defaultValue: "BadRequest");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "FailureCount",
+                table: "EspnKnownBadUri");
+
+            migrationBuilder.DropColumn(
+                name: "Reason",
+                table: "EspnKnownBadUri");
+        }
+    }
+}

--- a/test/unit/SportsData.Provider.Tests.Unit/Application/Documents/DocumentRequestedHandlerTests.cs
+++ b/test/unit/SportsData.Provider.Tests.Unit/Application/Documents/DocumentRequestedHandlerTests.cs
@@ -746,7 +746,7 @@ public class DocumentRequestedHandlerTests : ProviderTestBase<DocumentRequestedH
         await handler.Consume(ctx);
 
         // assert
-        knownBad.Verify(x => x.MarkBadAsync(ProbabilitiesUri), Times.Once);
+        knownBad.Verify(x => x.MarkBadAsync(ProbabilitiesUri, KnownBadReason.BadRequest), Times.Once);
         background.Verify(x => x.Enqueue<IProcessResourceIndexItems>(
             It.IsAny<Expression<Func<IProcessResourceIndexItems, Task>>>()), Times.Never);
     }
@@ -772,5 +772,27 @@ public class DocumentRequestedHandlerTests : ProviderTestBase<DocumentRequestedH
         espnApi.Verify(
             x => x.GetResource(It.IsAny<Uri>(), It.IsAny<bool>(), It.IsAny<bool>()),
             Times.Never);
+    }
+
+    [Fact]
+    public async Task WhenEspnReturnsNotFound_MarksUriWithNotFoundReason()
+    {
+        // arrange — ESPN 404s (resource doesn't exist yet / ever); the
+        // suppression uses the escalating-backoff reason, not the flat one.
+        Mocker.GetMock<IProvideEspnApiData>()
+            .Setup(x => x.GetResource(It.IsAny<Uri>(), true, false))
+            .ReturnsAsync(new Failure<string>(string.Empty, ResultStatus.NotFound, []));
+
+        var knownBad = Mocker.GetMock<IKnownBadUriCache>();
+        var handler = Mocker.CreateInstance<DocumentRequestedHandler>();
+
+        var msg = ProbabilitiesRequest(Fixture);
+        var ctx = Mock.Of<ConsumeContext<DocumentRequested>>(x => x.Message == msg);
+
+        // act
+        await handler.Consume(ctx);
+
+        // assert
+        knownBad.Verify(x => x.MarkBadAsync(ProbabilitiesUri, KnownBadReason.NotFound), Times.Once);
     }
 }

--- a/test/unit/SportsData.Provider.Tests.Unit/Infrastructure/Providers/KnownBadUriCacheTests.cs
+++ b/test/unit/SportsData.Provider.Tests.Unit/Infrastructure/Providers/KnownBadUriCacheTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+﻿using FluentAssertions;
 
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -61,7 +61,7 @@ public class KnownBadUriCacheTests
         var cache = CreateCache();
         var uri = new Uri("http://sports.core.api.espn.com/v2/sports/football/leagues/college-football/events/401866615/competitions/401866615/probabilities");
 
-        await cache.MarkBadAsync(uri);
+        await cache.MarkBadAsync(uri, KnownBadReason.BadRequest);
 
         (await cache.IsKnownBadAsync(uri)).Should().BeTrue();
     }
@@ -71,7 +71,7 @@ public class KnownBadUriCacheTests
     {
         var cache = CreateCache();
 
-        await cache.MarkBadAsync(new Uri("http://sports.core.api.espn.com/v2/events/1/probabilities?lang=en&region=us"));
+        await cache.MarkBadAsync(new Uri("http://sports.core.api.espn.com/v2/events/1/probabilities?lang=en&region=us"), KnownBadReason.BadRequest);
 
         (await cache.IsKnownBadAsync(new Uri("http://sports.core.api.espn.com/v2/events/1/probabilities?lang=en&region=us&page=2")))
             .Should().BeTrue();
@@ -87,7 +87,7 @@ public class KnownBadUriCacheTests
     {
         var cache = CreateCache();
         var uri = new Uri("http://sports.core.api.espn.com/v2/events/1/probabilities");
-        await cache.MarkBadAsync(uri);
+        await cache.MarkBadAsync(uri, KnownBadReason.BadRequest);
 
         _clock.Setup(x => x.UtcNow()).Returns(FixedNow.AddHours(13));
 
@@ -100,7 +100,7 @@ public class KnownBadUriCacheTests
         // The new-KEDA-pod scenario: pod A learns a bad URI; pod B (a brand
         // new cache instance over the same database) must know it too.
         var uri = new Uri("http://sports.core.api.espn.com/v2/events/1/probabilities");
-        await CreateCache().MarkBadAsync(uri);
+        await CreateCache().MarkBadAsync(uri, KnownBadReason.BadRequest);
 
         var freshPod = CreateCache();
 
@@ -112,19 +112,66 @@ public class KnownBadUriCacheTests
     {
         var expiredUri = new Uri("http://sports.core.api.espn.com/v2/events/1/probabilities");
         var freshUri = new Uri("http://sports.core.api.espn.com/v2/events/2/probabilities");
-        await CreateCache().MarkBadAsync(expiredUri);
+        await CreateCache().MarkBadAsync(expiredUri, KnownBadReason.BadRequest);
 
         // 13h later the first entry is expired; a new pod marks a second URI.
         _clock.Setup(x => x.UtcNow()).Returns(FixedNow.AddHours(13));
         var freshPod = CreateCache();
-        await freshPod.MarkBadAsync(freshUri);
+        await freshPod.MarkBadAsync(freshUri, KnownBadReason.BadRequest);
 
         (await freshPod.IsKnownBadAsync(expiredUri)).Should().BeFalse();
         (await freshPod.IsKnownBadAsync(freshUri)).Should().BeTrue();
 
-        // The write pruned the expired row from the table.
+        // The expired row SURVIVES expiry (FailureCount must persist for
+        // the NotFound backoff) — it is pruned only past the 7-day grace.
         using var scope = _scopeFactory.CreateScope();
         var dataContext = scope.ServiceProvider.GetRequiredService<AppDataContext>();
-        (await dataContext.EspnKnownBadUris.CountAsync()).Should().Be(1);
+        (await dataContext.EspnKnownBadUris.CountAsync()).Should().Be(2);
+
+        // 8 days later a new write prunes it.
+        _clock.Setup(x => x.UtcNow()).Returns(FixedNow.AddDays(8));
+        await freshPod.MarkBadAsync(freshUri, KnownBadReason.BadRequest);
+        (await dataContext.EspnKnownBadUris.AsNoTracking().CountAsync()).Should().Be(1);
+    }
+
+    [Fact]
+    public async Task NotFound_BacksOffExponentially_AndEscalationSurvivesNewPod()
+    {
+        var uri = new Uri("http://sports.core.api.espn.com/v2/sports/football/leagues/college-football/seasons/2026/athletes/5421843");
+        var cache = CreateCache();
+
+        // Failure 1: suppressed 5 minutes — expired at +6m.
+        await cache.MarkBadAsync(uri, KnownBadReason.NotFound);
+        (await cache.IsKnownBadAsync(uri)).Should().BeTrue();
+        _clock.Setup(x => x.UtcNow()).Returns(FixedNow.AddMinutes(6));
+        (await cache.IsKnownBadAsync(uri)).Should().BeFalse();
+
+        // Failure 2 (from a FRESH pod — escalation is persisted): 10 minutes.
+        var freshPod = CreateCache();
+        await freshPod.MarkBadAsync(uri, KnownBadReason.NotFound);
+        _clock.Setup(x => x.UtcNow()).Returns(FixedNow.AddMinutes(6 + 9));
+        (await freshPod.IsKnownBadAsync(uri)).Should().BeTrue();
+        _clock.Setup(x => x.UtcNow()).Returns(FixedNow.AddMinutes(6 + 11));
+        (await freshPod.IsKnownBadAsync(uri)).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task NotFound_BackoffCapsAtSixHours()
+    {
+        var uri = new Uri("http://sports.core.api.espn.com/v2/dead");
+        var cache = CreateCache();
+
+        // Drive the failure count far past the cap threshold.
+        for (var i = 0; i < 12; i++)
+        {
+            await cache.MarkBadAsync(uri, KnownBadReason.NotFound);
+        }
+
+        // Still suppressed just before six hours...
+        _clock.Setup(x => x.UtcNow()).Returns(FixedNow.AddMinutes(355));
+        (await cache.IsKnownBadAsync(uri)).Should().BeTrue();
+        // ...and expired just after.
+        _clock.Setup(x => x.UtcNow()).Returns(FixedNow.AddMinutes(365));
+        (await cache.IsKnownBadAsync(uri)).Should().BeFalse();
     }
 }

--- a/test/unit/SportsData.Provider.Tests.Unit/Infrastructure/Providers/KnownBadUriCacheTests.cs
+++ b/test/unit/SportsData.Provider.Tests.Unit/Infrastructure/Providers/KnownBadUriCacheTests.cs
@@ -126,7 +126,7 @@ public class KnownBadUriCacheTests
         // the NotFound backoff) — it is pruned only past the 7-day grace.
         using var scope = _scopeFactory.CreateScope();
         var dataContext = scope.ServiceProvider.GetRequiredService<AppDataContext>();
-        (await dataContext.EspnKnownBadUris.CountAsync()).Should().Be(2);
+        (await dataContext.EspnKnownBadUris.AsNoTracking().CountAsync()).Should().Be(2);
 
         // 8 days later a new write prunes it.
         _clock.Setup(x => x.UtcNow()).Returns(FixedNow.AddDays(8));
@@ -172,6 +172,26 @@ public class KnownBadUriCacheTests
         (await cache.IsKnownBadAsync(uri)).Should().BeTrue();
         // ...and expired just after.
         _clock.Setup(x => x.UtcNow()).Returns(FixedNow.AddMinutes(365));
+        (await cache.IsKnownBadAsync(uri)).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ReasonChange_ResetsBackoffEscalation()
+    {
+        // A URI that 400'd repeatedly (count climbing) then starts 404ing
+        // must begin the NotFound backoff at the 5-minute base — the count
+        // means "consecutive failures of this kind".
+        var uri = new Uri("http://sports.core.api.espn.com/v2/flip");
+        var cache = CreateCache();
+        await cache.MarkBadAsync(uri, KnownBadReason.BadRequest);
+        await cache.MarkBadAsync(uri, KnownBadReason.BadRequest);
+        await cache.MarkBadAsync(uri, KnownBadReason.BadRequest);
+
+        await cache.MarkBadAsync(uri, KnownBadReason.NotFound);
+
+        // Inherited count (4) would give a 40-minute window; a reset gives
+        // 5 minutes — expired at +6m proves the reset.
+        _clock.Setup(x => x.UtcNow()).Returns(FixedNow.AddMinutes(6));
         (await cache.IsKnownBadAsync(uri)).Should().BeFalse();
     }
 }


### PR DESCRIPTION
## Summary

Producer's dependency retry loop re-requests missing documents indefinitely (by design — at-least-once + DLQ). When ESPN references a resource it never serves, that loop becomes a permanent ESPN hammer. Observed in prod: NCAA game 401866614's play participants name athlete **5421843**, whose season-2026 athlete page 404s — the play processor re-requested the AthleteSeason doc every ~64 seconds for 24+ hours (**~1,400 ESPN requests/day**, each logging an Error).

## Design

Extends #683's `KnownBadUriCache` with reason-aware suppression via a `KnownBadReason` enum:

- **BadRequest** — unchanged flat 12h TTL (permanent "unsupported resource" verdicts).
- **NotFound** — escalating backoff: **5m doubling per consecutive failure, capped at 6h**. This reconciles the two 404 realities: a resource that exists *next week* (AP poll) or *minutes later* (live-window publish race) costs one short window, while a truly dead URI decays to ~4 probes/day.

Supporting changes:

- `EspnKnownBadUri` gains `Reason` + `FailureCount`; the failure count is **persisted so a fresh KEDA pod continues the escalation** instead of resetting to 5 minutes. Migration backfills existing rows as `BadRequest`/1 — historically accurate, since only 400s were ever marked.
- Prune moves from at-expiry to a **7-day grace** — pruning at expiry would wipe the failure history on every probe cycle and reset every backoff. The just-written key is excluded from the prune.
- Both fetch paths (`DocumentRequestedHandler.ProcessResourceIndex`, `ResourceIndexItemProcessor` live-fetch branch) mark 404s and log **one Warning per probe** instead of an Error per ask.
- A DB outage during `MarkBadAsync` now still suppresses in-memory at base TTL (previously only `DbUpdateException` was handled).

**Deliberately untouched:** Producer's DLQ/dependency-retry semantics. Producer keeps retrying its documents; Provider just answers "still nothing" from memory until the window lapses and a real probe runs. Known follow-up (next work item): Producer's dependency retry never increments its attempt counter ("attempt 1" forever) and has no cap.

## Validation

- Provider suite: 90 passed — new tests cover backoff escalation surviving a pod restart, the 6h cap, and the NotFound handler branch
- Migration applied and verified on all three local Provider databases
- Build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnJySMvfUPeQSMufNNcKSK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of ESPN responses by tracking invalid requests and missing resources separately.
  - Reduced repeated processing attempts for unavailable resources and unnecessary error logging.

- **Reliability**
  - Added progressive suppression delays for repeatedly missing resources, capped at six hours.
  - Preserved failure history across service restarts and improved cleanup of outdated records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->