### PR TITLE
feat(producer): cache contest preview history

### DIFF
--- a/src/SportsData.Producer/Application/Contests/Queries/Matchups/GetContestPreviewHistory/ContestPreviewHistoryCache.cs
+++ b/src/SportsData.Producer/Application/Contests/Queries/Matchups/GetContestPreviewHistory/ContestPreviewHistoryCache.cs
@@ -1,0 +1,120 @@
+using Microsoft.Extensions.Caching.Distributed;
+
+using SportsData.Core.Common;
+using SportsData.Core.Dtos.Canonical;
+using SportsData.Core.Extensions;
+
+using System;
+using System.Threading.Tasks;
+
+namespace SportsData.Producer.Application.Contests.Queries.Matchups.GetContestPreviewHistory;
+
+/// <summary>
+/// Caching policy for preview history: key shape and entry lifetime.
+/// </summary>
+/// <remarks>
+/// Separate from the handler on purpose. The handler's job is deciding WHAT the
+/// preview history is; how long an answer stays true, and how it is addressed in a
+/// key-value store, is a different concern and reads as noise inside it. It lives in
+/// this slice rather than a shared infrastructure namespace because the policy is
+/// specific to this query — the lifetime rule below is a statement about spreads and
+/// kickoff times, not something another feature would reuse.
+/// </remarks>
+public interface IContestPreviewHistoryCache
+{
+    Task<ContestPreviewHistoryDto?> GetAsync(GetContestPreviewHistoryQuery query);
+
+    /// <param name="contestStartUtc">
+    /// Kickoff for the contest, or null when the id resolved to nothing. Drives the
+    /// entry lifetime — see the implementation.
+    /// </param>
+    Task SetAsync(
+        GetContestPreviewHistoryQuery query,
+        ContestPreviewHistoryDto dto,
+        DateTime? contestStartUtc);
+}
+
+/// <inheritdoc />
+public sealed class ContestPreviewHistoryCache : IContestPreviewHistoryCache
+{
+    /// <summary>Lifetime once the contest's inputs have frozen.</summary>
+    private static readonly TimeSpan SettledTtl = TimeSpan.FromDays(7);
+
+    /// <summary>Lifetime while the contest is still ahead of us — short, because the spread moves.</summary>
+    private static readonly TimeSpan LiveTtl = TimeSpan.FromHours(1);
+
+    /// <summary>
+    /// Lifetime for a contest id that resolved to nothing. Brief, so a request arriving
+    /// before the contest is sourced cannot pin an empty result for long.
+    /// </summary>
+    private static readonly TimeSpan UnresolvedContestTtl = TimeSpan.FromMinutes(5);
+
+    /// <summary>How long after kickoff the inputs are considered frozen.</summary>
+    private static readonly TimeSpan SettlesAfterStart = TimeSpan.FromHours(24);
+
+    private readonly IDistributedCache _cache;
+    private readonly IDateTimeProvider _dateTimeProvider;
+
+    public ContestPreviewHistoryCache(
+        IDistributedCache cache,
+        IDateTimeProvider dateTimeProvider)
+    {
+        _cache = cache;
+        _dateTimeProvider = dateTimeProvider;
+    }
+
+    public Task<ContestPreviewHistoryDto?> GetAsync(GetContestPreviewHistoryQuery query) =>
+        _cache.GetRecordAsync<ContestPreviewHistoryDto>(BuildKey(query));
+
+    public Task SetAsync(
+        GetContestPreviewHistoryQuery query,
+        ContestPreviewHistoryDto dto,
+        DateTime? contestStartUtc) =>
+        _cache.SetRecordAsync(BuildKey(query), dto, ResolveTtl(contestStartUtc));
+
+    /// <summary>
+    /// Key for one preview-history result.
+    /// </summary>
+    /// <remarks>
+    /// MeetingCount and RecentGameCount are included deliberately: the query exposes
+    /// both, so two callers asking for different depths must not share an entry. Every
+    /// caller happens to use the 5/5 defaults today, which is precisely why keying on
+    /// contest id alone would have looked correct indefinitely.
+    /// <para>
+    /// The v1 segment is a payload version — changing ContestPreviewHistoryDto
+    /// invalidates every entry by bumping it, rather than feeding old shapes to new
+    /// deserializers until they expire.
+    /// </para>
+    /// </remarks>
+    private static string BuildKey(GetContestPreviewHistoryQuery query) =>
+        $"preview-history:v1:{query.ContestId}:{query.MeetingCount}:{query.RecentGameCount}";
+
+    /// <summary>
+    /// How long a result stays true.
+    /// </summary>
+    /// <remarks>
+    /// Almost everything in the payload is genuinely historical — head-to-head meetings
+    /// and prior-season records are settled facts. The exception is the spread: the
+    /// handler's spread context reads the contest's CURRENT line and derives favorite,
+    /// underdog, magnitude and the ATS key-number bucket from it, and lines move through
+    /// the week. A multi-day entry for an upcoming game would therefore serve a stale
+    /// line dressed up as historical fact, which is the one way this cache could
+    /// actively mislead rather than merely lag.
+    /// <para>
+    /// Hence short until the game is well past kickoff, long afterwards. An hour still
+    /// collapses thousands of user views into a single computation, which is where
+    /// nearly all the benefit lives.
+    /// </para>
+    /// </remarks>
+    private TimeSpan ResolveTtl(DateTime? contestStartUtc)
+    {
+        if (contestStartUtc is null)
+            return UnresolvedContestTtl;
+
+        var settlesAt = contestStartUtc.Value.Add(SettlesAfterStart);
+
+        return _dateTimeProvider.UtcNow() >= settlesAt
+            ? SettledTtl
+            : LiveTtl;
+    }
+}

