### PR TITLE
feat(producer,api,core): live-source only games that back a pick'em league

### DIFF
--- a/src/SportsData.Api/Application/Internal/LeagueContestsController.cs
+++ b/src/SportsData.Api/Application/Internal/LeagueContestsController.cs
@@ -28,20 +28,10 @@ public class LeagueContestsController : ApiControllerBase
         [FromServices] IGetContestIdsInLeaguesQueryHandler handler,
         CancellationToken cancellationToken)
     {
-        if (request?.ContestIds is null)
-        {
-            return BadRequest("contestIds is required.");
-        }
-
-        // Bound the probe so a malformed caller can't turn this into a
-        // giant ANY() scan. Producer batches per season week (< 1k).
-        if (request.ContestIds.Length > 5000)
-        {
-            return BadRequest("Too many contest ids; batch the request.");
-        }
-
+        // Null and oversized inputs are the validator's job — the handler
+        // returns BadRequest through the Result pipeline.
         var result = await handler.ExecuteAsync(
-            new GetContestIdsInLeaguesQuery(request.ContestIds), cancellationToken);
+            new GetContestIdsInLeaguesQuery(request?.ContestIds!), cancellationToken);
         return result.ToActionResult();
     }
 }

--- a/src/SportsData.Api/Application/Internal/LeagueContestsController.cs
+++ b/src/SportsData.Api/Application/Internal/LeagueContestsController.cs
@@ -1,0 +1,47 @@
+﻿using Microsoft.AspNetCore.Mvc;
+
+using SportsData.Api.Application.Internal.Queries.GetContestIdsInLeagues;
+using SportsData.Core.Common;
+using SportsData.Core.Extensions;
+using SportsData.Core.Infrastructure.Clients.Api;
+
+namespace SportsData.Api.Application.Internal;
+
+/// <summary>
+/// Service-to-service inquiries about league usage. Consumed by Producer's
+/// CompetitionStreamScheduler so live-sourcing covers ONLY games that back
+/// a pick'em league (team or player — both generate PickemGroupMatchup
+/// rows) instead of every game ESPN publishes.
+///
+/// Anonymous by design: the answer ("this contest appears in some league")
+/// carries no user data and no league identity, and Producer reaches this
+/// over in-cluster DNS. Revisit with a service credential if the surface
+/// ever grows beyond membership-free facts.
+/// </summary>
+[ApiController]
+[Route("system/league-contests")]
+public class LeagueContestsController : ApiControllerBase
+{
+    [HttpPost("in-use")]
+    public async Task<ActionResult<List<Guid>>> GetContestIdsInLeagues(
+        [FromBody] GetContestIdsInLeaguesRequest request,
+        [FromServices] IGetContestIdsInLeaguesQueryHandler handler,
+        CancellationToken cancellationToken)
+    {
+        if (request?.ContestIds is null)
+        {
+            return BadRequest("contestIds is required.");
+        }
+
+        // Bound the probe so a malformed caller can't turn this into a
+        // giant ANY() scan. Producer batches per season week (< 1k).
+        if (request.ContestIds.Length > 5000)
+        {
+            return BadRequest("Too many contest ids; batch the request.");
+        }
+
+        var result = await handler.ExecuteAsync(
+            new GetContestIdsInLeaguesQuery(request.ContestIds), cancellationToken);
+        return result.ToActionResult();
+    }
+}

--- a/src/SportsData.Api/Application/Internal/Queries/GetContestIdsInLeagues/GetContestIdsInLeaguesQueryHandler.cs
+++ b/src/SportsData.Api/Application/Internal/Queries/GetContestIdsInLeagues/GetContestIdsInLeaguesQueryHandler.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.EntityFrameworkCore;
+﻿using FluentValidation;
+
+using Microsoft.EntityFrameworkCore;
 
 using SportsData.Api.Infrastructure.Data;
 using SportsData.Core.Common;
@@ -6,6 +8,22 @@ using SportsData.Core.Common;
 namespace SportsData.Api.Application.Internal.Queries.GetContestIdsInLeagues;
 
 public record GetContestIdsInLeaguesQuery(Guid[] ContestIds);
