### PR TITLE
feat(core,api,producer): X-Trace-Id response header + timed matchups legs

### DIFF
--- a/src/SportsData.Api/Application/UI/Leagues/Queries/GetLeagueWeekMatchups/GetLeagueWeekMatchupsQueryHandler.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Queries/GetLeagueWeekMatchups/GetLeagueWeekMatchupsQueryHandler.cs
@@ -154,6 +154,7 @@ public class GetLeagueWeekMatchupsQueryHandler : IGetLeagueWeekMatchupsQueryHand
             // other (one DbContext can't run concurrent operations), but
             // they overlap the HTTP call, so total ≈ max(http, local)
             // instead of the sum.
+            var producerLegTimer = System.Diagnostics.Stopwatch.StartNew();
             var matchupsTask = _contestClientFactory
                 .Resolve(league.Sport)
                 .GetMatchupsByContestIds(contestIds, direction, cancellationToken);
@@ -212,6 +213,7 @@ public class GetLeagueWeekMatchupsQueryHandler : IGetLeagueWeekMatchupsQueryHand
                 query.Week);
 
             var matchupsResult = await matchupsTask;
+            producerLegTimer.Stop();
             if (!matchupsResult.IsSuccess)
             {
                 _logger.LogError("Failed to retrieve canonical matchups for leagueId={LeagueId}, week={Week}", query.LeagueId, query.Week);
@@ -333,12 +335,17 @@ public class GetLeagueWeekMatchupsQueryHandler : IGetLeagueWeekMatchupsQueryHand
                 Matchups = matchups.OrderBy(x => x.StartDateUtc).ToList()
             };
 
+            // ProducerLegMs = dispatch → response for the overlapped canonical
+            // call, the historical long pole of this endpoint. Pairs with
+            // Producer's "Canonical matchups served" event under the same
+            // @TraceId (surfaced to clients as the X-Trace-Id header).
             _logger.LogInformation(
-                "Successfully completed GetLeagueWeekMatchupsQueryHandler.ExecuteAsync for leagueId={LeagueId}, week={Week}, userId={UserId}, returning {Count} matchups",
+                "Successfully completed GetLeagueWeekMatchupsQueryHandler.ExecuteAsync for leagueId={LeagueId}, week={Week}, userId={UserId}, returning {Count} matchups. ProducerLegMs={ProducerLegMs}",
                 query.LeagueId,
                 query.Week,
                 query.UserId,
-                result.Matchups.Count);
+                result.Matchups.Count,
+                producerLegTimer.ElapsedMilliseconds);
 
             return new Success<LeagueWeekMatchupsDto>(result);
         }

--- a/src/SportsData.Api/Application/UI/Leagues/Queries/GetLeagueWeekMatchups/GetLeagueWeekMatchupsQueryHandler.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Queries/GetLeagueWeekMatchups/GetLeagueWeekMatchupsQueryHandler.cs
@@ -154,10 +154,28 @@ public class GetLeagueWeekMatchupsQueryHandler : IGetLeagueWeekMatchupsQueryHand
             // other (one DbContext can't run concurrent operations), but
             // they overlap the HTTP call, so total ≈ max(http, local)
             // instead of the sum.
-            var producerLegTimer = System.Diagnostics.Stopwatch.StartNew();
-            var matchupsTask = _contestClientFactory
-                .Resolve(league.Sport)
-                .GetMatchupsByContestIds(contestIds, direction, cancellationToken);
+            // Timed INSIDE the async wrapper so the measurement ends when
+            // Producer responds — not when this handler gets around to
+            // awaiting. Stopping a timer after the await would report
+            // max(producer, local) and blame Producer for slow local
+            // queries whenever the overlap goes the other way.
+            long producerLegMs = -1;
+            async Task<Result<List<SportsData.Core.Dtos.Canonical.LeagueMatchupDto>>> CallProducerTimedAsync()
+            {
+                var sw = System.Diagnostics.Stopwatch.StartNew();
+                try
+                {
+                    return await _contestClientFactory
+                        .Resolve(league.Sport)
+                        .GetMatchupsByContestIds(contestIds, direction, cancellationToken);
+                }
+                finally
+                {
+                    producerLegMs = sw.ElapsedMilliseconds;
+                }
+            }
+
+            var matchupsTask = CallProducerTimedAsync();
 
             List<ContestPredictionDto> predictions;
             List<MatchupPreviewProjection> previews;
@@ -213,7 +231,6 @@ public class GetLeagueWeekMatchupsQueryHandler : IGetLeagueWeekMatchupsQueryHand
                 query.Week);
 
             var matchupsResult = await matchupsTask;