--- a/src/SportsData.Producer/Application/Contests/Queries/Matchups/GetContestPreviewHistory/GetContestPreviewHistoryQueryHandler.cs
+++ b/src/SportsData.Producer/Application/Contests/Queries/Matchups/GetContestPreviewHistory/GetContestPreviewHistoryQueryHandler.cs
@@ -3,9 +3,11 @@ using Dapper;
 using FluentValidation;
 
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Distributed;
 
 using SportsData.Core.Common;
 using SportsData.Core.Dtos.Canonical;
+using SportsData.Core.Extensions;
 using SportsData.Producer.Application.FranchiseSeasons.Queries.GetFranchiseSeasonMetricsById;
 using SportsData.Producer.Infrastructure.Data.Common;
 using SportsData.Producer.Infrastructure.Sql;
@@ -26,16 +28,90 @@ public class GetContestPreviewHistoryQueryHandler : IGetContestPreviewHistoryQue
     private readonly IValidator<GetContestPreviewHistoryQuery> _validator;
     private readonly IGetFranchiseSeasonMetricsByIdQueryHandler _metricsHandler;
 
+    private readonly IDistributedCache _cache;
+    private readonly IDateTimeProvider _dateTimeProvider;
+
+    /// <summary>
+    /// TTL once the contest's inputs have frozen — see <see cref="ResolveCacheTtl"/>.
+    /// </summary>
+    private static readonly TimeSpan SettledTtl = TimeSpan.FromDays(7);
+
+    /// <summary>
+    /// TTL while the contest is still ahead of us. Short because the spread moves.
+    /// </summary>
+    private static readonly TimeSpan LiveTtl = TimeSpan.FromHours(1);
+
+    /// <summary>
+    /// TTL for a contest id we could not resolve. Kept brief so a request that
+    /// arrives before the contest is sourced does not pin an empty result.
+    /// </summary>
+    private static readonly TimeSpan UnresolvedContestTtl = TimeSpan.FromMinutes(5);
+
+    /// <summary>
+    /// Inputs freeze this long after kickoff, at which point the entry can live a
+    /// long time.
+    /// </summary>
+    private static readonly TimeSpan SettlesAfterStart = TimeSpan.FromHours(24);
+
     public GetContestPreviewHistoryQueryHandler(
         TeamSportDataContext dbContext,
         ProducerSqlQueryProvider sqlProvider,
         IValidator<GetContestPreviewHistoryQuery> validator,
-        IGetFranchiseSeasonMetricsByIdQueryHandler metricsHandler)
+        IGetFranchiseSeasonMetricsByIdQueryHandler metricsHandler,
+        IDistributedCache cache,
+        IDateTimeProvider dateTimeProvider)
     {
         _dbContext = dbContext;
         _sqlProvider = sqlProvider;
         _validator = validator;
         _metricsHandler = metricsHandler;
+        _cache = cache;
+        _dateTimeProvider = dateTimeProvider;
+    }
+
+    /// <summary>
+    /// Cache key for one preview-history result.
+    /// </summary>
+    /// <remarks>
+    /// Includes MeetingCount and RecentGameCount deliberately. The query exposes
+    /// both, so two callers asking for different depths must not share an entry.
+    /// Every caller happens to use the 5/5 defaults today, which is precisely why
+    /// keying on contest id alone would have looked correct indefinitely.
+    /// <para>
+    /// The v1 segment is a payload-shape version: changing ContestPreviewHistoryDto
+    /// invalidates every entry by bumping it, rather than serving old shapes to new
+    /// deserializers until the TTL expires.
+    /// </para>
+    /// </remarks>
+    private static string BuildCacheKey(GetContestPreviewHistoryQuery query) =>
+        $"preview-history:v1:{query.ContestId}:{query.MeetingCount}:{query.RecentGameCount}";
+
+    /// <summary>
+    /// How long this result stays valid.
+    /// </summary>
+    /// <remarks>
+    /// Almost everything here is genuinely historical — head-to-head meetings and
+    /// prior-season records cannot change. The exception is the spread:
+    /// <see cref="BuildSpreadContextAsync"/> reads the contest's current line and
+    /// derives favorite, magnitude and ATS bucket from it, and lines move through
+    /// the week. A multi-day entry for an upcoming game would therefore serve a
+    /// stale line dressed up as historical fact.
+    /// <para>
+    /// So: short TTL until the game is 24h past kickoff, long TTL after. An hour
+    /// still collapses thousands of user views into one computation, which is
+    /// where nearly all the benefit lives.
+    /// </para>
+    /// </remarks>
+    private TimeSpan ResolveCacheTtl(DateTime? startDateUtc)
+    {
+        if (startDateUtc is null)
+            return UnresolvedContestTtl;
+
+        var settlesAt = startDateUtc.Value.Add(SettlesAfterStart);
+
+        return _dateTimeProvider.UtcNow() >= settlesAt
+            ? SettledTtl
+            : LiveTtl;
     }
 
     /// <summary>
