### PR TITLE
feat(api): cache league week matchups, never while a game is live

### DIFF
--- a/src/SportsData.Api/Application/UI/Leagues/Queries/GetLeagueWeekMatchups/GetLeagueWeekMatchupsQueryHandler.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Queries/GetLeagueWeekMatchups/GetLeagueWeekMatchupsQueryHandler.cs
@@ -28,19 +28,22 @@ public class GetLeagueWeekMatchupsQueryHandler : IGetLeagueWeekMatchupsQueryHand
     private readonly IContestClientFactory _contestClientFactory;
     private readonly IDateTimeProvider _dateTimeProvider;
     private readonly ILeagueMembershipGuard _membershipGuard;
+    private readonly ILeagueWeekMatchupsCache _cache;
 
     public GetLeagueWeekMatchupsQueryHandler(
         ILogger<GetLeagueWeekMatchupsQueryHandler> logger,
         AppDataContext dbContext,
         IContestClientFactory contestClientFactory,
         IDateTimeProvider dateTimeProvider,
-        ILeagueMembershipGuard membershipGuard)
+        ILeagueMembershipGuard membershipGuard,
+        ILeagueWeekMatchupsCache cache)
     {
         _logger = logger;
         _dbContext = dbContext;
         _contestClientFactory = contestClientFactory;
         _dateTimeProvider = dateTimeProvider;
         _membershipGuard = membershipGuard;
+        _cache = cache;
     }
 
     public async Task<Result<LeagueWeekMatchupsDto>> ExecuteAsync(
@@ -62,6 +65,21 @@ public class GetLeagueWeekMatchupsQueryHandler : IGetLeagueWeekMatchupsQueryHand
             query.UserId,
             query.LeagueId,
             query.Week);
+
+        // Read sits AFTER the membership guard, never before: the guard is the only
+        // per-user thing here and must run on every request. The payload itself is
+        // league-scoped, so one entry serves every member.
+        var fromCache = await _cache.GetAsync(query.LeagueId, query.Week);
+
+        if (fromCache is not null)
+        {
+            _logger.LogDebug(
+                "League week matchups served from cache, leagueId={LeagueId}, week={Week}",
+                query.LeagueId,
+                query.Week);
+
+            return new Success<LeagueWeekMatchupsDto>(fromCache);
+        }
 
         try
         {
@@ -363,6 +381,9 @@ public class GetLeagueWeekMatchupsQueryHandler : IGetLeagueWeekMatchupsQueryHand
                 query.UserId,
                 result.Matchups.Count,
                 producerLegMs);
+
+            // No-ops while any contest in the week is live — see the cache's TTL policy.
+            await _cache.SetAsync(query.LeagueId, query.Week, result);
 
             return new Success<LeagueWeekMatchupsDto>(result);
         }

