### PR TITLE
perf(producer,api): league matchups hot path — Contest-first record laterals, gated situations, overlapped Producer call

### DIFF
--- a/src/SportsData.Api/Application/UI/Leagues/Queries/GetLeagueWeekMatchups/GetLeagueWeekMatchupsQueryHandler.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Queries/GetLeagueWeekMatchups/GetLeagueWeekMatchupsQueryHandler.cs
@@ -138,40 +138,6 @@ public class GetLeagueWeekMatchupsQueryHandler : IGetLeagueWeekMatchupsQueryHand
             var contestIds = matchups.Select(x => x.ContestId).Distinct().ToList();
 
             _logger.LogDebug(
-                "Querying contest predictions for {ContestCount} contests, leagueId={LeagueId}, week={Week}",
-                contestIds.Count,
-                query.LeagueId,
-                query.Week);
-
-            var predictions = await _dbContext.ContestPredictions
-                .Where(x => contestIds.Contains(x.ContestId))
-                .AsNoTracking()
-                .ToListAsync(cancellationToken);
-
-            _logger.LogDebug(
-                "Found {PredictionCount} contest predictions, leagueId={LeagueId}, week={Week}",
-                predictions.Count,
-                query.LeagueId,
-                query.Week);
-
-            _logger.LogDebug(
-                "Querying matchup previews for {ContestCount} contests, leagueId={LeagueId}, week={Week}",
-                contestIds.Count,
-                query.LeagueId,
-                query.Week);
-
-            var previews = await _dbContext.MatchupPreviews
-                .Where(x => contestIds.Contains(x.ContestId) && x.RejectedUtc == null)
-                .AsNoTracking()
-                .ToListAsync(cancellationToken);
-
-            _logger.LogDebug(
-                "Found {PreviewCount} matchup previews, leagueId={LeagueId}, week={Week}",
-                previews.Count,
-                query.LeagueId,
-                query.Week);
-
-            _logger.LogDebug(
                 "Calling ContestClient.GetMatchupsByContestIds for {ContestCount} contests, leagueId={LeagueId}, week={Week}",
                 contestIds.Count,
                 query.LeagueId,
@@ -182,9 +148,45 @@ public class GetLeagueWeekMatchupsQueryHandler : IGetLeagueWeekMatchupsQueryHand
             // docs/team-mark-user-preference-design.md.
             var direction = MarkDirection.Roundel;
 
-            var matchupsResult = await _contestClientFactory
+            // The Producer round trip is this handler's long pole — start
+            // it FIRST and run the local predictions/previews queries while
+            // it's in flight. Those two stay sequential relative to each
+            // other (one DbContext can't run concurrent operations), but
+            // they overlap the HTTP call, so total ≈ max(http, local)
+            // instead of the sum.
+            var matchupsTask = _contestClientFactory
                 .Resolve(league.Sport)
                 .GetMatchupsByContestIds(contestIds, direction, cancellationToken);
+
+            var predictions = await _dbContext.ContestPredictions
+                .Where(x => contestIds.Contains(x.ContestId))
+                .AsNoTracking()
+                .ToListAsync(cancellationToken);
+
+            // Projection, not entities: MatchupPreview rows carry the full
+            // AI-generated preview text; this handler reads six scalars.
+            var previews = await _dbContext.MatchupPreviews
+                .Where(x => contestIds.Contains(x.ContestId) && x.RejectedUtc == null)
+                .AsNoTracking()
+                .Select(x => new
+                {
+                    x.ContestId,
+                    x.CreatedUtc,
+                    x.ApprovedUtc,
+                    x.RejectedUtc,
+                    x.PredictedStraightUpWinner,
+                    x.PredictedSpreadWinner,
+                })
+                .ToListAsync(cancellationToken);
+
+            _logger.LogDebug(
+                "Found {PredictionCount} contest predictions and {PreviewCount} matchup previews, leagueId={LeagueId}, week={Week}",
+                predictions.Count,
+                previews.Count,
+                query.LeagueId,
+                query.Week);
+
+            var matchupsResult = await matchupsTask;
             if (!matchupsResult.IsSuccess)
             {
                 _logger.LogError("Failed to retrieve canonical matchups for leagueId={LeagueId}, week={Week}", query.LeagueId, query.Week);

--- a/src/SportsData.Api/Application/UI/Leagues/Queries/GetLeagueWeekMatchups/GetLeagueWeekMatchupsQueryHandler.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Queries/GetLeagueWeekMatchups/GetLeagueWeekMatchupsQueryHandler.cs
@@ -7,7 +7,6 @@ using SportsData.Api.Application.UI.Leagues.Authorization;
 using SportsData.Api.Application.UI.Leagues.Dtos;
 using SportsData.Api.Application.UI.Leagues.Mapping;
 using SportsData.Api.Infrastructure.Data;
-using SportsData.Api.Infrastructure.Data.Entities;
 using SportsData.Core.Infrastructure.Clients.Contest;
 using SportsData.Core.Common;
 
@@ -159,13 +158,24 @@ public class GetLeagueWeekMatchupsQueryHandler : IGetLeagueWeekMatchupsQueryHand
                 .Resolve(league.Sport)
                 .GetMatchupsByContestIds(contestIds, direction, cancellationToken);
 
-            List<ContestPrediction> predictions;
+            List<ContestPredictionDto> predictions;
             List<MatchupPreviewProjection> previews;
             try
             {
+                // Straight into the wire DTO — the handler consumes exactly
+                // these five fields, and projecting here removes the manual
+                // per-matchup mapping loop below.
                 predictions = await _dbContext.ContestPredictions
                     .Where(x => contestIds.Contains(x.ContestId))
                     .AsNoTracking()
+                    .Select(x => new ContestPredictionDto
+                    {
+                        ContestId = x.ContestId,
+                        ModelVersion = x.ModelVersion,
+                        PredictionType = x.PredictionType,
+                        WinProbability = x.WinProbability,
+                        WinnerFranchiseSeasonId = x.WinnerFranchiseSeasonId,
+                    })
                     .ToListAsync(cancellationToken);
 
                 // Projection, not entities: MatchupPreview rows carry the full
@@ -288,19 +298,8 @@ public class GetLeagueWeekMatchupsQueryHandler : IGetLeagueWeekMatchupsQueryHand
                     matchup.IsPreviewReviewed = previews.Any(x => x.ContestId == matchup.ContestId &&
                                                                   x is { ApprovedUtc: not null, RejectedUtc: null });
 
-                    var contestPredictions = predictions.Where(x => x.ContestId == matchup.ContestId);
-
-                    foreach (var prediction in contestPredictions)
-                    {
-                        matchup.Predictions.Add(new ContestPredictionDto()
-                        {
-                            ContestId = prediction.ContestId,
-                            ModelVersion = prediction.ModelVersion,
-                            PredictionType = prediction.PredictionType,
-                            WinProbability = prediction.WinProbability,
-                            WinnerFranchiseSeasonId = prediction.WinnerFranchiseSeasonId
-                        });
-                    }
+                    matchup.Predictions.AddRange(
+                        predictions.Where(x => x.ContestId == matchup.ContestId));
                 }
                 else
                 {

--- a/src/SportsData.Api/Application/UI/Leagues/Queries/GetLeagueWeekMatchups/GetLeagueWeekMatchupsQueryHandler.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Queries/GetLeagueWeekMatchups/GetLeagueWeekMatchupsQueryHandler.cs
@@ -1,4 +1,4 @@
-using FluentValidation.Results;
+﻿using FluentValidation.Results;
 
 using Microsoft.EntityFrameworkCore;
 
@@ -7,6 +7,7 @@ using SportsData.Api.Application.UI.Leagues.Authorization;
 using SportsData.Api.Application.UI.Leagues.Dtos;
 using SportsData.Api.Application.UI.Leagues.Mapping;
 using SportsData.Api.Infrastructure.Data;
+using SportsData.Api.Infrastructure.Data.Entities;
 using SportsData.Core.Infrastructure.Clients.Contest;
 using SportsData.Core.Common;
 
@@ -158,26 +159,40 @@ public class GetLeagueWeekMatchupsQueryHandler : IGetLeagueWeekMatchupsQueryHand
                 .Resolve(league.Sport)
                 .GetMatchupsByContestIds(contestIds, direction, cancellationToken);
 
-            var predictions = await _dbContext.ContestPredictions
-                .Where(x => contestIds.Contains(x.ContestId))
-                .AsNoTracking()
-                .ToListAsync(cancellationToken);
+            List<ContestPrediction> predictions;
+            List<MatchupPreviewProjection> previews;
+            try
+            {
+                predictions = await _dbContext.ContestPredictions
+                    .Where(x => contestIds.Contains(x.ContestId))
+                    .AsNoTracking()
+                    .ToListAsync(cancellationToken);
 
-            // Projection, not entities: MatchupPreview rows carry the full
-            // AI-generated preview text; this handler reads six scalars.
-            var previews = await _dbContext.MatchupPreviews
-                .Where(x => contestIds.Contains(x.ContestId) && x.RejectedUtc == null)
-                .AsNoTracking()
-                .Select(x => new
-                {
-                    x.ContestId,
-                    x.CreatedUtc,
-                    x.ApprovedUtc,
-                    x.RejectedUtc,
-                    x.PredictedStraightUpWinner,
-                    x.PredictedSpreadWinner,
-                })
-                .ToListAsync(cancellationToken);
+                // Projection, not entities: MatchupPreview rows carry the full
+                // AI-generated preview text; this handler reads six scalars.
+                previews = await _dbContext.MatchupPreviews
+                    .Where(x => contestIds.Contains(x.ContestId) && x.RejectedUtc == null)
+                    .AsNoTracking()
+                    .Select(x => new MatchupPreviewProjection(
+                        x.ContestId,
+                        x.CreatedUtc,
+                        x.ApprovedUtc,
+                        x.RejectedUtc,
+                        x.PredictedStraightUpWinner,
+                        x.PredictedSpreadWinner))
+                    .ToListAsync(cancellationToken);
+            }
+            catch
+            {
+                // The Producer call is still in flight; observe its eventual
+                // fault so it can't surface as an unobserved task exception.
+                // (Its own response is simply discarded — the request token
+                // still cancels it if the caller aborted.)
+                _ = matchupsTask.ContinueWith(
+                    static t => _ = t.Exception,
+                    TaskContinuationOptions.OnlyOnFaulted);
+                throw;
+            }
 
             _logger.LogDebug(
                 "Found {PredictionCount} contest predictions and {PreviewCount} matchup previews, leagueId={LeagueId}, week={Week}",
@@ -344,3 +359,16 @@ public class GetLeagueWeekMatchupsQueryHandler : IGetLeagueWeekMatchupsQueryHand
         }
     }
 }
+
+/// <summary>
+/// The six scalars this handler reads from MatchupPreview — a named
+/// projection so the query contract is explicit and the AI preview text
+/// never leaves the database.
+/// </summary>
+internal sealed record MatchupPreviewProjection(
+    Guid ContestId,
+    DateTime CreatedUtc,
+    DateTime? ApprovedUtc,
+    DateTime? RejectedUtc,
+    Guid? PredictedStraightUpWinner,
+    Guid? PredictedSpreadWinner);

--- a/src/SportsData.Producer/Application/Contests/Queries/Matchups/GetMatchupsByContestIds/GetMatchupsByContestIdsQueryHandler.cs
+++ b/src/SportsData.Producer/Application/Contests/Queries/Matchups/GetMatchupsByContestIds/GetMatchupsByContestIdsQueryHandler.cs
@@ -70,7 +70,18 @@ public class GetMatchupsByContestIdsQueryHandler : IGetMatchupsByContestIdsQuery
         var streamTimes = await GetActiveStreamTimesAsync(query.ContestIds, cancellationToken);
         var probables = await GetProbablePitchersAsync(query.ContestIds, cancellationToken);
         var seriesSummaries = await GetCurrentSeriesSummariesAsync(query.ContestIds, cancellationToken);
-        var situations = await GetLiveSituationsAsync(query.ContestIds, cancellationToken);
+
+        // Snap state exists only for games currently being played, but this
+        // used to load EVERY play of EVERY requested contest — for a
+        // completed 32-game NCAA week that's thousands of rows fetched per
+        // request to decorate cards that never render a situation line.
+        // Restrict the stitch to contests that aren't terminal or pre-game;
+        // unknown/null statuses fail OPEN into the stitch so a live game
+        // with a missing status row still gets its snap state.
+        var liveEligibleContestIds = FilterLiveEligibleContestIds(matchups);
+        var situations = liveEligibleContestIds.Length == 0
+            ? new Dictionary<Guid, LiveSituation>()
+            : await GetLiveSituationsAsync(liveEligibleContestIds, cancellationToken);
         foreach (var matchup in matchups)
         {
             matchup.StreamScheduledTimeUtc = streamTimes.GetValueOrDefault(matchup.ContestId);
@@ -103,6 +114,31 @@ public class GetMatchupsByContestIdsQueryHandler : IGetMatchupsByContestIdsQuery
 
         return new Success<List<LeagueMatchupDto>>(matchups);
     }
+
+    /// <summary>
+    /// Statuses that can never carry live snap state: the game hasn't
+    /// started, or is over and will never produce another play. An
+    /// EXCLUSION list on purpose — ESPN's live vocabulary is wider than
+    /// its terminal one (STATUS_IN_PROGRESS, STATUS_HALFTIME,
+    /// STATUS_END_PERIOD, STATUS_DELAYED, ...), and a status we've never
+    /// seen (or a null from a missing CompetitionStatus row) must fail
+    /// open into the stitch rather than blank a live card.
+    /// </summary>
+    private static readonly HashSet<string> NoSnapStateStatuses = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "STATUS_SCHEDULED",
+        "STATUS_FINAL",
+        "STATUS_POSTPONED",
+        "STATUS_CANCELED",
+        "STATUS_FORFEIT",
+    };
+
+    internal static Guid[] FilterLiveEligibleContestIds(IReadOnlyCollection<LeagueMatchupDto> matchups) =>
+        matchups
+            .Where(m => m.Status is null || !NoSnapStateStatuses.Contains(m.Status))
+            .Select(m => m.ContestId)
+            .Distinct()
+            .ToArray();
 
     /// <summary>
     /// Football snap state (down, distance, ball spot) for the live card,