@@ -59,6 +135,18 @@ public class GetContestPreviewHistoryQueryHandler : IGetContestPreviewHistoryQue
                 ResultStatus.Validation,
                 validationResult.Errors);
         }
+
+        // Assembling this DTO costs ~10 sequential round trips (head-to-head,
+        // prior-season summaries for both sides, spread target, two margin facts,
+        // two ATS buckets), and it is identical for every user viewing the same
+        // matchup — it is not user-scoped. Cache read sits after validation so a
+        // malformed query still fails fast.
+        var cacheKey = BuildCacheKey(query);
+
+        var fromCache = await _cache.GetRecordAsync<ContestPreviewHistoryDto>(cacheKey);
+
+        if (fromCache is not null)
+            return new Success<ContestPreviewHistoryDto>(fromCache);
 
         var connection = _dbContext.Database.GetDbConnection();
 
@@ -93,6 +181,7 @@ public class GetContestPreviewHistoryQueryHandler : IGetContestPreviewHistoryQue
             .Select(c => new
             {
                 c.SeasonYear,
+                c.StartDateUtc,
                 c.AwayTeamFranchiseSeasonId,
                 c.HomeTeamFranchiseSeasonId
             })
@@ -107,6 +196,8 @@ public class GetContestPreviewHistoryQueryHandler : IGetContestPreviewHistoryQue
         }
 
         dto.SpreadContext = await BuildSpreadContextAsync(connection, query.ContestId, cancellationToken);
+
+        await _cache.SetRecordAsync(cacheKey, dto, ResolveCacheTtl(target?.StartDateUtc));
 
         return new Success<ContestPreviewHistoryDto>(dto);
     }

--- a/src/SportsData.Producer/Application/Contests/Queries/Matchups/GetContestPreviewHistory/GetContestPreviewHistoryQueryHandler.cs
+++ b/src/SportsData.Producer/Application/Contests/Queries/Matchups/GetContestPreviewHistory/GetContestPreviewHistoryQueryHandler.cs
@@ -3,7 +3,6 @@ using Dapper;
 using FluentValidation;
 
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Caching.Distributed;
 
 using SportsData.Core.Common;
 using SportsData.Core.Dtos.Canonical;
@@ -28,90 +27,20 @@ public class GetContestPreviewHistoryQueryHandler : IGetContestPreviewHistoryQue
     private readonly IValidator<GetContestPreviewHistoryQuery> _validator;
     private readonly IGetFranchiseSeasonMetricsByIdQueryHandler _metricsHandler;
 