+
+public class GetContestIdsInLeaguesQueryValidator : AbstractValidator<GetContestIdsInLeaguesQuery>
+{
+    public GetContestIdsInLeaguesQueryValidator()
+    {
+        // Empty is VALID (answered [] without a query); null and oversized
+        // are not — the 5,000 bound keeps a malformed caller from turning
+        // the probe into a giant ANY() scan. Producer batches per season
+        // week (< 1k).
+        RuleFor(x => x.ContestIds).NotNull();
+        RuleFor(x => x.ContestIds)
+            .Must(ids => ids.Length <= 5000)
+            .When(x => x.ContestIds is not null)
+            .WithMessage("Too many contest ids; batch the request.");
+    }
+}
 
 public interface IGetContestIdsInLeaguesQueryHandler
 {
@@ -23,16 +41,26 @@ public interface IGetContestIdsInLeaguesQueryHandler
 public class GetContestIdsInLeaguesQueryHandler : IGetContestIdsInLeaguesQueryHandler
 {
     private readonly AppDataContext _dataContext;
+    private readonly IValidator<GetContestIdsInLeaguesQuery> _validator;
 
-    public GetContestIdsInLeaguesQueryHandler(AppDataContext dataContext)
+    public GetContestIdsInLeaguesQueryHandler(
+        AppDataContext dataContext,
+        IValidator<GetContestIdsInLeaguesQuery> validator)
     {
         _dataContext = dataContext;
+        _validator = validator;
     }
 
     public async Task<Result<List<Guid>>> ExecuteAsync(
         GetContestIdsInLeaguesQuery query,
         CancellationToken cancellationToken = default)
     {
+        var validation = await _validator.ValidateAsync(query, cancellationToken);
+        if (!validation.IsValid)
+        {
+            return new Failure<List<Guid>>(default!, ResultStatus.BadRequest, validation.Errors);
+        }
+
         if (query.ContestIds.Length == 0)
         {
             return new Success<List<Guid>>([]);

--- a/src/SportsData.Api/Application/Internal/Queries/GetContestIdsInLeagues/GetContestIdsInLeaguesQueryHandler.cs
+++ b/src/SportsData.Api/Application/Internal/Queries/GetContestIdsInLeagues/GetContestIdsInLeaguesQueryHandler.cs
@@ -1,0 +1,50 @@
+﻿using Microsoft.EntityFrameworkCore;
+
+using SportsData.Api.Infrastructure.Data;
+using SportsData.Core.Common;
+
+namespace SportsData.Api.Application.Internal.Queries.GetContestIdsInLeagues;
+
+public record GetContestIdsInLeaguesQuery(Guid[] ContestIds);
+
+public interface IGetContestIdsInLeaguesQueryHandler
+{
+    Task<Result<List<Guid>>> ExecuteAsync(
+        GetContestIdsInLeaguesQuery query,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Which of the supplied contests appear in any league's matchups (team
+/// or player pick'em — both generate PickemGroupMatchup rows), any season
+/// week. Powers Producer's stream-scheduling filter so live-sourcing
+/// covers only games that back a league.
+/// </summary>
+public class GetContestIdsInLeaguesQueryHandler : IGetContestIdsInLeaguesQueryHandler
+{
+    private readonly AppDataContext _dataContext;
+
+    public GetContestIdsInLeaguesQueryHandler(AppDataContext dataContext)
+    {
+        _dataContext = dataContext;
+    }
+
+    public async Task<Result<List<Guid>>> ExecuteAsync(
+        GetContestIdsInLeaguesQuery query,
+        CancellationToken cancellationToken = default)
+    {
+        if (query.ContestIds.Length == 0)
+        {
+            return new Success<List<Guid>>([]);
+        }
+
+        var inUse = await _dataContext.PickemGroupMatchups
+            .AsNoTracking()
+            .Where(m => query.ContestIds.Contains(m.ContestId))
+            .Select(m => m.ContestId)
+            .Distinct()
+            .ToListAsync(cancellationToken);
+
+        return new Success<List<Guid>>(inUse);
+    }
+}

--- a/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
@@ -343,6 +343,8 @@ namespace SportsData.Api.DependencyInjection
                 Application.UI.PlayerLineups.Queries.GetPlayerStandings.GetPlayerStandingsQueryValidator>();
             services.AddScoped<Application.Internal.Queries.GetContestIdsInLeagues.IGetContestIdsInLeaguesQueryHandler,
                 Application.Internal.Queries.GetContestIdsInLeagues.GetContestIdsInLeaguesQueryHandler>();
+            services.AddScoped<FluentValidation.IValidator<Application.Internal.Queries.GetContestIdsInLeagues.GetContestIdsInLeaguesQuery>,
+                Application.Internal.Queries.GetContestIdsInLeagues.GetContestIdsInLeaguesQueryValidator>();
             services.AddScoped<FluentValidation.IValidator<UpsertLineupSlotCommand>, UpsertLineupSlotCommandValidator>();
             services.AddScoped<FluentValidation.IValidator<ClearLineupSlotCommand>, ClearLineupSlotCommandValidator>();
 

--- a/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
@@ -1,4 +1,4 @@
-using Hangfire;
+﻿using Hangfire;
 
 using FluentValidation;
 
@@ -341,6 +341,8 @@ namespace SportsData.Api.DependencyInjection
                 Application.UI.PlayerLineups.Queries.GetPlayerStandings.GetPlayerStandingsQueryHandler>();
             services.AddScoped<FluentValidation.IValidator<Application.UI.PlayerLineups.Queries.GetPlayerStandings.GetPlayerStandingsQuery>,
                 Application.UI.PlayerLineups.Queries.GetPlayerStandings.GetPlayerStandingsQueryValidator>();
+            services.AddScoped<Application.Internal.Queries.GetContestIdsInLeagues.IGetContestIdsInLeaguesQueryHandler,
+                Application.Internal.Queries.GetContestIdsInLeagues.GetContestIdsInLeaguesQueryHandler>();
             services.AddScoped<FluentValidation.IValidator<UpsertLineupSlotCommand>, UpsertLineupSlotCommandValidator>();
             services.AddScoped<FluentValidation.IValidator<ClearLineupSlotCommand>, ClearLineupSlotCommandValidator>();
 

--- a/src/SportsData.Core/Config/CommonConfigKeys.cs
+++ b/src/SportsData.Core/Config/CommonConfigKeys.cs
@@ -62,6 +62,11 @@ namespace SportsData.Core.Config
         public static string CacheServiceUri =>
             $"{nameof(CommonConfig)}:{nameof(CommonConfig.RedisUri)}";
 
+        // Single-URL (not sport-keyed): the API service is one deployment,
+        // unlike the per-sport Producer-side services.
+        public static string GetApiUri() =>
+            $"{nameof(CommonConfig)}:ApiClientConfig:ApiUrl";
+
         public static string GetContestProviderUri(Sport mode) =>
             $"{nameof(CommonConfig)}:{nameof(ContestClientConfig)}:{mode}:{nameof(ContestClientConfig.ApiUrl)}";
 

--- a/src/SportsData.Core/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Core/DependencyInjection/ServiceRegistration.cs
@@ -7,6 +7,7 @@ using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 
@@ -605,6 +606,20 @@ namespace SportsData.Core.DependencyInjection
             services.AddHttpClient(HttpClients.AthleteClient);
             services.AddSingleton<IContestClientFactory, ContestClientFactory>();
             services.AddSingleton<ISeasonClientFactory, SeasonClientFactory>();
+
+            // API client (Producer→API inquiries). Registered as a typed
+            // client only where CommonConfig:ApiClientConfig:ApiUrl is
+            // present (currently the Producer labels); everywhere else the
+            // TryAdd fallback resolves to UnconfiguredApiClient, whose
+            // Failure results push callers onto their fail-open path.
+            var apiUrl = configuration[CommonConfigKeys.GetApiUri()];
+            if (!string.IsNullOrEmpty(apiUrl))
+            {
+                services.AddHttpClient<Infrastructure.Clients.Api.IProvideApi, Infrastructure.Clients.Api.ApiClient>(
+                    HttpClients.ApiClient,
+                    client => client.BaseAddress = new Uri(apiUrl));
+            }
+            services.TryAddSingleton<Infrastructure.Clients.Api.IProvideApi, Infrastructure.Clients.Api.UnconfiguredApiClient>();
 
             // Register mode-agnostic clients (same URL for all sports)
             var contestApiUrl = configuration[CommonConfigKeys.GetContestProviderUri()];

--- a/src/SportsData.Core/Infrastructure/Clients/Api/ApiClient.cs
+++ b/src/SportsData.Core/Infrastructure/Clients/Api/ApiClient.cs
@@ -1,0 +1,88 @@
+using FluentValidation.Results;
+
+using Microsoft.Extensions.Logging;
+
+using SportsData.Core.Common;
+
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SportsData.Core.Infrastructure.Clients.Api;
+
+/// <summary>
+/// Wire shape for POST system/league-contests/in-use on the API service.
+/// </summary>
+public record GetContestIdsInLeaguesRequest(Guid[] ContestIds);
+
+/// <summary>
+/// Producer → API inquiries. Today that is one question: which of these
+/// contests appear in any pick'em league's matchups? The
+/// CompetitionStreamScheduler uses the answer to live-source ONLY games
+/// that back a league instead of every game ESPN publishes (2026-08-29:
+/// 688 of 729 scheduled NCAA streams served no league). Callers must
+/// FAIL OPEN on Failure — blinding league games on game day is worse
+/// than briefly over-sourcing.
+/// </summary>
+public interface IProvideApi : Middleware.Health.IProvideHealthChecks
+{
+    Task<Result<List<Guid>>> GetContestIdsInLeagues(List<Guid> contestIds, CancellationToken ct = default);
+}
+
+public class ApiClient : ClientBase, IProvideApi
+{
+    private readonly ILogger<ApiClient> _logger;
+
+    public ApiClient(ILogger<ApiClient> logger, HttpClient httpClient)
+        : base(httpClient)
+    {
+        _logger = logger;
+    }
+
+    public async Task<Result<List<Guid>>> GetContestIdsInLeagues(List<Guid> contestIds, CancellationToken ct = default)
+    {
+        if (contestIds is null || contestIds.Count == 0)
+            return new Success<List<Guid>>([]);
+
+        try
+        {
+            var result = await PostOrDefaultAsync<List<Guid>, GetContestIdsInLeaguesRequest>(
+                "system/league-contests/in-use",
+                new GetContestIdsInLeaguesRequest(contestIds.ToArray()),
+                [],
+                ct);
+            return new Success<List<Guid>>(result);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "GetContestIdsInLeagues failed; caller should fail open.");
+            return new Failure<List<Guid>>(
+                default!,
+                ResultStatus.Error,
+                [new ValidationFailure("contestIds", ex.Message)]);
+        }
+    }
+}
+
+/// <summary>
+/// Fallback registration for services whose configuration carries no
+/// <c>CommonConfig:ApiClientConfig:ApiUrl</c> — every call returns
+/// Failure so callers take their fail-open path. Keeps IProvideApi
+/// resolvable everywhere without forcing an AppConfig backfill on
+/// services that never call the API.
+/// </summary>
+public class UnconfiguredApiClient : IProvideApi
+{
+    public Task<Result<List<Guid>>> GetContestIdsInLeagues(List<Guid> contestIds, CancellationToken ct = default) =>
+        Task.FromResult<Result<List<Guid>>>(new Failure<List<Guid>>(
+            default!,
+            ResultStatus.Error,
+            [new ValidationFailure("ApiClientConfig", "ApiClientConfig:ApiUrl is not configured for this service.")]));
+
+    public string GetProviderName() => nameof(UnconfiguredApiClient);
+
+    public Task<Dictionary<string, object>> GetHealthStatus() =>
+        Task.FromResult(new Dictionary<string, object> { ["configured"] = false });
+}

--- a/src/SportsData.Core/Infrastructure/Clients/Api/ApiClient.cs
+++ b/src/SportsData.Core/Infrastructure/Clients/Api/ApiClient.cs
@@ -48,11 +48,25 @@ public class ApiClient : ClientBase, IProvideApi
 
         try
         {
+            // Null payload must surface as Failure, never as Success([]) —
+            // an empty SUCCESS means "none of these back a league" and
+            // would make the scheduler cull every league stream, the exact
+            // outcome the fail-open contract exists to prevent.
             var result = await PostOrDefaultAsync<List<Guid>, GetContestIdsInLeaguesRequest>(
                 "system/league-contests/in-use",
                 new GetContestIdsInLeaguesRequest(contestIds.ToArray()),
-                [],
+                null!,
                 ct);
+
+            if (result is null)
+            {
+                _logger.LogWarning("GetContestIdsInLeagues returned a null payload; caller should fail open.");
+                return new Failure<List<Guid>>(
+                    default!,
+                    ResultStatus.Error,
+                    [new ValidationFailure("response", "Null payload from system/league-contests/in-use.")]);
+            }
+
             return new Success<List<Guid>>(result);
         }
         catch (Exception ex)

--- a/src/SportsData.Core/Infrastructure/Clients/HttpClients.cs
+++ b/src/SportsData.Core/Infrastructure/Clients/HttpClients.cs
@@ -2,6 +2,7 @@
 {
     public static class HttpClients
     {
+        public const string ApiClient = "ApiClient";
         public const string AthleteClient = "AthleteClient";
         public const string ContestClient = "ContestClient";
         public const string FranchiseClient = "FranchiseClient";

--- a/src/SportsData.Producer/Application/Competitions/CompetitionStreamScheduler.cs
+++ b/src/SportsData.Producer/Application/Competitions/CompetitionStreamScheduler.cs
@@ -1,7 +1,8 @@
-using Microsoft.EntityFrameworkCore;
+﻿using Microsoft.EntityFrameworkCore;
 
 using SportsData.Core.Common;
 using SportsData.Core.DependencyInjection;
+using SportsData.Core.Infrastructure.Clients.Api;
 using SportsData.Core.Processing;
 using SportsData.Producer.Enums;
 using SportsData.Producer.Infrastructure.Data;
@@ -47,19 +48,22 @@ public class CompetitionStreamScheduler
     private readonly IProvideBackgroundJobs _backgroundJobProvider;
     private readonly IAppMode _appMode;
     private readonly IDateTimeProvider _dateTimeProvider;
+    private readonly IProvideApi _apiClient;
 
     public CompetitionStreamScheduler(
         ILogger<CompetitionStreamScheduler> logger,
         TeamSportDataContext dataContext,
         IProvideBackgroundJobs backgroundJobProvider,
         IAppMode appMode,
-        IDateTimeProvider dateTimeProvider)
+        IDateTimeProvider dateTimeProvider,
+        IProvideApi apiClient)
     {
         _logger = logger;
         _dataContext = dataContext;
         _backgroundJobProvider = backgroundJobProvider;
         _appMode = appMode;
         _dateTimeProvider = dateTimeProvider;
+        _apiClient = apiClient;
     }
 
     /// <summary>
@@ -71,8 +75,8 @@ public class CompetitionStreamScheduler
     /// Event-driven single-contest reschedule path. Invoked from
     /// <see cref="Consumers.ContestStartTimeUpdatedConsumerHandler"/> after
     /// MassTransit delivers <c>ContestStartTimeUpdated</c>. Companion to the
-    /// recurring <see cref="ExecuteAsync"/> sweep — that one runs daily for
-    /// MLB and weekly for football, which is too sparse to catch mid-day ESPN
+    /// recurring <see cref="ExecuteAsync"/> sweep — that one runs hourly,
+    /// which is too sparse to catch mid-day ESPN
     /// game-time changes (the failure mode this method exists to fix).
     ///
     /// Reuses <see cref="TryRescheduleAsync"/> for the actual reschedule logic
@@ -163,8 +167,21 @@ public class CompetitionStreamScheduler
 
         var existingByCompetitionId = existingStreams.ToDictionary(s => s.CompetitionId);
 
+        // Live-source ONLY games that back a pick'em league. A SeasonWeek
+        // holds every sourced game (all NCAA classifications — 700+ on a
+        // fall Saturday); streaming them all live-polls ESPN play-by-play
+        // nobody consumes (2026-08-29: 688 of 729 scheduled NCAA streams
+        // served no league). FAIL OPEN: when the API can't answer, null
+        // disables filtering entirely — briefly over-sourcing beats
+        // blinding league games on game day. Player pick'em is covered
+        // too: those leagues generate PickemGroupMatchup rows as well.
+        var leagueContestIds = await GetLeagueContestIdsAsync(
+            competitions.Select(c => c.ContestId).Distinct().ToList(), cancellationToken);
+
         var scheduledCount = 0;
         var rescheduledCount = 0;
+        var culledCount = 0;
+        var skippedCount = 0;
 
         foreach (var competition in competitions)
         {
@@ -179,15 +196,36 @@ public class CompetitionStreamScheduler
                 continue;
             }
 
+            var inLeague = leagueContestIds is null || leagueContestIds.Contains(competition.ContestId);
+
             var desiredScheduledTimeUtc = ComputeScheduledTimeUtc(competition.Date, now);
 
             if (existingByCompetitionId.TryGetValue(competition.Id, out var existingStream))
             {
+                // A previously-scheduled stream whose contest backs no
+                // league (league deleted, or scheduled before this filter
+                // existed): cancel it. Only Scheduled streams — anything
+                // further along is already running or terminal.
+                if (!inLeague && existingStream.Status == CompetitionStreamStatus.Scheduled)
+                {
+                    _dataContext.CompetitionStreams.Remove(existingStream);
+                    await _dataContext.SaveChangesAsync(cancellationToken);
+                    TryDeleteOrphanJob(existingStream.BackgroundJobId, competition.Id);
+                    culledCount++;
+                    continue;
+                }
+
                 if (await TryRescheduleAsync(existingStream, competition, contest, desiredScheduledTimeUtc, now, cancellationToken))
                 {
                     rescheduledCount++;
                 }
 
+                continue;
+            }
+
+            if (!inLeague)
+            {
+                skippedCount++;
                 continue;
             }
 
@@ -230,8 +268,45 @@ public class CompetitionStreamScheduler
         }
 
         _logger.LogInformation(
-            "Stream scheduling complete for SeasonWeek {SeasonWeekNumber}. New: {ScheduledCount}, Rescheduled: {RescheduledCount}.",
-            seasonWeek.Number, scheduledCount, rescheduledCount);
+            "Stream scheduling complete for SeasonWeek {SeasonWeekNumber}. New: {ScheduledCount}, Rescheduled: {RescheduledCount}, SkippedNonLeague: {SkippedCount}, CulledNonLeague: {CulledCount}, FilterActive: {FilterActive}.",
+            seasonWeek.Number, scheduledCount, rescheduledCount, skippedCount, culledCount, leagueContestIds is not null);
+    }
+
+    /// <summary>
+    /// Asks the API which of the candidate contests appear in any pick'em
+    /// league's matchups. Null = the filter is unavailable (API down, not
+    /// configured, or a defective response) and the caller must schedule
+    /// everything — the pre-filter behavior.
+    /// </summary>
+    private async Task<HashSet<Guid>?> GetLeagueContestIdsAsync(
+        List<Guid> candidateContestIds,
+        CancellationToken cancellationToken)
+    {
+        if (candidateContestIds.Count == 0)
+        {
+            return [];
+        }
+
+        try
+        {
+            var result = await _apiClient.GetContestIdsInLeagues(candidateContestIds, cancellationToken);
+            if (result?.IsSuccess == true && result.Value is not null)
+            {
+                return result.Value.ToHashSet();
+            }
+
+            _logger.LogWarning(
+                "League-contest inquiry did not succeed; scheduling ALL {Count} candidate contests (fail open).",
+                candidateContestIds.Count);
+            return null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "League-contest inquiry threw; scheduling ALL {Count} candidate contests (fail open).",
+                candidateContestIds.Count);
+            return null;
+        }
     }
 
     private void TryDeleteOrphanJob(string jobId, Guid competitionId)

--- a/src/SportsData.Producer/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Producer/DependencyInjection/ServiceRegistration.cs
@@ -1,4 +1,4 @@
-using FluentValidation;
+﻿using FluentValidation;
 
 using Hangfire;
 
@@ -467,21 +467,27 @@ namespace SportsData.Producer.DependencyInjection
                     job => job.ExecuteAsync(),
                     "0 7 * * 0"); // Sunday at 07:00 UTC
 
+                // Hourly (was weekly): with the league-contest filter the
+                // sweep is cheap and idempotent, and hourly runs mean a
+                // league created mid-week gets its games' streams within
+                // the hour instead of waiting for Sunday. The
+                // matchups-generated event path (immediate scheduling) is
+                // the planned follow-up.
                 recurringJobManager.AddOrUpdate<CompetitionStreamScheduler>(
                     nameof(CompetitionStreamScheduler),
                     job => job.Execute(),
-                    "0 7 * * 0"); // Sunday at 07:00 UTC
+                    Cron.Hourly());
             }
 
             if (mode is Sport.BaseballMlb)
             {
-                // MLB plays daily, so re-run the scheduler each morning to catch
-                // newly-rolled SeasonWeek windows. The scheduler is idempotent —
-                // already-scheduled streams are skipped via the existing CompetitionStream row.
+                // Hourly (was daily): same rationale as football — the
+                // league-contest filter makes each run cheap, and new
+                // leagues get streams within the hour.
                 recurringJobManager.AddOrUpdate<CompetitionStreamScheduler>(
                     nameof(CompetitionStreamScheduler),
                     job => job.Execute(),
-                    "0 7 * * *"); // Daily at 07:00 UTC
+                    Cron.Hourly());
             }
 
             if (mode is Sport.FootballNcaa or Sport.FootballNfl or Sport.BaseballMlb)

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Competitions/CompetitionStreamSchedulerTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Competitions/CompetitionStreamSchedulerTests.cs
@@ -1,4 +1,4 @@
-using System.Linq.Expressions;
+﻿using System.Linq.Expressions;
 
 using FluentAssertions;
 