--- a/src/SportsData.Producer/Infrastructure/Sql/GetMatchupsByContestIds.sql
+++ b/src/SportsData.Producer/Infrastructure/Sql/GetMatchupsByContestIds.sql
@@ -197,7 +197,11 @@ LEFT JOIN LATERAL (
     ON conf."CompetitionCompetitorId" = prev_cc."Id" AND conf."Type" = 'vsconf'
   WHERE (prev_ct."AwayTeamFranchiseSeasonId" = fsAway."Id" OR prev_ct."HomeTeamFranchiseSeasonId" = fsAway."Id")
     AND prev_ct."StartDateUtc" < c."StartDateUtc"
-  ORDER BY prev_ct."StartDateUtc" DESC
+  -- prev_comp."Id" tie-break: a Contest can host multiple Competitions
+  -- (stale reschedule artifacts), and date alone would let LIMIT 1 pick
+  -- an arbitrary one. Deterministic, matching the probables stitch's
+  -- lowest-id-wins convention.
+  ORDER BY prev_ct."StartDateUtc" DESC, prev_comp."Id"
   LIMIT 1
 ) enterAway ON TRUE
 INNER JOIN public."FranchiseSeason" fsHome ON fsHome."Id" = c."HomeTeamFranchiseSeasonId"
@@ -264,7 +268,11 @@ LEFT JOIN LATERAL (
     ON conf."CompetitionCompetitorId" = prev_cc."Id" AND conf."Type" = 'vsconf'
   WHERE (prev_ct."AwayTeamFranchiseSeasonId" = fsHome."Id" OR prev_ct."HomeTeamFranchiseSeasonId" = fsHome."Id")
     AND prev_ct."StartDateUtc" < c."StartDateUtc"
-  ORDER BY prev_ct."StartDateUtc" DESC
+  -- prev_comp."Id" tie-break: a Contest can host multiple Competitions
+  -- (stale reschedule artifacts), and date alone would let LIMIT 1 pick
+  -- an arbitrary one. Deterministic, matching the probables stitch's
+  -- lowest-id-wins convention.
+  ORDER BY prev_ct."StartDateUtc" DESC, prev_comp."Id"
   LIMIT 1
 ) enterHome ON TRUE
 WHERE c."Id" = ANY(@ContestIds)