-    private readonly IDistributedCache _cache;
-    private readonly IDateTimeProvider _dateTimeProvider;
-
-    /// <summary>
-    /// TTL once the contest's inputs have frozen — see <see cref="ResolveCacheTtl"/>.
-    /// </summary>
-    private static readonly TimeSpan SettledTtl = TimeSpan.FromDays(7);
-
-    /// <summary>
-    /// TTL while the contest is still ahead of us. Short because the spread moves.
-    /// </summary>
-    private static readonly TimeSpan LiveTtl = TimeSpan.FromHours(1);
-
-    /// <summary>
-    /// TTL for a contest id we could not resolve. Kept brief so a request that
-    /// arrives before the contest is sourced does not pin an empty result.
-    /// </summary>
-    private static readonly TimeSpan UnresolvedContestTtl = TimeSpan.FromMinutes(5);
-
-    /// <summary>
-    /// Inputs freeze this long after kickoff, at which point the entry can live a
-    /// long time.
-    /// </summary>
-    private static readonly TimeSpan SettlesAfterStart = TimeSpan.FromHours(24);
+    private readonly IContestPreviewHistoryCache _cache;
 
     public GetContestPreviewHistoryQueryHandler(
         TeamSportDataContext dbContext,
         ProducerSqlQueryProvider sqlProvider,
         IValidator<GetContestPreviewHistoryQuery> validator,
         IGetFranchiseSeasonMetricsByIdQueryHandler metricsHandler,
-        IDistributedCache cache,
-        IDateTimeProvider dateTimeProvider)
+        IContestPreviewHistoryCache cache)
     {
         _dbContext = dbContext;
         _sqlProvider = sqlProvider;
         _validator = validator;
         _metricsHandler = metricsHandler;
         _cache = cache;
-        _dateTimeProvider = dateTimeProvider;
-    }
-
-    /// <summary>
-    /// Cache key for one preview-history result.
-    /// </summary>
-    /// <remarks>
-    /// Includes MeetingCount and RecentGameCount deliberately. The query exposes
-    /// both, so two callers asking for different depths must not share an entry.
-    /// Every caller happens to use the 5/5 defaults today, which is precisely why
-    /// keying on contest id alone would have looked correct indefinitely.
-    /// <para>
-    /// The v1 segment is a payload-shape version: changing ContestPreviewHistoryDto
-    /// invalidates every entry by bumping it, rather than serving old shapes to new
-    /// deserializers until the TTL expires.
-    /// </para>
-    /// </remarks>
-    private static string BuildCacheKey(GetContestPreviewHistoryQuery query) =>
-        $"preview-history:v1:{query.ContestId}:{query.MeetingCount}:{query.RecentGameCount}";
-
-    /// <summary>
-    /// How long this result stays valid.
-    /// </summary>
-    /// <remarks>
-    /// Almost everything here is genuinely historical — head-to-head meetings and
-    /// prior-season records cannot change. The exception is the spread:
-    /// <see cref="BuildSpreadContextAsync"/> reads the contest's current line and
-    /// derives favorite, magnitude and ATS bucket from it, and lines move through
-    /// the week. A multi-day entry for an upcoming game would therefore serve a
-    /// stale line dressed up as historical fact.
-    /// <para>
-    /// So: short TTL until the game is 24h past kickoff, long TTL after. An hour
-    /// still collapses thousands of user views into one computation, which is
-    /// where nearly all the benefit lives.
-    /// </para>
-    /// </remarks>
-    private TimeSpan ResolveCacheTtl(DateTime? startDateUtc)
-    {
-        if (startDateUtc is null)
-            return UnresolvedContestTtl;
-
-        var settlesAt = startDateUtc.Value.Add(SettlesAfterStart);
-
-        return _dateTimeProvider.UtcNow() >= settlesAt
-            ? SettledTtl
-            : LiveTtl;
     }
 
     /// <summary>
@@ -136,14 +65,10 @@ public class GetContestPreviewHistoryQueryHandler : IGetContestPreviewHistoryQue
                 validationResult.Errors);
         }
 
-        // Assembling this DTO costs ~10 sequential round trips (head-to-head,
-        // prior-season summaries for both sides, spread target, two margin facts,
-        // two ATS buckets), and it is identical for every user viewing the same
-        // matchup — it is not user-scoped. Cache read sits after validation so a
+        // Assembling this DTO costs ~10 sequential round trips and is identical for
+        // every user viewing the same matchup. Read sits after validation so a
         // malformed query still fails fast.
-        var cacheKey = BuildCacheKey(query);
-
-        var fromCache = await _cache.GetRecordAsync<ContestPreviewHistoryDto>(cacheKey);
+        var fromCache = await _cache.GetAsync(query);
 
         if (fromCache is not null)
             return new Success<ContestPreviewHistoryDto>(fromCache);
@@ -197,7 +122,7 @@ public class GetContestPreviewHistoryQueryHandler : IGetContestPreviewHistoryQue
 
         dto.SpreadContext = await BuildSpreadContextAsync(connection, query.ContestId, cancellationToken);
 