-            producerLegTimer.Stop();
             if (!matchupsResult.IsSuccess)
             {
                 _logger.LogError("Failed to retrieve canonical matchups for leagueId={LeagueId}, week={Week}", query.LeagueId, query.Week);
@@ -345,7 +362,7 @@ public class GetLeagueWeekMatchupsQueryHandler : IGetLeagueWeekMatchupsQueryHand
                 query.Week,
                 query.UserId,
                 result.Matchups.Count,
-                producerLegTimer.ElapsedMilliseconds);
+                producerLegMs);
 
             return new Success<LeagueWeekMatchupsDto>(result);
         }

--- a/src/SportsData.Api/Program.cs
+++ b/src/SportsData.Api/Program.cs
@@ -24,6 +24,7 @@ using SportsData.Core.Common;
 using SportsData.Core.Config;
 using SportsData.Core.DependencyInjection;
 using SportsData.Core.Infrastructure.Clients.AI;
+using SportsData.Core.Middleware;
 using SportsData.Core.Infrastructure.Clients.MetricBot;
 using SportsData.Core.Middleware.Health;
 using SportsData.Core.Processing;
@@ -358,7 +359,7 @@ namespace SportsData.Api
                         .AllowAnyHeader()
                         .AllowAnyMethod()
                         .AllowCredentials() // Required for cookies
-                        .WithExposedHeaders("Set-Cookie") // Explicitly expose Set-Cookie header
+                        .WithExposedHeaders("Set-Cookie", TraceIdResponseHeaderMiddleware.HeaderName) // Set-Cookie + X-Trace-Id (complete-trace lookup)
                         .SetIsOriginAllowedToAllowWildcardSubdomains(); // Allow subdomains
                 });
             });
@@ -374,6 +375,11 @@ namespace SportsData.Api
             // Configure the HTTP request pipeline.
             // Don't redirect to HTTPS when behind a proxy (Front Door, Traefik)
             // app.UseHttpsRedirection();
+
+            // First in the pipeline so every response — including CORS
+            // preflights, 401s and 500s — carries X-Trace-Id. The value is
+            // the Seq @TraceId for the whole cross-service call.
+            app.UseMiddleware<TraceIdResponseHeaderMiddleware>();
 
             app.UseCors("AllowFrontend");
 

--- a/src/SportsData.Core/Middleware/TraceIdResponseHeaderMiddleware.cs
+++ b/src/SportsData.Core/Middleware/TraceIdResponseHeaderMiddleware.cs
@@ -1,0 +1,49 @@
+using Microsoft.AspNetCore.Http;
+
+using System.Diagnostics;
+using System.Threading.Tasks;
+
+namespace SportsData.Core.Middleware
+{
+    /// <summary>
+    /// Stamps the request's W3C trace id onto every response as
+    /// <c>X-Trace-Id</c>. The value is the SAME id OpenTelemetry propagates
+    /// downstream via <c>traceparent</c> on outgoing HttpClient calls
+    /// (e.g. API → Producer), and the same id Serilog writes to Seq — so
+    /// one header value from the browser's network tab is a complete-trace
+    /// query: <c>@TraceId = '&lt;value&gt;'</c> spans every service the
+    /// request touched.
+    ///
+    /// Header is set via OnStarting so it survives whatever status code
+    /// the pipeline ultimately produces (including 401/403/500).
+    /// </summary>
+    public class TraceIdResponseHeaderMiddleware
+    {
+        public const string HeaderName = "X-Trace-Id";
+
+        private readonly RequestDelegate _next;
+
+        public TraceIdResponseHeaderMiddleware(RequestDelegate next)
+        {
+            _next = next;
+        }
+
+        public Task InvokeAsync(HttpContext context)
+        {
+            context.Response.OnStarting(() =>
+            {
+                if (!context.Response.Headers.ContainsKey(HeaderName))
+                {
+                    // Activity is created by the AspNetCore OTel instrumentation;
+                    // TraceIdentifier is the framework fallback when tracing is off.
+                    var traceId = Activity.Current?.TraceId.ToString() ?? context.TraceIdentifier;
+                    context.Response.Headers.Append(HeaderName, traceId);
+                }
+
+                return Task.CompletedTask;
+            });
+
+            return _next(context);
+        }
+    }
+}