--- a/src/SportsData.Producer/Infrastructure/Sql/GetMatchupsByContestIds.sql
+++ b/src/SportsData.Producer/Infrastructure/Sql/GetMatchupsByContestIds.sql
@@ -166,15 +166,27 @@ LEFT JOIN LATERAL (
 -- FranchiseSeason W/L. Parsed from ESPN's CompetitionCompetitorRecord Summary
 -- ("6-2"). Null (→ 0 via COALESCE) at the season opener or an un-sourced gap.
 -- See docs/features/point-in-time-team-records.md.
+--
+-- Driven from Contest (its Away/HomeTeamFranchiseSeasonId columns), NOT from
+-- CompetitionCompetitor: the previous competitor-first form did a
+-- Competition→Contest PK hop for EVERY historical game of the team just to
+-- learn its date, ~740 random PK lookups per 32-game request — 3.2s of a 5s
+-- execution under cold buffers (measured 2026-08-29). Contest-first walks the
+-- team's prior contests newest-first and joins the record chain only until
+-- LIMIT 1 is satisfied — records are near-universally present, so that's one
+-- contest in practice. Same semantics: the newest prior contest THAT YIELDS a
+-- 'total' record wins.
 LEFT JOIN LATERAL (
   SELECT
     split_part(tot."Summary", '-', 1)::int  AS "Wins",
     split_part(tot."Summary", '-', 2)::int  AS "Losses",
     split_part(conf."Summary", '-', 1)::int AS "ConferenceWins",
     split_part(conf."Summary", '-', 2)::int AS "ConferenceLosses"
-  FROM public."CompetitionCompetitor" prev_cc
-  INNER JOIN public."Competition" prev_comp ON prev_comp."Id" = prev_cc."CompetitionId"
-  INNER JOIN public."Contest" prev_ct ON prev_ct."Id" = prev_comp."ContestId"
+  FROM public."Contest" prev_ct
+  INNER JOIN public."Competition" prev_comp ON prev_comp."ContestId" = prev_ct."Id"
+  INNER JOIN public."CompetitionCompetitor" prev_cc
+    ON prev_cc."CompetitionId" = prev_comp."Id"
+   AND prev_cc."FranchiseSeasonId" = fsAway."Id"
   INNER JOIN public."CompetitionCompetitorRecord" tot
     ON tot."CompetitionCompetitorId" = prev_cc."Id" AND tot."Type" = 'total'
   -- LEFT (not INNER) on purpose: an FBS independent (Notre Dame, UConn, …) has
@@ -183,7 +195,7 @@ LEFT JOIN LATERAL (
   -- the authoritative driver; a missing 'vsconf' correctly yields 0-0 conference.
   LEFT JOIN public."CompetitionCompetitorRecord" conf
     ON conf."CompetitionCompetitorId" = prev_cc."Id" AND conf."Type" = 'vsconf'
-  WHERE prev_cc."FranchiseSeasonId" = fsAway."Id"
+  WHERE (prev_ct."AwayTeamFranchiseSeasonId" = fsAway."Id" OR prev_ct."HomeTeamFranchiseSeasonId" = fsAway."Id")
     AND prev_ct."StartDateUtc" < c."StartDateUtc"
   ORDER BY prev_ct."StartDateUtc" DESC
   LIMIT 1
@@ -233,21 +245,24 @@ LEFT JOIN LATERAL (
   -- this team's entry in it, or NULL = honestly unranked.
   SELECT public.poll_rank_asof(fsHome."Id", fsHome."SeasonYear", c."StartDateUtc") AS "Current"
 ) fsrdHome ON TRUE
--- Entering record for the home team — same lag as enterAway above.
+-- Entering record for the home team — same lag and same Contest-first
+-- shape as enterAway above.
 LEFT JOIN LATERAL (
   SELECT
     split_part(tot."Summary", '-', 1)::int  AS "Wins",
     split_part(tot."Summary", '-', 2)::int  AS "Losses",
     split_part(conf."Summary", '-', 1)::int AS "ConferenceWins",
     split_part(conf."Summary", '-', 2)::int AS "ConferenceLosses"
-  FROM public."CompetitionCompetitor" prev_cc
-  INNER JOIN public."Competition" prev_comp ON prev_comp."Id" = prev_cc."CompetitionId"
-  INNER JOIN public."Contest" prev_ct ON prev_ct."Id" = prev_comp."ContestId"
+  FROM public."Contest" prev_ct
+  INNER JOIN public."Competition" prev_comp ON prev_comp."ContestId" = prev_ct."Id"
+  INNER JOIN public."CompetitionCompetitor" prev_cc
+    ON prev_cc."CompetitionId" = prev_comp."Id"
+   AND prev_cc."FranchiseSeasonId" = fsHome."Id"
   INNER JOIN public."CompetitionCompetitorRecord" tot
     ON tot."CompetitionCompetitorId" = prev_cc."Id" AND tot."Type" = 'total'
   LEFT JOIN public."CompetitionCompetitorRecord" conf
     ON conf."CompetitionCompetitorId" = prev_cc."Id" AND conf."Type" = 'vsconf'
-  WHERE prev_cc."FranchiseSeasonId" = fsHome."Id"
+  WHERE (prev_ct."AwayTeamFranchiseSeasonId" = fsHome."Id" OR prev_ct."HomeTeamFranchiseSeasonId" = fsHome."Id")
     AND prev_ct."StartDateUtc" < c."StartDateUtc"
   ORDER BY prev_ct."StartDateUtc" DESC
   LIMIT 1

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Contests/Queries/GetMatchupsByContestIds/GetMatchupsByContestIdsQueryHandlerTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Contests/Queries/GetMatchupsByContestIds/GetMatchupsByContestIdsQueryHandlerTests.cs
@@ -1,9 +1,11 @@
-#nullable enable
+﻿#nullable enable
 
 using FluentAssertions;
 
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
+
+using SportsData.Core.Dtos.Canonical;
 
 using SportsData.Producer.Application.Contests.Queries.Matchups.GetMatchupsByContestIds;
 using SportsData.Producer.Infrastructure.Data.Baseball;
@@ -773,5 +775,66 @@ public class GetMatchupsByContestIdsQueryHandlerTests
         });
 
         return (competitorId, athleteSeasonId);
+    }
+
+    // ─── FilterLiveEligibleContestIds — the situations-stitch gate ───────────
+
+    private static LeagueMatchupDto Matchup(Guid contestId, string? status) =>
+        new() { ContestId = contestId, Status = status };
+
+    [Fact]
+    public void FilterLiveEligible_ExcludesTerminalAndPreGameStatuses()
+    {
+        var matchups = new[]
+        {
+            Matchup(Guid.NewGuid(), "STATUS_FINAL"),
+            Matchup(Guid.NewGuid(), "STATUS_SCHEDULED"),
+            Matchup(Guid.NewGuid(), "STATUS_POSTPONED"),
+            Matchup(Guid.NewGuid(), "STATUS_CANCELED"),
+            Matchup(Guid.NewGuid(), "STATUS_FORFEIT"),
+        };
+
+        GetMatchupsByContestIdsQueryHandler.FilterLiveEligibleContestIds(matchups)
+            .Should().BeEmpty();
+    }
+
+    [Fact]
+    public void FilterLiveEligible_FailsOpenForLiveUnknownAndNullStatuses()
+    {
+        // Live vocabulary is wider than the terminal one; unknown or
+        // missing statuses must fail OPEN so a live game with a missing
+        // CompetitionStatus row still gets its snap state.
+        var live = Guid.NewGuid();
+        var halftime = Guid.NewGuid();
+        var unknown = Guid.NewGuid();
+        var missing = Guid.NewGuid();
+        var matchups = new[]
+        {
+            Matchup(live, "STATUS_IN_PROGRESS"),
+            Matchup(halftime, "STATUS_HALFTIME"),
+            Matchup(unknown, "STATUS_SOMETHING_NEW"),
+            Matchup(missing, null),
+            Matchup(Guid.NewGuid(), "STATUS_FINAL"),
+        };
+
+        GetMatchupsByContestIdsQueryHandler.FilterLiveEligibleContestIds(matchups)
+            .Should().BeEquivalentTo(new[] { live, halftime, unknown, missing });
+    }
+
+    [Fact]
+    public void FilterLiveEligible_DeduplicatesContestIds()
+    {
+        // A Contest can host multiple Competitions (doubleheaders /
+        // reschedule artifacts) — the outer SQL can emit the same
+        // ContestId twice.
+        var contestId = Guid.NewGuid();
+        var matchups = new[]
+        {
+            Matchup(contestId, "STATUS_IN_PROGRESS"),
+            Matchup(contestId, "STATUS_IN_PROGRESS"),
+        };
+
+        GetMatchupsByContestIdsQueryHandler.FilterLiveEligibleContestIds(matchups)
+            .Should().ContainSingle().Which.Should().Be(contestId);
     }
 }