-        await _cache.SetRecordAsync(cacheKey, dto, ResolveCacheTtl(target?.StartDateUtc));
+        await _cache.SetAsync(query, dto, target?.StartDateUtc);
 
         return new Success<ContestPreviewHistoryDto>(dto);
     }

--- a/src/SportsData.Producer/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Producer/DependencyInjection/ServiceRegistration.cs
@@ -397,6 +397,8 @@ namespace SportsData.Producer.DependencyInjection
                 Application.Contests.Queries.Matchups.GetContestPreviewHistory.GetContestPreviewHistoryQueryHandler>();
             services.AddScoped<IValidator<Application.Contests.Queries.Matchups.GetContestPreviewHistory.GetContestPreviewHistoryQuery>,
                 Application.Contests.Queries.Matchups.GetContestPreviewHistory.GetContestPreviewHistoryQueryValidator>();
+            services.AddScoped<Application.Contests.Queries.Matchups.GetContestPreviewHistory.IContestPreviewHistoryCache,
+                Application.Contests.Queries.Matchups.GetContestPreviewHistory.ContestPreviewHistoryCache>();
             services.AddScoped<IGetMatchupResultQueryHandler, GetMatchupResultQueryHandler>();
             services.AddScoped<IGetContestResultsByContestIdsQueryHandler, GetContestResultsByContestIdsQueryHandler>();
             services.AddScoped<IGetFinalizedContestIdsQueryHandler, GetFinalizedContestIdsQueryHandler>();


### PR DESCRIPTION
Builds on #692, which registered `AddCaching` in Producer — `IDistributedCache` didn't previously resolve there.

## Why this query

Assembling `ContestPreviewHistoryDto` costs roughly **ten sequential database round trips per contest**: head-to-head meetings, prior-season results, the contest lookup, a prior-season summary for each side, the spread target, two margin facts, two ATS buckets.

It's served to every user opening a matchup's History tab *and* again to AI preview generation. And it isn't user-scoped — one entry serves everyone looking at the same game.

## TTL is derived from kickoff, not fixed

Almost everything in the payload is genuinely historical: head-to-head meetings and prior-season records are settled facts.

**The exception is the spread.** `BuildSpreadContextAsync` reads the contest's *current* line and derives favorite, underdog, magnitude and the ATS key-number bucket from it — and lines move through the week. A multi-day entry for an upcoming game would serve a stale line dressed up as historical fact. That's the one way this cache could actively mislead rather than merely lag, so the TTL is shaped around it:

| Contest state | TTL | Why |
|---|---|---|
| More than 24h past kickoff | 7 days | Inputs frozen; nothing can change |
| Before that | 1 hour | Spread still moving |
| Contest id unresolvable | 5 minutes | Don't pin an empty result for a contest that isn't sourced yet |

An hour still collapses thousands of user views into one computation, which is where nearly all the benefit lives.

Clock comes from `IDateTimeProvider` rather than `DateTime.UtcNow`, so the boundary is testable.

## Cache key

```
preview-history:v1:{ContestId}:{MeetingCount}:{RecentGameCount}
```

The paging parameters are in the key because the query exposes them and two callers asking for different depths must not share an entry. **Every caller uses the 5/5 defaults today** — which is exactly why keying on contest id alone would have looked correct indefinitely. Same shape of bug as the `QueryCachingBehavior` deleted in #692, just narrower.

`v1` is a payload version: changing the DTO invalidates every entry by bumping it, rather than feeding old shapes to new deserializers until they expire.

The read sits after validation, so a malformed query still fails fast.

## Not in this PR

Pre-warming on `PickemGroupWeekMatchupsGenerated` (there's a TODO in the tree for it). That's cross-service — the API would enqueue work that lands in Producer — and warming ~60 contests at once needs a throttling decision. Its own PR.

Explicit eviction on `ContestFinalized` is also deferred: the TTL boundary already covers it, since a contest crossing kickoff+24h transitions to the settled tier on its next miss.

## Verification

- Build: SportsData.Producer — 0 errors
- Tests: Producer **633 passed, 0 failed**, 18 skipped

Analysis in `docs/audit/caching-vertical-2026-08.md` (uncommitted in the tree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnJySMvfUPeQSMufNNcKSK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved contest preview history loading with distributed caching.
  * Cached results are returned faster when available, while validation continues before retrieval.
  * Cache refresh timing now adapts to contest status and time since kickoff, helping keep previews current while reducing unnecessary processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->