### PR TITLE
fix(producer): Worker role no longer listens on the daemon Hangfire queue

### DIFF
--- a/src/SportsData.Producer/Program.cs
+++ b/src/SportsData.Producer/Program.cs
@@ -125,9 +125,10 @@ public class Program
         //
         // Queue routing:
         //   - Daemon-only pods listen on ["daemon"] exclusively.
-        //   - Worker pods listen on ["default"] only. This is PR D of the streamer
-        //     cutover: Daemon pods are confirmed healthy in prod, so Worker no longer
-        //     needs the transitional "daemon" fallback.
+        //   - Worker-only pods listen on ["default"] exclusively. This is PR D of the
+        //     streamer cutover: Daemon pods are confirmed healthy in prod, so Worker no
+        //     longer uses the transitional "daemon" fallback. (A Worker|Daemon combo is
+        //     the one exception, handled below.)
         //
         //     Dropping it is a correctness fix, not cleanup. Worker replicas are
         //     KEDA-scaled off a trigger that counts the *default* queue only, so the

--- a/src/SportsData.Producer/Program.cs
+++ b/src/SportsData.Producer/Program.cs
@@ -125,20 +125,30 @@ public class Program
         //
         // Queue routing:
         //   - Daemon-only pods listen on ["daemon"] exclusively.
-        //   - Worker pods listen on ["default", "daemon"] during the streamer-cutover
-        //     transition (PR A–C). PR D will drop "daemon" from Worker once Daemon pods
-        //     are confirmed healthy in prod.
+        //   - Worker pods listen on ["default"] only. This is PR D of the streamer
+        //     cutover: Daemon pods are confirmed healthy in prod, so Worker no longer
+        //     needs the transitional "daemon" fallback.
+        //
+        //     Dropping it is a correctness fix, not cleanup. Worker replicas are
+        //     KEDA-scaled off a trigger that counts the *default* queue only, so the
+        //     autoscaler cannot see a Worker holding a daemon job. The failure mode is
+        //     self-arming: when "default" drains, a Worker reaches into "daemon" and can
+        //     claim a competition streamer built to run for hours - and that same empty
+        //     queue is what tells KEDA to scale down and kill the pod 90s later
+        //     (ShutdownTimeout). Long-running daemon work must only ever land on pods no
+        //     autoscaler is authorized to reap.
         //   - All (local-dev / docker-compose) listens on both.
         //   - Other combos fall back to Hangfire's default ["default"].
         // See docs/contest-finalization-reconcile-backstop.md Step 4.
         var needsHangfireServer = role.HasFlag(ProducerRole.Worker) || role.HasFlag(ProducerRole.Daemon);
-        // Worker checked before Daemon (same mutual-exclusion rationale as the
-        // pool-sizing switch above): an accidental `Worker|Daemon` combo falls
-        // through to the both-queues case, which is the safer fallback.
+        // An explicit `Worker|Daemon` combo is matched before either flag alone so it
+        // still listens on both queues - a single pod wearing both hats has no separate
+        // daemon pod to defer to. Deployed roles are always one or the other.
         string[]? hangfireQueues = role switch
         {
             _ when role == ProducerRole.All => new[] { "default", "daemon" },
-            _ when role.HasFlag(ProducerRole.Worker) => new[] { "default", "daemon" },
+            _ when role.HasFlag(ProducerRole.Worker) && role.HasFlag(ProducerRole.Daemon) => new[] { "default", "daemon" },
+            _ when role.HasFlag(ProducerRole.Worker) => new[] { "default" },
             _ when role.HasFlag(ProducerRole.Daemon) => new[] { "daemon" },
             _ => null
         };


### PR DESCRIPTION
Completes **PR D** of the streamer cutover, which `Program.cs` has been carrying as a TODO since PR A–C:

> Worker pods listen on `["default", "daemon"]` during the streamer-cutover transition (PR A–C). PR D will drop "daemon" from Worker once Daemon pods are confirmed healthy in prod.

Daemon pods are confirmed healthy — `producer-football-ncaa-daemon` has two replicas, one with 4h48m uptime.

## Why this is a correctness fix, not cleanup

Worker replicas are KEDA-scaled off a trigger that counts the **default** queue only, so the autoscaler has no visibility into a Worker holding a **daemon** job. The failure mode is self-arming:

1. The default queue drains.
2. A Worker, listening on both, reaches into `daemon` and claims a competition streamer — a job built to run for hours.
3. That same empty default queue is what tells KEDA to scale down.
4. The pod is killed ~90s later (Hangfire `ShutdownTimeout`), abandoning the stream mid-game.

Long-running daemon work must only ever land on pods no autoscaler is authorized to reap.

I verified in Seq that both live NCAAFB streams today ran with `Role=Daemon`, so this race has not yet been lost in production. This closes it before it can be.

## Change

`Program.cs` queue routing: `Worker` → `["default"]`. An explicit `Worker|Daemon` combo is now matched *ahead* of either flag alone and still listens on both queues, since a pod wearing both hats has no separate daemon pod to defer to. Deployed roles are always one or the other; `All` (local-dev/compose) is unchanged.

## Context

Found while diagnosing KEDA thrash on `producer-football-ncaa-worker` during the 2026-08-29 NCAAFB slate — pods cycling 4→1→4 within twelve seconds. The scaler-side fixes (metric counts in-flight work; HPA scale-down damping) are staged in sports-data-config on `fix/keda-scaler-metric-and-behavior`; the deployment is pinned at 4 replicas on main until those land.

## Verification

- `dotnet build` SportsData.Producer — 0 warnings, 0 errors
- `dotnet test` Producer unit — **633 passed, 0 failed**, 18 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnJySMvfUPeQSMufNNcKSK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected background job routing so worker-only instances process standard jobs without consuming daemon-specific jobs.
  * Preserved existing queue access for daemon instances and combined worker/daemon configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->