### PR DESCRIPTION
## Summary

The UI matchups route (`/ui/leagues/{id}/matchups/{week}`) was taking 5–30s under load (operator-measured 8.54s on a 32-game NCAA week). Post-index profiling on prod isolated three independent costs; all three are addressed.

### 1. Entering-record laterals rewritten Contest-first (`GetMatchupsByContestIds.sql`)

The old laterals drove from `CompetitionCompetitor` and did a `Competition`→`Contest` PK hop for **every historical game of every team** just to learn its date — ~740 random PK lookups per 32-game request, **3.2s of a 5.0s cold execution** (EXPLAIN ANALYZE, prod, 2026-08-29). The new shape walks the team's prior contests newest-first via `Away/HomeTeamFranchiseSeasonId` and joins the record chain only until `LIMIT 1` is satisfied.

**Evidence:** output byte-identical against the same 32 prod contests; warm execution 217–286ms (new) vs 354–408ms (old) across alternating runs; cold behavior improves structurally (~4× fewer random page reads).

### 2. Situations stitch gated by status (`GetMatchupsByContestIdsQueryHandler`)

`GetLiveSituationsAsync` loaded **every play of every requested contest** to compute snap state that only renders on live cards — thousands of rows per request for completed weeks. Now gated: `SCHEDULED`/`FINAL`/`POSTPONED`/`CANCELED`/`FORFEIT` skip it; null/unknown statuses **fail open** (ESPN's live vocabulary — `STATUS_IN_PROGRESS`, `STATUS_HALFTIME`, `STATUS_END_PERIOD`, … — is wider than its terminal one, and a live game with a lagging status row must still get its situation line). The query is skipped entirely when nothing is live-eligible.

### 3. API handler overlap (`GetLeagueWeekMatchupsQueryHandler`)

Predictions, previews, and the Producer HTTP call ran sequentially. The HTTP call (the long pole) now starts first and the two local EF queries run while it's in flight — one `DbContext` can't run concurrent operations, so they stay sequential relative to each other but overlap the round trip: total ≈ max instead of sum. The previews query also projects six scalars instead of full entities dragging AI preview text.

## Validation

- Output equivalence proven on prod data (byte-identical result hash, old vs new SQL, same 32 contests)
- Local E2E: near-instantaneous loads (operator-verified)
- Producer: 628 passed (3 new tests on the live-eligibility filter — terminal exclusion, fail-open for live/unknown/null, doubleheader dedup)
- API: 756 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnJySMvfUPeQSMufNNcKSK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Matchup, prediction, and preview data now load more efficiently, reducing wait times.
  * Preview data retrieval is streamlined while preserving existing results.
  * Live-situation requests are skipped when no eligible contests are available.

* **Bug Fixes**
  * Live matchup updates now exclude scheduled, completed, postponed, canceled, and forfeited contests.
  * Team records are matched more accurately to the correct contest and season.
  * Unknown or missing contest statuses continue to be handled safely.
  * Duplicate contest entries are removed from live matchup processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->