--- a/src/SportsData.Api/Application/UI/Leagues/Queries/GetLeagueWeekMatchups/LeagueWeekMatchupsCache.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Queries/GetLeagueWeekMatchups/LeagueWeekMatchupsCache.cs
@@ -1,0 +1,118 @@
+using Microsoft.Extensions.Caching.Distributed;
+
+using SportsData.Api.Application.UI.Leagues.Dtos;
+using SportsData.Core.Extensions;
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace SportsData.Api.Application.UI.Leagues.Queries.GetLeagueWeekMatchups;
+
+/// <summary>
+/// Caching policy for a league's week of matchups: key shape, entry lifetime, and
+/// — most importantly — when NOT to cache at all.
+/// </summary>
+/// <remarks>
+/// Lives in the slice rather than shared infrastructure because the rules below are
+/// statements about football game states, not something another feature would reuse.
+/// </remarks>
+public interface ILeagueWeekMatchupsCache
+{
+    Task<LeagueWeekMatchupsDto?> GetAsync(Guid leagueId, int week);
+
+    /// <summary>
+    /// Stores the payload if — and only if — its contents are safe to serve again.
+    /// A no-op while any contest in the week is live.
+    /// </summary>
+    Task SetAsync(Guid leagueId, int week, LeagueWeekMatchupsDto dto);
+}
+
+/// <inheritdoc />
+public sealed class LeagueWeekMatchupsCache : ILeagueWeekMatchupsCache
+{
+    /// <summary>Every contest finished. Results are frozen.</summary>
+    private static readonly TimeSpan SettledTtl = TimeSpan.FromMinutes(30);
+
+    /// <summary>Nothing has kicked off yet. Metadata drifts slowly; spreads move but not by the minute.</summary>
+    private static readonly TimeSpan PregameTtl = TimeSpan.FromMinutes(5);
+
+    private const string ScheduledStatus = "STATUS_SCHEDULED";
+    private const string FinalStatus = "STATUS_FINAL";
+
+    private readonly IDistributedCache _cache;
+
+    public LeagueWeekMatchupsCache(IDistributedCache cache)
+    {
+        _cache = cache;
+    }
+
+    public Task<LeagueWeekMatchupsDto?> GetAsync(Guid leagueId, int week) =>
+        _cache.GetRecordAsync<LeagueWeekMatchupsDto>(BuildKey(leagueId, week));
+
+    public async Task SetAsync(Guid leagueId, int week, LeagueWeekMatchupsDto dto)
+    {
+        var ttl = ResolveTtl(dto);
+
+        if (ttl is null)
+            return;
+
+        await _cache.SetRecordAsync(BuildKey(leagueId, week), dto, ttl.Value);
+    }
+
+    /// <summary>
+    /// Key is league + week only.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately NOT keyed by user. The query takes a UserId, but it is used solely
+    /// for the membership guard and logging — no per-user pick data reaches this payload.
+    /// One entry therefore serves every member of the league, which is the entire point.
+    /// If per-user content is ever added here, this key becomes a data-leakage bug and
+    /// must gain the user id (or the caching must be removed).
+    /// </remarks>
+    private static string BuildKey(Guid leagueId, int week) =>
+        $"league-week-matchups:v1:{leagueId}:{week}";
+
+    /// <summary>
+    /// Lifetime for this payload, or null to mean "do not cache".
+    /// </summary>
+    /// <remarks>
+    /// This payload carries live game state — Status, Period, Clock, AwayScore,
+    /// HomeScore — merged in from Producer. Serving a cached copy while a game is in
+    /// progress would freeze the scoreboard on the surface users are watching precisely
+    /// because it is changing. So we do not cache at all while anything is live: during
+    /// game windows the behaviour is identical to having no cache.
+    /// <para>
+    /// That costs nothing. Under load the database is not the constraint here — measured
+    /// at one active Postgres connection against fifty concurrent users — so the win from
+    /// caching is in the long tail of pre- and post-game browsing, which is exactly what
+    /// this still covers.
+    /// </para>
+    /// <para>
+    /// Unrecognised or missing statuses are treated as live. Failing closed means a new
+    /// or unexpected ESPN status degrades to today's behaviour rather than silently
+    /// pinning a stale scoreboard.
+    /// </para>
+    /// </remarks>
+    private static TimeSpan? ResolveTtl(LeagueWeekMatchupsDto dto)
+    {
+        if (dto.Matchups.Count == 0)
+            return PregameTtl;
+
+        var statuses = dto.Matchups.Select(m => m.Status).ToList();
+
+        if (statuses.Any(s => !IsScheduled(s) && !IsFinal(s)))
+            return null;
+
+        return statuses.All(IsFinal)
+            ? SettledTtl
+            : PregameTtl;
+    }
+
+    private static bool IsScheduled(string? status) =>
+        string.Equals(status, ScheduledStatus, StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsFinal(string? status) =>
+        status is not null &&
+        status.StartsWith(FinalStatus, StringComparison.OrdinalIgnoreCase);
+}

--- a/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
@@ -181,6 +181,7 @@ namespace SportsData.Api.DependencyInjection
             services.AddScoped<IGetInviteableUsersQueryHandler, GetInviteableUsersQueryHandler>();
             services.AddScoped<IGetLeagueScoresByWeekQueryHandler, GetLeagueScoresByWeekQueryHandler>();
             services.AddScoped<IGetLeagueWeekMatchupsQueryHandler, GetLeagueWeekMatchupsQueryHandler>();
+            services.AddScoped<ILeagueWeekMatchupsCache, LeagueWeekMatchupsCache>();
             services.AddScoped<IGetLeagueWeekOverviewQueryHandler, GetLeagueWeekOverviewQueryHandler>();
             services.AddScoped<IGetPublicLeaguesQueryHandler, GetPublicLeaguesQueryHandler>();
             services.AddScoped<IGetUserLeaguesQueryHandler, GetUserLeaguesQueryHandler>();

--- a/src/SportsData.Api/Program.cs
+++ b/src/SportsData.Api/Program.cs
@@ -184,6 +184,13 @@ namespace SportsData.Api
 
             services.AddCoreServices(config);
 
+            // Distributed cache (Redis). The API had none until now — AddMemoryCache
+            // earlier is per-pod and serves Firebase token validation only. Registered
+            // here so a league's week of matchups is cached once for every member rather
+            // than recomputed per request, per pod.
+            // See docs/audit/caching-vertical-2026-08.md.
+            services.AddCaching(config, builder.Environment.ApplicationName);
+
             // Add OpenTelemetry instrumentation
             services.AddInstrumentation(builder.Environment.ApplicationName, config);
 

--- a/test/unit/SportsData.Api.Tests.Unit/Application/UI/Leagues/LeagueWeekMatchupsCacheTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/UI/Leagues/LeagueWeekMatchupsCacheTests.cs
@@ -1,0 +1,222 @@
+using FluentAssertions;
+
+using Microsoft.Extensions.Caching.Distributed;
+
+using Moq;
+
+using SportsData.Api.Application.UI.Leagues.Dtos;
+using SportsData.Api.Application.UI.Leagues.Queries.GetLeagueWeekMatchups;
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Xunit;
+
+namespace SportsData.Api.Tests.Unit.Application.UI.Leagues;
+
+/// <summary>
+/// The league-week matchups payload carries live game state — Status, Period, Clock,
+/// AwayScore, HomeScore. Serving a cached copy mid-game would freeze the scoreboard on
+/// the surface users watch precisely because it is moving. These tests pin the rule that
+/// prevents that: while anything in the week is live, nothing is written to the cache.
+/// </summary>
+public class LeagueWeekMatchupsCacheTests
+{
+    private static readonly Guid LeagueId = Guid.Parse("0b5f2f8a-1111-2222-3333-444455556666");
+    private const int Week = 1;
+
+    private static LeagueWeekMatchupsDto DtoWithStatuses(params string?[] statuses)
+    {
+        var dto = new LeagueWeekMatchupsDto();
+
+        foreach (var status in statuses)
+        {
+            dto.Matchups.Add(new LeagueWeekMatchupsDto.MatchupForPickDto { Status = status });
+        }
+
+        return dto;
+    }
+
+    private static (LeagueWeekMatchupsCache Cache, Mock<IDistributedCache> Store) BuildSut()
+    {
+        var store = new Mock<IDistributedCache>();
+        return (new LeagueWeekMatchupsCache(store.Object), store);
+    }
+
+    private static void VerifyWritten(Mock<IDistributedCache> store, Times times) =>
+        store.Verify(
+            x => x.SetAsync(
+                It.IsAny<string>(),
+                It.IsAny<byte[]>(),
+                It.IsAny<DistributedCacheEntryOptions>(),
+                It.IsAny<CancellationToken>()),
+            times);
+
+    [Theory]
+    [InlineData("STATUS_IN_PROGRESS")]
+    [InlineData("STATUS_HALFTIME")]
+    [InlineData("STATUS_END_PERIOD")]
+    [InlineData("STATUS_DELAYED")]
+    public async Task SetAsync_DoesNotCache_WhenAnyContestIsLive(string liveStatus)
+    {
+        var (cache, store) = BuildSut();
+
+        // One live game among finished ones is still a live week.
+        var dto = DtoWithStatuses("STATUS_FINAL", liveStatus, "STATUS_FINAL");
+
+        await cache.SetAsync(LeagueId, Week, dto);
+
+        VerifyWritten(store, Times.Never());
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("SOMETHING_ESPN_INVENTED_LATER")]
+    public async Task SetAsync_DoesNotCache_WhenAStatusIsUnrecognised(string? unknownStatus)
+    {
+        var (cache, store) = BuildSut();
+
+        var dto = DtoWithStatuses("STATUS_SCHEDULED", unknownStatus);
+
+        await cache.SetAsync(LeagueId, Week, dto);
+
+        // Fail closed: an unfamiliar status degrades to no caching rather than
+        // silently pinning a stale scoreboard.
+        VerifyWritten(store, Times.Never());
+    }
+
+    [Fact]
+    public async Task SetAsync_Caches_WhenEveryContestIsScheduled()
+    {
+        var (cache, store) = BuildSut();
+
+        var dto = DtoWithStatuses("STATUS_SCHEDULED", "STATUS_SCHEDULED");
+
+        await cache.SetAsync(LeagueId, Week, dto);
+
+        VerifyWritten(store, Times.Once());
+    }
+
+    [Fact]
+    public async Task SetAsync_Caches_WhenEveryContestIsFinal()
+    {
+        var (cache, store) = BuildSut();
+
+        var dto = DtoWithStatuses("STATUS_FINAL", "STATUS_FINAL_OT");
+
+        await cache.SetAsync(LeagueId, Week, dto);
+
+        VerifyWritten(store, Times.Once());
+    }
+
+    [Fact]
+    public async Task SetAsync_Caches_WhenWeekMixesScheduledAndFinal()
+    {
+        var (cache, store) = BuildSut();
+
+        // Mid-week: some games played, none in progress. Safe to serve again.
+        var dto = DtoWithStatuses("STATUS_FINAL", "STATUS_SCHEDULED");
+
+        await cache.SetAsync(LeagueId, Week, dto);
+
+        VerifyWritten(store, Times.Once());
+    }
+
+    [Fact]
+    public async Task SetAsync_UsesALongerLifetime_OnceEveryContestIsFinal()
+    {
+        var (cache, store) = BuildSut();
+
+        DistributedCacheEntryOptions? finalOptions = null;
+        DistributedCacheEntryOptions? pregameOptions = null;
+
+        store.Setup(x => x.SetAsync(
+                It.IsAny<string>(),
+                It.IsAny<byte[]>(),
+                It.IsAny<DistributedCacheEntryOptions>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<string, byte[], DistributedCacheEntryOptions, CancellationToken>(
+                (_, _, options, _) => finalOptions = options)
+            .Returns(Task.CompletedTask);
+
+        await cache.SetAsync(LeagueId, Week, DtoWithStatuses("STATUS_FINAL"));
+
+        store.Setup(x => x.SetAsync(
+                It.IsAny<string>(),
+                It.IsAny<byte[]>(),
+                It.IsAny<DistributedCacheEntryOptions>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<string, byte[], DistributedCacheEntryOptions, CancellationToken>(
+                (_, _, options, _) => pregameOptions = options)
+            .Returns(Task.CompletedTask);
+
+        await cache.SetAsync(LeagueId, Week, DtoWithStatuses("STATUS_SCHEDULED"));
+
+        finalOptions!.AbsoluteExpirationRelativeToNow
+            .Should().BeGreaterThan(pregameOptions!.AbsoluteExpirationRelativeToNow!.Value);
+    }
+
+    [Fact]
+    public async Task SetAsync_Caches_WhenTheWeekHasNoMatchups()
+    {
+        var (cache, store) = BuildSut();
+
+        // An empty week has no live state to go stale.
+        await cache.SetAsync(LeagueId, Week, new LeagueWeekMatchupsDto());
+
+        VerifyWritten(store, Times.Once());
+    }
+
+    [Fact]
+    public async Task GetAsync_And_SetAsync_AgreeOnTheKey()
+    {
+        var (cache, store) = BuildSut();
+
+        string? writtenKey = null;
+
+        store.Setup(x => x.SetAsync(
+                It.IsAny<string>(),
+                It.IsAny<byte[]>(),
+                It.IsAny<DistributedCacheEntryOptions>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<string, byte[], DistributedCacheEntryOptions, CancellationToken>(
+                (key, _, _, _) => writtenKey = key)
+            .Returns(Task.CompletedTask);
+
+        await cache.SetAsync(LeagueId, Week, DtoWithStatuses("STATUS_SCHEDULED"));
+        await cache.GetAsync(LeagueId, Week);
+
+        store.Verify(
+            x => x.GetAsync(writtenKey!, It.IsAny<CancellationToken>()),
+            Times.Once());
+    }
+
+    [Fact]
+    public async Task Key_IsScopedToLeagueAndWeek()
+    {
+        var (cache, store) = BuildSut();
+
+        var keys = new List<string>();
+
+        store.Setup(x => x.SetAsync(
+                It.IsAny<string>(),
+                It.IsAny<byte[]>(),
+                It.IsAny<DistributedCacheEntryOptions>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<string, byte[], DistributedCacheEntryOptions, CancellationToken>(
+                (key, _, _, _) => keys.Add(key))
+            .Returns(Task.CompletedTask);
+
+        var otherLeague = Guid.Parse("99999999-8888-7777-6666-555544443333");
+
+        await cache.SetAsync(LeagueId, 1, DtoWithStatuses("STATUS_SCHEDULED"));
+        await cache.SetAsync(LeagueId, 2, DtoWithStatuses("STATUS_SCHEDULED"));
+        await cache.SetAsync(otherLeague, 1, DtoWithStatuses("STATUS_SCHEDULED"));
+
+        keys.Should().OnlyHaveUniqueItems(
+            "a league or week must never collide with another league or week");
+    }
+}


### PR DESCRIPTION
This is item 5 of the caching plan. **Item 4 turned out not to be worth building — reasoning at the bottom.**

## Why this is cacheable

`UserId` reaches `GetLeagueWeekMatchupsQueryHandler` only for the membership guard and logging. No per-user pick data is in the response, so the payload is **league-scoped** and one entry serves every member.

## The hazard, and the rule

The same payload carries live game state — `Status`, `Period`, `Clock`, `AwayScore`, `HomeScore` — merged in from Producer. Serving a cached copy mid-game would **freeze the scoreboard** on the one surface people watch precisely because it's moving.

So: **do not cache at all while anything in the week is live.**

| Week state | Behaviour |
|---|---|
| Any contest live | **No caching.** Identical to today. |
| All scheduled | 5 minutes |
| All final | 30 minutes |
| Any status unrecognised or null | **No caching** (fail closed) |

During game windows this change is a no-op by construction, which is the property that makes it safe to ship into a season. It costs nothing measurable: under load the database isn't the constraint on this path — one active Postgres connection against fifty concurrent VUs — so the win was always in the long tail of pre- and post-game browsing, which this still covers.

Failing closed on unknown statuses means a status ESPN invents later degrades to today's behaviour rather than silently pinning a stale scoreboard.

## Ordering that matters

The cache read sits **after** the membership guard, never before. The guard is the only per-user step and must run on every request — skipping it would turn a performance change into an authorization bug. See `docs/audit/league-authorization-idor.md`.

The cache key is league + week and deliberately excludes the user. If per-user content is ever added to this payload, that key becomes a data-leakage bug; there's a comment on it saying so.

## Also here

`AddCaching` is now registered in the API, which had **no distributed cache at all** — `AddMemoryCache` there is per-pod and serves Firebase token validation only.

Caching policy lives beside the query and handler in the slice rather than in `Core`, per the VSA correction on #693. These rules are statements about football game states, not something another feature reuses.

## Verification

- Build: SportsData.Api — 0 errors *(worth noting given the API PR gate doesn't compile)*
- Tests: Api **770 passed, 0 failed** — 14 new, pinning the live-bypass across in-progress, halftime, end-of-period, delayed, null, empty and unknown-future statuses

## On item 4 — pre-warming — which I did not build

My audit recommended warming preview history on `PickemGroupWeekMatchupsGenerated` so "the first user of the week gets a hit". Checking the code, that doesn't hold:

1. `MatchupPreviewProcessor` **already** calls `GetContestPreviewHistory` during preview generation, so those contests are warmed as a side effect.
2. Generation happens *days* before kickoff, and #693 set the pre-game TTL to **1 hour** because the spread moves.

So any warm at league-creation time expires long before a user looks. My recommendation assumed a long pre-game TTL and I then chose a short one for correctness — the two don't compose, and that's my error.

What would actually work is a recurring warm during the pre-game window, refreshing at the TTL cadence. That means **a new recurring job**, which given how the Sunday sweeps behaved last weekend is a decision worth making deliberately rather than as a rider. The `TODO` remains in the tree, unclaimed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnJySMvfUPeQSMufNNcKSK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance Improvements**
  - League week matchup results are now cached to speed up repeated requests.
  - Cached results expire appropriately based on matchup status, helping keep active data current.
  - Unrecognized or in-progress matchup statuses are excluded from caching to avoid serving unreliable results.

- **Reliability**
  - Empty weeks and different league/week combinations are handled consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->