@@ -6,6 +6,7 @@ using Moq;
 
 using SportsData.Core.Common;
 using SportsData.Core.DependencyInjection;
+using SportsData.Core.Infrastructure.Clients.Api;
 using SportsData.Core.Processing;
 using SportsData.Producer.Application.Competitions;
 using SportsData.Producer.Enums;
@@ -514,5 +515,101 @@ public class CompetitionStreamSchedulerTests : ProducerTestBase<CompetitionStrea
                 It.IsAny<Expression<Func<ICompetitionBroadcastingJob, Task>>>(),
                 It.IsAny<TimeSpan>()))
             .Returns(jobId);
+    }
+
+    // ─── League-contest filter — live-source only games that back a league ───
+
+    private void SetupLeagueContests(params Guid[] contestIds)
+    {
+        Mocker.GetMock<IProvideApi>()
+            .Setup(x => x.GetContestIdsInLeagues(It.IsAny<List<Guid>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Success<List<Guid>>(contestIds.ToList()));
+    }
+
+    [Fact]
+    public async Task Execute_ContestNotInAnyLeague_SkipsScheduling()
+    {
+        await SeedSeasonWeekAsync();
+        await SeedCompetitionAsync(competitionDate: FixedNow.AddHours(3));
+        SetupLeagueContests(); // API answers: none of these back a league
+
+        await _sut.ExecuteAsync(CancellationToken.None);
+
+        FootballDataContext.CompetitionStreams.Should().BeEmpty();
+        Mock.Get(Mocker.Get<IProvideBackgroundJobs>())
+            .Verify(x => x.Schedule<ICompetitionBroadcastingJob>(
+                It.IsAny<Expression<Func<ICompetitionBroadcastingJob, Task>>>(),
+                It.IsAny<TimeSpan>()),
+                Times.Never);
+    }
+
+    [Fact]
+    public async Task Execute_ContestInLeague_SchedulesNormally()
+    {
+        await SeedSeasonWeekAsync();
+        var competitionId = await SeedCompetitionAsync(competitionDate: FixedNow.AddHours(3));
+        var contestId = FootballDataContext.Competitions.Single(c => c.Id == competitionId).ContestId;
+        SetupLeagueContests(contestId);
+        SetupScheduleReturns("hf-league-1");
+
+        await _sut.ExecuteAsync(CancellationToken.None);
+
+        FootballDataContext.CompetitionStreams.Single().BackgroundJobId.Should().Be("hf-league-1");
+    }
+
+    [Fact]
+    public async Task Execute_ExistingScheduledStream_NoLongerInLeague_IsCulled()
+    {
+        // Scheduled before the filter existed (or the league was deleted):
+        // the sweep removes the row and deletes the Hangfire job.
+        await SeedSeasonWeekAsync();
+        var competitionId = await SeedCompetitionAsync(competitionDate: FixedNow.AddHours(3));
+        await SeedExistingStreamAsync(
+            competitionId, FixedNow.AddHours(3) - TimeSpan.FromMinutes(10),
+            CompetitionStreamStatus.Scheduled, "hf-stale");
+        SetupLeagueContests(); // no league contests
+
+        await _sut.ExecuteAsync(CancellationToken.None);
+
+        FootballDataContext.CompetitionStreams.Should().BeEmpty();
+        Mock.Get(Mocker.Get<IProvideBackgroundJobs>())
+            .Verify(x => x.Delete("hf-stale"), Times.Once);
+    }
+
+    [Fact]
+    public async Task Execute_ActiveStream_NotInLeague_IsLeftAlone()
+    {
+        // Only Scheduled streams are culled — a live stream is never
+        // yanked out from under a running job.
+        await SeedSeasonWeekAsync();
+        var competitionId = await SeedCompetitionAsync(competitionDate: FixedNow.AddHours(3));
+        await SeedExistingStreamAsync(
+            competitionId, FixedNow.AddHours(3) - TimeSpan.FromMinutes(10),
+            CompetitionStreamStatus.Active, "hf-live");
+        SetupLeagueContests();
+
+        await _sut.ExecuteAsync(CancellationToken.None);
+
+        FootballDataContext.CompetitionStreams.Single().BackgroundJobId.Should().Be("hf-live");
+        Mock.Get(Mocker.Get<IProvideBackgroundJobs>())
+            .Verify(x => x.Delete(It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Execute_LeagueInquiryFails_FailsOpenAndSchedulesEverything()
+    {
+        // API down / unconfigured → schedule ALL candidates. Briefly
+        // over-sourcing beats blinding league games on game day.
+        await SeedSeasonWeekAsync();
+        var competitionId = await SeedCompetitionAsync(competitionDate: FixedNow.AddHours(3));
+        Mocker.GetMock<IProvideApi>()
+            .Setup(x => x.GetContestIdsInLeagues(It.IsAny<List<Guid>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Failure<List<Guid>>(
+                default!, ResultStatus.Error, []));
+        SetupScheduleReturns("hf-failopen-1");
+
+        await _sut.ExecuteAsync(CancellationToken.None);
+
+        FootballDataContext.CompetitionStreams.Single().CompetitionId.Should().Be(competitionId);
     }
 }


### PR DESCRIPTION
## Summary

`CompetitionStreamScheduler` scheduled a live-polling stream for **every** non-final competition in the current SeasonWeek — all NCAA classifications on a fall Saturday, every MLB game daily — whether or not any league needed them. Measured 2026-08-29: **688 of 729 scheduled NCAA streams and 95 of 169 MLB streams backed no league**, each live-polling ESPN play-by-play nobody consumes (this was also the source of the MLB traffic visible in the ESPN Cache Performance dashboard on league-free days). Prod was hand-culled the same morning; this PR makes the sweep self-maintaining.

## Mechanism — the sweep asks the API which candidates matter

**Core** — new `IProvideApi`/`ApiClient` (the first Producer→API client). `GetContestIdsInLeagues` returns the subset of contest ids present in any league's `PickemGroupMatchup` rows — covering **team and player pick'em**, since both generate matchup rows. Registered as a typed client only where `CommonConfig:ApiClientConfig:ApiUrl` is configured; everywhere else a `TryAdd` fallback (`UnconfiguredApiClient`) returns Failure so callers take their fail-open path. Single-URL key, deliberately not sport-keyed — the API is one deployment.

**API** — `POST system/league-contests/in-use`, CQRS handler, 5,000-id bound. Namespace is `Application.Internal`, *not* `Application.System` — the latter shadows the BCL `System` namespace for the entire Application tree (found the hard way). Anonymous by design: the answer is a membership-free fact carrying no user or league identity; the comment documents the revisit trigger if this surface ever grows.

**Producer** — the sweep filters candidates through the inquiry:
- Non-league contests are **skipped** (no stream row, no Hangfire job, no ESPN polling).
- Existing `Scheduled` streams whose contest backs no league are **culled** (row + job) — a deleted league's streams evaporate within the hour, and pre-filter backlogs self-clean.
- **Live streams are never touched** — only `Scheduled` is cullable.
- **Fail open** on any API trouble (down, unconfigured, defective response): schedule everything. Briefly over-sourcing beats blinding league games on game day.
- Both sweeps move to **hourly** (football was weekly, MLB daily) — a league created mid-week gets its games' streams within the hour.

**Follow-up (separate PR):** the matchups-generated event path for immediate stream scheduling, pending API→Producer shovels (a messaging direction that doesn't exist yet).

## Deploy prerequisite

`CommonConfig:ApiClientConfig:ApiUrl` = `http://api-service:8080` on the three Producer AppConfig labels. Until present, the filter fails open — i.e., pre-change behavior, already mitigated in prod by the manual cull.

## Tests

- 5 new scheduler tests: skip non-league, schedule in-league, cull stale `Scheduled`, leave `Active` alone, fail-open
- The 22 existing scheduler tests pass unmodified (the fail-open default makes the filter invisible to them)
- Core 265, API 756, Producer 633 — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnJySMvfUPeQSMufNNcKSK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Competition stream scheduling now prioritizes contests included in active pick’em league matchups.
  - Scheduling runs hourly for more timely updates.
- **Bug Fixes**
  - Removed streams for contests no longer covered by leagues, including their scheduled jobs.
  - Prevented unnecessary streams from being created for contests outside league coverage.
  - Scheduling continues safely when league data is temporarily unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->