--- a/src/SportsData.Core/Middleware/TraceIdResponseHeaderMiddleware.cs
+++ b/src/SportsData.Core/Middleware/TraceIdResponseHeaderMiddleware.cs
@@ -32,11 +32,16 @@ namespace SportsData.Core.Middleware
         {
             context.Response.OnStarting(() =>
             {
-                if (!context.Response.Headers.ContainsKey(HeaderName))
+                // Only the W3C Activity trace id — no TraceIdentifier
+                // fallback. Serilog emits @TraceId to Seq only when an
+                // Activity is active, so a fallback value would be a header
+                // that matches nothing when pasted into Seq. Contract:
+                // header present ⇒ the value IS queryable as @TraceId.
+                // (With AspNetCore OTel instrumentation on, the Activity is
+                // effectively always present; absence means tracing is off.)
+                var traceId = Activity.Current?.TraceId.ToString();
+                if (traceId is not null && !context.Response.Headers.ContainsKey(HeaderName))
                 {
-                    // Activity is created by the AspNetCore OTel instrumentation;
-                    // TraceIdentifier is the framework fallback when tracing is off.
-                    var traceId = Activity.Current?.TraceId.ToString() ?? context.TraceIdentifier;
                     context.Response.Headers.Append(HeaderName, traceId);
                 }
 

--- a/src/SportsData.Producer/Application/Contests/Queries/Matchups/GetMatchupsByContestIds/GetMatchupsByContestIdsQueryHandler.cs
+++ b/src/SportsData.Producer/Application/Contests/Queries/Matchups/GetMatchupsByContestIds/GetMatchupsByContestIdsQueryHandler.cs
@@ -52,6 +52,11 @@ public class GetMatchupsByContestIdsQueryHandler : IGetMatchupsByContestIdsQuery
             return new Success<List<LeagueMatchupDto>>(new List<LeagueMatchupDto>());
         }
 
+        // Timed so the Producer leg of a cross-service trace is legible in
+        // Seq: these events carry the same @TraceId as the API request that
+        // called us (W3C traceparent via HttpClient instrumentation).
+        var totalTimer = System.Diagnostics.Stopwatch.StartNew();
+
         var sql = _sqlProvider.GetMatchupsByContestIds();
 
         // Direction is the lowercase enum name ("roundel" / "shield" / "hex")
@@ -66,6 +71,8 @@ public class GetMatchupsByContestIdsQueryHandler : IGetMatchupsByContestIdsQuery
                 new { ContestIds = query.ContestIds, Direction = directionTag },
                 cancellationToken: cancellationToken)))
             .ToList();
+
+        var sqlMs = totalTimer.ElapsedMilliseconds;
 
         var streamTimes = await GetActiveStreamTimesAsync(query.ContestIds, cancellationToken);
         var probables = await GetProbablePitchersAsync(query.ContestIds, cancellationToken);
@@ -111,6 +118,13 @@ public class GetMatchupsByContestIdsQueryHandler : IGetMatchupsByContestIdsQuery
                 }
             }
         }
+
+        _logger.LogInformation(
+            "Canonical matchups served. Requested={RequestedCount}, Returned={ReturnedCount}, SqlMs={SqlMs}, TotalMs={TotalMs}",
+            query.ContestIds.Length,
+            matchups.Count,
+            sqlMs,
+            totalTimer.ElapsedMilliseconds);
 
         return new Success<List<LeagueMatchupDto>>(matchups);
     }


### PR DESCRIPTION
## Summary

Complete-trace visibility for slow requests (`/ui/leagues/{id}/matchups/{week}` still spikes at times), built on the correlation the system **already feeds through end-to-end**: the W3C trace id. OTel mints it per request, propagates it API→Producer via `traceparent` on the `ContestClient` call, and Serilog already writes it to every request-scoped Seq event as `@TraceId` — including historical events. The only missing piece was showing it to the caller, plus lighting up the legs that logged nothing.

### Changes

- **Core** — `TraceIdResponseHeaderMiddleware`: stamps `X-Trace-Id` on every response via `OnStarting`, so it survives 401/403/500. Deliberately *not* a hand-rolled correlation id: the synchronous HTTP path never had one (the business `CorrelationId` scheme belongs to the messaging world), and inventing one would duplicate `traceparent` propagation with five pieces of manual plumbing while leaving two ids per request in Seq.
- **API** — middleware first in the pipeline; CORS policy exposes the header for browser code. The matchups completion log gains `ProducerLegMs` — dispatch→response for the overlapped canonical call, the endpoint's historical long pole.
- **Producer** — `GetMatchupsByContestIds` logged nothing, making its leg invisible in any trace. Now logs `Canonical matchups served` with `Requested`/`Returned`/`SqlMs`/`TotalMs`, carrying the caller's trace id.

### Workflow

Slow request → copy `X-Trace-Id` from the network tab → Seq: `@TraceId = '<value>'` → API milestones with `ProducerLegMs`, Producer's `SqlMs`/`TotalMs`, and the delta between them (network/queueing — the piece that has never been directly observable) in one view.

**Scope note:** this traces the synchronous call graph. Background work (Hangfire jobs, MassTransit consumers) has no ambient request Activity and keeps the business `CorrelationId` scheme; `DocumentRequestedHandler`'s correlation-resolution fallback chain already bridges the two where they meet.

## Validation

- Boot-verified on a live local API: `X-Trace-Id` present on a 503 health response and a 200 controller response
- API suite 756 passed; Producer matchups handler tests 21 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnJySMvfUPeQSMufNNcKSK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `X-Trace-Id` response header to help identify and track individual requests.
  * Trace IDs are available to browser-based clients when permitted by response policies.

* **Improvements**
  * Added timing details for request processing and matchup data retrieval.
  * Improved visibility into response and database performance to support faster troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->