### PR TITLE
fix(producer): register AthleteCareerStatistics processor for FootballNcaa

### DIFF
--- a/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Football/AthleteCareerStatisticsDocumentProcessor.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Football/AthleteCareerStatisticsDocumentProcessor.cs
@@ -13,7 +13,15 @@ using SportsData.Producer.Infrastructure.Data.Football;
 
 namespace SportsData.Producer.Application.Documents.Processors.Providers.Espn.Football;
 
+// NCAA registration was missing until 2026-08-30. FootballAthleteDocumentProcessor
+// spawns AthleteCareerStatistics for both football sports, and Provider sources the
+// documents, but with no NCAA processor registered every one of them threw
+// "No processor registered for (Espn, FootballNcaa, AthleteCareerStatistics)" and
+// then burned the full retry ladder failing again. The processor itself is
+// sport-agnostic within football — TDataContext is FootballDataContext, which NCAA
+// already uses — so registration was the only thing missing.
 [DocumentProcessor(SourceDataProvider.Espn, Sport.FootballNfl, DocumentType.AthleteCareerStatistics)]
+[DocumentProcessor(SourceDataProvider.Espn, Sport.FootballNcaa, DocumentType.AthleteCareerStatistics)]
 public class AthleteCareerStatisticsDocumentProcessor<TDataContext> : DocumentProcessorBase<TDataContext>
     where TDataContext : FootballDataContext
 {


### PR DESCRIPTION
Found in production logs today:

```
No processor registered for (Espn, FootballNcaa, AthleteCareerStatistics)
  SourceRef: .../college-football/athletes/5416075/statistics
```

## What was wrong

`FootballAthleteDocumentProcessor` spawns `AthleteCareerStatistics` for both football sports, and Provider dutifully sources and stores the documents. But `AthleteCareerStatisticsDocumentProcessor` carried only a `FootballNfl` registration, so every NCAA document threw at the factory.

**This wasn't only lost data — it was active waste.** Each failure entered the escalating retry ladder and re-failed identically, so a single career-stats document cost roughly ten job executions to accomplish nothing. The canonical data was already fetched and sitting in Mongo; we discarded it and paid for the discarding.

## The change

One attribute. The processor is sport-agnostic within football — `TDataContext` is constrained to `FootballDataContext`, which NCAA already uses — so registration was genuinely the only thing missing. No logic changed.

## Sweep for the same gap

Checked every ESPN processor for single-sport registrations:

| Processor | Verdict |
|---|---|
| `AthleteCareerStatisticsDocumentProcessor` | **Gap — fixed here** |
| `DraftDocumentProcessor` | Correct, NFL-only (no college draft) |
| `DraftRoundsDocumentProcessor` | Correct, NFL-only |

Only the one real gap.

## Note for the cascade work

These documents are spawned at `FootballAthleteDocumentProcessor.cs:328` behind `ShouldSpawn`. Once the athlete-cascade scoping lands (`docs/features/athlete-cascade-scoping.md`), fewer will arrive — but the ones that do will land as canonical data instead of failing. The two changes are independent and both correct.

## Verification

- `dotnet build` SportsData.Producer — 0 warnings, 0 errors
- `dotnet test` Producer unit — **633 passed, 0 failed**, 18 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnJySMvfUPeQSMufNNcKSK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for processing athlete career statistics from ESPN NCAA football data.
  * NFL football processing remains supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->