### PR TITLE
fix(producer): key preview history by the spread instead of racing it with a TTL

### DIFF
--- a/src/SportsData.Producer/Application/Contests/Queries/Matchups/GetContestPreviewHistory/ContestPreviewHistoryCache.cs
+++ b/src/SportsData.Producer/Application/Contests/Queries/Matchups/GetContestPreviewHistory/ContestPreviewHistoryCache.cs
@@ -1,10 +1,10 @@
 using Microsoft.Extensions.Caching.Distributed;
 
-using SportsData.Core.Common;
 using SportsData.Core.Dtos.Canonical;
 using SportsData.Core.Extensions;
 
 using System;
+using System.Globalization;
 using System.Threading.Tasks;
 
 namespace SportsData.Producer.Application.Contests.Queries.Matchups.GetContestPreviewHistory;
@@ -17,31 +17,39 @@ namespace SportsData.Producer.Application.Contests.Queries.Matchups.GetContestPr
 /// preview history is; how long an answer stays true, and how it is addressed in a
 /// key-value store, is a different concern and reads as noise inside it. It lives in
 /// this slice rather than a shared infrastructure namespace because the policy is
-/// specific to this query — the lifetime rule below is a statement about spreads and
-/// kickoff times, not something another feature would reuse.
+/// specific to this query.
 /// </remarks>
 public interface IContestPreviewHistoryCache
 {
-    Task<ContestPreviewHistoryDto?> GetAsync(GetContestPreviewHistoryQuery query);
+    /// <param name="homeSpread">
+    /// The contest's current home spread, or null when it has no line. Part of the key —
+    /// see <see cref="ContestPreviewHistoryCache.BuildKey"/>.
+    /// </param>
+    Task<ContestPreviewHistoryDto?> GetAsync(
+        GetContestPreviewHistoryQuery query,
+        double? homeSpread);
 
     /// <param name="contestStartUtc">
-    /// Kickoff for the contest, or null when the id resolved to nothing. Drives the
-    /// entry lifetime — see the implementation.
+    /// Kickoff, or null when the contest id resolved to nothing.
+    /// </param>
+    /// <param name="homeSpread">
+    /// The contest's current home spread, or null when it has no line.
     /// </param>
     Task SetAsync(
         GetContestPreviewHistoryQuery query,
         ContestPreviewHistoryDto dto,
-        DateTime? contestStartUtc);
+        DateTime? contestStartUtc,
+        double? homeSpread);
 }
 
 /// <inheritdoc />
 public sealed class ContestPreviewHistoryCache : IContestPreviewHistoryCache
 {
-    /// <summary>Lifetime once the contest's inputs have frozen.</summary>
-    private static readonly TimeSpan SettledTtl = TimeSpan.FromDays(7);
-
-    /// <summary>Lifetime while the contest is still ahead of us — short, because the spread moves.</summary>
-    private static readonly TimeSpan LiveTtl = TimeSpan.FromHours(1);
+    /// <summary>
+    /// Lifetime for a resolved contest. Long, because the line is in the key rather than
+    /// governed by expiry — see <see cref="ResolveTtl"/>.
+    /// </summary>
+    private static readonly TimeSpan ResolvedTtl = TimeSpan.FromDays(7);
 
     /// <summary>
     /// Lifetime for a contest id that resolved to nothing. Brief, so a request arriving
@@ -49,72 +57,75 @@ public sealed class ContestPreviewHistoryCache : IContestPreviewHistoryCache
     /// </summary>
     private static readonly TimeSpan UnresolvedContestTtl = TimeSpan.FromMinutes(5);
 
-    /// <summary>How long after kickoff the inputs are considered frozen.</summary>
-    private static readonly TimeSpan SettlesAfterStart = TimeSpan.FromHours(24);
-
     private readonly IDistributedCache _cache;
-    private readonly IDateTimeProvider _dateTimeProvider;
 
-    public ContestPreviewHistoryCache(
-        IDistributedCache cache,
-        IDateTimeProvider dateTimeProvider)
+    public ContestPreviewHistoryCache(IDistributedCache cache)
     {
         _cache = cache;
-        _dateTimeProvider = dateTimeProvider;
     }
 
-    public Task<ContestPreviewHistoryDto?> GetAsync(GetContestPreviewHistoryQuery query) =>
-        _cache.GetRecordAsync<ContestPreviewHistoryDto>(BuildKey(query));
+    public Task<ContestPreviewHistoryDto?> GetAsync(
+        GetContestPreviewHistoryQuery query,
+        double? homeSpread) =>
+        _cache.GetRecordAsync<ContestPreviewHistoryDto>(BuildKey(query, homeSpread));
 
     public Task SetAsync(
         GetContestPreviewHistoryQuery query,
         ContestPreviewHistoryDto dto,
-        DateTime? contestStartUtc) =>
-        _cache.SetRecordAsync(BuildKey(query), dto, ResolveTtl(contestStartUtc));
+        DateTime? contestStartUtc,
+        double? homeSpread) =>
+        _cache.SetRecordAsync(
+            BuildKey(query, homeSpread),
+            dto,
+            ResolveTtl(contestStartUtc));
 
     /// <summary>
     /// Key for one preview-history result.
     /// </summary>
     /// <remarks>
-    /// MeetingCount and RecentGameCount are included deliberately: the query exposes
-    /// both, so two callers asking for different depths must not share an entry. Every
-    /// caller happens to use the 5/5 defaults today, which is precisely why keying on
-    /// contest id alone would have looked correct indefinitely.
+    /// The home spread is part of the key, and that is what makes a long lifetime safe.
+    /// Every other input is settled history — past meetings, prior-season records — so the
+    /// only thing that can make a cached answer wrong is the line moving. Keying on it
+    /// means a move produces a different key and the answer is recomputed, instead of a
+    /// timer racing the sportsbook.
     /// <para>
-    /// The v1 segment is a payload version — changing ContestPreviewHistoryDto
-    /// invalidates every entry by bumping it, rather than feeding old shapes to new
-    /// deserializers until they expire.
+    /// The SIGNED value, not the magnitude: a line crossing zero swaps favorite and
+    /// underdog, so -3 and +3 are different answers, not the same one.
+    /// </para>
+    /// <para>
+    /// MeetingCount and RecentGameCount are included because the query exposes both, and
+    /// two callers asking for different depths must not share an entry. Every caller uses
+    /// the 5/5 defaults today, which is precisely why keying on contest id alone would
+    /// have looked correct indefinitely.
+    /// </para>
+    /// <para>
+    /// v1 is a payload version — changing ContestPreviewHistoryDto invalidates every entry
+    /// by bumping it, rather than feeding old shapes to new deserializers.
     /// </para>
     /// </remarks>
-    private static string BuildKey(GetContestPreviewHistoryQuery query) =>
-        $"preview-history:v1:{query.ContestId}:{query.MeetingCount}:{query.RecentGameCount}";
+    private static string BuildKey(GetContestPreviewHistoryQuery query, double? homeSpread)
+    {
+        var spread = homeSpread?.ToString("0.##", CultureInfo.InvariantCulture) ?? "none";
+
+        return $"preview-history:v1:{query.ContestId}:{query.MeetingCount}:{query.RecentGameCount}:s{spread}";
+    }
 
     /// <summary>
     /// How long a result stays true.
     /// </summary>
     /// <remarks>
-    /// Almost everything in the payload is genuinely historical — head-to-head meetings
-    /// and prior-season records are settled facts. The exception is the spread: the
-    /// handler's spread context reads the contest's CURRENT line and derives favorite,
-    /// underdog, magnitude and the ATS key-number bucket from it, and lines move through
-    /// the week. A multi-day entry for an upcoming game would therefore serve a stale
-    /// line dressed up as historical fact, which is the one way this cache could
-    /// actively mislead rather than merely lag.
+    /// Long for any contest we could resolve. Correctness against a moving line is handled
+    /// by the key, not by expiry, so the TTL exists only as a backstop against unbounded
+    /// growth and against slow drift in inputs we do not key on.
     /// <para>
-    /// Hence short until the game is well past kickoff, long afterwards. An hour still
-    /// collapses thousands of user views into a single computation, which is where
-    /// nearly all the benefit lives.
+    /// This endpoint is read almost entirely BEFORE kickoff, while people are deciding
+    /// picks; after the game nobody opens it. An expiry short enough to keep a line honest
+    /// would therefore have expired during the only window that matters — which is why the
+    /// line moved into the key instead.
     /// </para>
     /// </remarks>
-    private TimeSpan ResolveTtl(DateTime? contestStartUtc)
-    {
-        if (contestStartUtc is null)
-            return UnresolvedContestTtl;
-
-        var settlesAt = contestStartUtc.Value.Add(SettlesAfterStart);
-
-        return _dateTimeProvider.UtcNow() >= settlesAt
-            ? SettledTtl
-            : LiveTtl;
-    }
+    private static TimeSpan ResolveTtl(DateTime? contestStartUtc) =>
+        contestStartUtc is null
+            ? UnresolvedContestTtl
+            : ResolvedTtl;
 }

--- a/src/SportsData.Producer/Application/Contests/Queries/Matchups/GetContestPreviewHistory/GetContestPreviewHistoryQueryHandler.cs
+++ b/src/SportsData.Producer/Application/Contests/Queries/Matchups/GetContestPreviewHistory/GetContestPreviewHistoryQueryHandler.cs
@@ -65,15 +65,34 @@ public class GetContestPreviewHistoryQueryHandler : IGetContestPreviewHistoryQue
                 validationResult.Errors);
         }
 
-        // Assembling this DTO costs ~10 sequential round trips and is identical for
-        // every user viewing the same matchup. Read sits after validation so a
-        // malformed query still fails fast.
-        var fromCache = await _cache.GetAsync(query);
+        var connection = _dbContext.Database.GetDbConnection();
+
+        // The spread is fetched BEFORE the cache read, and its value goes into the key.
+        //
+        // Everything else in this payload is settled history, so the only thing that can
+        // make a cached answer wrong is the line moving. Putting the line in the key makes
+        // that impossible by construction: when it moves, the key changes and we recompute
+        // — no TTL guessing, and no window in which we serve spread-conditioned facts
+        // derived from a line that no longer exists.
+        //
+        // This matters because this endpoint is read almost entirely BEFORE kickoff, while
+        // people are deciding picks. A time-based expiry short enough to keep the line
+        // honest would expire during the exact window the feature is used.
+        //
+        // Cost is one indexed read on the hot path, against a database measured at one
+        // active connection under fifty concurrent users. A hit still avoids the other
+        // nine round trips.
+        var spreadTarget = await connection.QueryFirstOrDefaultAsync<SpreadTargetRow>(
+            new CommandDefinition(
+                _sqlProvider.GetContestSpreadTarget(),
+                new { query.ContestId },
+                cancellationToken: cancellationToken));
+
+        // Read sits after validation so a malformed query still fails fast.
+        var fromCache = await _cache.GetAsync(query, spreadTarget?.HomeSpread);
 
         if (fromCache is not null)
             return new Success<ContestPreviewHistoryDto>(fromCache);
-
-        var connection = _dbContext.Database.GetDbConnection();
 
         var headToHead = (await connection.QueryAsync<PreviewGameResultDto>(
             new CommandDefinition(
@@ -120,9 +139,9 @@ public class GetContestPreviewHistoryQueryHandler : IGetContestPreviewHistoryQue
                 target.HomeTeamFranchiseSeasonId, target.SeasonYear, cancellationToken);
         }
 
-        dto.SpreadContext = await BuildSpreadContextAsync(connection, query.ContestId, cancellationToken);
+        dto.SpreadContext = await BuildSpreadContextAsync(connection, spreadTarget, cancellationToken);
 
-        await _cache.SetAsync(query, dto, target?.StartDateUtc);
+        await _cache.SetAsync(query, dto, target?.StartDateUtc, spreadTarget?.HomeSpread);
 
         return new Success<ContestPreviewHistoryDto>(dto);
     }
@@ -182,17 +201,15 @@ public class GetContestPreviewHistoryQueryHandler : IGetContestPreviewHistoryQue
     /// odds era only). Null when the contest has no line — the block is
     /// spread-derived and meaningless without one.
     /// </summary>
+    /// <param name="target">
+    /// Already fetched by ExecuteAsync to build the cache key — passed in rather than
+    /// re-queried, so keying by spread costs no extra round trip on a miss.
+    /// </param>
     private async Task<PreviewSpreadContextDto?> BuildSpreadContextAsync(
         System.Data.Common.DbConnection connection,
-        Guid contestId,
+        SpreadTargetRow? target,
         CancellationToken cancellationToken)
     {
-        var target = await connection.QueryFirstOrDefaultAsync<SpreadTargetRow>(
-            new CommandDefinition(
-                _sqlProvider.GetContestSpreadTarget(),
-                new { ContestId = contestId },
-                cancellationToken: cancellationToken));
-
         if (target?.HomeSpread is null || target.HomeSpread.Value == 0)
             return null;
 

--- a/src/SportsData.Producer/Application/Contests/Queries/Matchups/GetContestPreviewHistory/RegenerateContestPreviewHistoryJob.cs
+++ b/src/SportsData.Producer/Application/Contests/Queries/Matchups/GetContestPreviewHistory/RegenerateContestPreviewHistoryJob.cs
@@ -1,0 +1,81 @@
+using SportsData.Core.Common;
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SportsData.Producer.Application.Contests.Queries.Matchups.GetContestPreviewHistory;
+
+/// <summary>
+/// Rebuilds a contest's cached preview history after its line moves.
+/// </summary>
+public interface IRegenerateContestPreviewHistoryJob
+{
+    Task RegenerateAsync(Guid contestId);
+}
+
+/// <inheritdoc />
+public class RegenerateContestPreviewHistoryJob : IRegenerateContestPreviewHistoryJob
+{
+    private readonly ILogger<RegenerateContestPreviewHistoryJob> _logger;
+    private readonly IGetContestPreviewHistoryQueryHandler _handler;
+
+    public RegenerateContestPreviewHistoryJob(
+        ILogger<RegenerateContestPreviewHistoryJob> logger,
+        IGetContestPreviewHistoryQueryHandler handler)
+    {
+        _logger = logger;
+        _handler = handler;
+    }
+
+    /// <summary>
+    /// Runs the query, which populates the cache entry for the contest's CURRENT line.
+    /// </summary>
+    /// <remarks>
+    /// The cache is keyed by the spread, so a line move produces a new key that nothing
+    /// has populated yet. Left alone, the next person to open the matchup dialog would
+    /// pay the full ~10 round trips to fill it. Running it here, off the request path and
+    /// immediately after the odds are persisted, means the entry is already warm by the
+    /// time anyone asks.
+    /// <para>
+    /// This is why the preview-history cache does not need a recurring warm job or a
+    /// short expiry: line movement is the only thing that invalidates it, and line
+    /// movement already publishes an event. React to that and there is no window in which
+    /// a user can take the hit.
+    /// </para>
+    /// <para>
+    /// Failures are logged and swallowed. This is a cache warm — if it does not run, the
+    /// next reader simply recomputes, which is the behaviour we had before. Throwing would
+    /// hand a retry storm to Hangfire in exchange for nothing.
+    /// </para>
+    /// </remarks>
+    public async Task RegenerateAsync(Guid contestId)
+    {
+        try
+        {
+            var result = await _handler.ExecuteAsync(
+                new GetContestPreviewHistoryQuery(contestId),
+                CancellationToken.None);
+
+            if (result.IsSuccess)
+            {
+                _logger.LogInformation(
+                    "Preview history regenerated after line move. ContestId={ContestId}",
+                    contestId);
+
+                return;
+            }
+
+            _logger.LogWarning(
+                "Preview history regeneration returned no result. ContestId={ContestId}",
+                contestId);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(
+                ex,
+                "Preview history regeneration failed. ContestId={ContestId}. The next reader will recompute.",
+                contestId);
+        }
+    }
+}

--- a/src/SportsData.Producer/Application/Contests/Queries/Matchups/GetContestPreviewHistory/RegenerateContestPreviewHistoryJob.cs
+++ b/src/SportsData.Producer/Application/Contests/Queries/Matchups/GetContestPreviewHistory/RegenerateContestPreviewHistoryJob.cs
@@ -38,10 +38,20 @@ public class RegenerateContestPreviewHistoryJob : IRegenerateContestPreviewHisto
     /// immediately after the odds are persisted, means the entry is already warm by the
     /// time anyone asks.
     /// <para>
-    /// This is why the preview-history cache does not need a recurring warm job or a
-    /// short expiry: line movement is the only thing that invalidates it, and line
-    /// movement already publishes an event. React to that and there is no window in which
-    /// a user can take the hit.
+    /// This closes the one miss that is caused by the DATA changing. Line movement is the
+    /// only content change that invalidates an entry, and it already publishes an event,
+    /// so reacting to it removes the window in which a reader would rebuild after a line
+    /// move.
+    /// </para>
+    /// <para>
+    /// It does not make misses impossible, and nothing here should be read as claiming so.
+    /// A reader still rebuilds when an entry simply is not there: the seven-day expiry on
+    /// a resolved contest, the five-minute expiry on one whose id did not resolve (so a
+    /// request arriving before the contest is sourced re-checks shortly after), eviction
+    /// under Redis's allkeys-lru policy when memory is tight, a Redis restart (the cache
+    /// has no persistence, by design), or a deliberate payload-version bump. Those are
+    /// lifecycle events rather than staleness, and rebuilding on them is the correct
+    /// behaviour — it is also exactly what happened before any of this caching existed.
     /// </para>
     /// <para>
     /// Failures are logged and swallowed. This is a cache warm — if it does not run, the

--- a/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Common/EventCompetitionOddsDocumentProcessor.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Common/EventCompetitionOddsDocumentProcessor.cs
@@ -8,6 +8,8 @@ using SportsData.Core.Extensions;
 using SportsData.Core.Infrastructure.DataSources.Espn;
 using SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Common;
 using SportsData.Core.Infrastructure.Refs;
+using SportsData.Core.Processing;
+using SportsData.Producer.Application.Contests.Queries.Matchups.GetContestPreviewHistory;
 using SportsData.Producer.Application.Documents.Processors.Commands;
 using SportsData.Producer.Infrastructure.Data.Common;
 using SportsData.Producer.Infrastructure.Data.Entities.Extensions;
@@ -24,6 +26,7 @@ public class EventCompetitionOddsDocumentProcessor<TDataContext> : DocumentProce
     where TDataContext : TeamSportDataContext
 {
     private readonly IJsonHashCalculator _jsonHash;
+    private readonly IProvideBackgroundJobs _backgroundJobProvider;
 
     public EventCompetitionOddsDocumentProcessor(
         ILogger<EventCompetitionOddsDocumentProcessor<TDataContext>> logger,
@@ -31,10 +34,12 @@ public class EventCompetitionOddsDocumentProcessor<TDataContext> : DocumentProce
         IEventBus bus,
         IGenerateExternalRefIdentities idGen,
         IGenerateResourceRefs refs,
-        IJsonHashCalculator jsonHash)
+        IJsonHashCalculator jsonHash,
+        IProvideBackgroundJobs backgroundJobProvider)
         : base(logger, db, bus, idGen, refs)
     {
         _jsonHash = jsonHash;
+        _backgroundJobProvider = backgroundJobProvider;
     }
 
     protected override async Task ProcessInternal(ProcessDocumentCommand command)
@@ -190,5 +195,18 @@ public class EventCompetitionOddsDocumentProcessor<TDataContext> : DocumentProce
 
         _logger.LogInformation("Persisted CompetitionOdds. CompetitionId={CompId}, Provider={Prov}, OddsId={OddsId}",
             competition.Id, dto.Provider.Id, incoming.Id);
+
+        // The preview-history cache is keyed by the spread, so a line move creates a key
+        // nothing has filled yet. Rebuild it now, off the request path, rather than
+        // leaving the next person who opens the matchup dialog to pay ~10 round trips.
+        //
+        // Gated on the SPREAD specifically: an over/under move does not appear in that
+        // key, so regenerating for it would be pure waste. Enqueued after SaveChanges so
+        // the job reads committed odds.
+        if (existing is null || existing.Spread != incoming.Spread)
+        {
+            _backgroundJobProvider.Enqueue<IRegenerateContestPreviewHistoryJob>(
+                job => job.RegenerateAsync(competition.Contest.Id));
+        }
     }
 }

--- a/src/SportsData.Producer/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Producer/DependencyInjection/ServiceRegistration.cs
@@ -399,6 +399,10 @@ namespace SportsData.Producer.DependencyInjection
                 Application.Contests.Queries.Matchups.GetContestPreviewHistory.GetContestPreviewHistoryQueryValidator>();
             services.AddScoped<Application.Contests.Queries.Matchups.GetContestPreviewHistory.IContestPreviewHistoryCache,
                 Application.Contests.Queries.Matchups.GetContestPreviewHistory.ContestPreviewHistoryCache>();
+            // Enqueued by interface from the odds processor, so the registration is
+            // required — Hangfire resolves the job type out of the container.
+            services.AddScoped<Application.Contests.Queries.Matchups.GetContestPreviewHistory.IRegenerateContestPreviewHistoryJob,
+                Application.Contests.Queries.Matchups.GetContestPreviewHistory.RegenerateContestPreviewHistoryJob>();
             services.AddScoped<IGetMatchupResultQueryHandler, GetMatchupResultQueryHandler>();
             services.AddScoped<IGetContestResultsByContestIdsQueryHandler, GetContestResultsByContestIdsQueryHandler>();
             services.AddScoped<IGetFinalizedContestIdsQueryHandler, GetFinalizedContestIdsQueryHandler>();

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/EventCompetitionOddsDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/EventCompetitionOddsDocumentProcessorTests.cs
@@ -11,6 +11,10 @@ using SportsData.Core.Common.Hashing;
 using SportsData.Core.Eventing;
 using SportsData.Core.Extensions;
 using SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Common;
+using SportsData.Core.Processing;
+
+using System.Linq.Expressions;
+using SportsData.Producer.Application.Contests.Queries.Matchups.GetContestPreviewHistory;
 using SportsData.Producer.Application.Documents.Processors.Commands;
 using SportsData.Producer.Application.Documents.Processors.Providers.Espn.Common;
 using SportsData.Producer.Infrastructure.Data.Entities;
@@ -322,6 +326,13 @@ namespace SportsData.Producer.Tests.Unit.Application.Documents.Processors.Provid
             count.Should().Be(1);
             // No events expected: NotifyOnCompletion=false and no domain changes
             bus.Verify(x => x.Publish(It.IsAny<object>(), It.IsAny<CancellationToken>()), Times.Never);
+
+            // Nothing moved, so nothing to rebuild. Regenerating on every odds document
+            // would recompute ~10 round trips per contest for an unchanged answer.
+            Mocker.GetMock<IProvideBackgroundJobs>().Verify(
+                x => x.Enqueue<IRegenerateContestPreviewHistoryJob>(
+                    It.IsAny<Expression<Func<IRegenerateContestPreviewHistoryJob, Task>>>()),
+                Times.Never);
         }
 
         [Fact]
@@ -422,6 +433,15 @@ namespace SportsData.Producer.Tests.Unit.Application.Documents.Processors.Provid
 
             // Events: one for create, one for update
             bus.Verify(x => x.Publish(It.IsAny<object>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
+
+            // The preview-history cache is keyed by the spread, so a line move leaves a
+            // key nothing has filled. Regeneration must be enqueued or the next person to
+            // open the matchup dialog pays the full rebuild.
+            // Twice: once when the odds were created, once when the spread moved.
+            Mocker.GetMock<IProvideBackgroundJobs>().Verify(
+                x => x.Enqueue<IRegenerateContestPreviewHistoryJob>(
+                    It.IsAny<Expression<Func<IRegenerateContestPreviewHistoryJob, Task>>>()),
+                Times.Exactly(2));
         }
 
         [Fact]


### PR DESCRIPTION
Follow-up to #693, correcting a design call I got wrong.

## What was wrong

#693 gave preview history a **1-hour lifetime before kickoff** and 7 days after, reasoning that the spread moves and a stale line is worse than a slow request.

The tiering was backwards for how the feature is used. This endpoint — `GET /api/{sport}/{league}/contests/{id}/history` — feeds the matchup dialog people open to **decide a pick**. That's entirely pre-game. Nobody opens it after the game to study head-to-head records.

So the 7-day tier covered the case with no traffic, and the 1-hour tier covered essentially all of it. The expiry short enough to keep the line honest was expiring, repeatedly, throughout the only window the feature is used.

## The fix

**Put the line in the key.** Staleness becomes impossible by construction: when the spread moves, the key changes and the answer is recomputed. No timer racing the sportsbook.

Every other input is settled history — past meetings, prior-season records — so with the line keyed, a resolved contest holds a 7-day entry whether or not it has kicked off.

```
preview-history:v1:{ContestId}:{MeetingCount}:{RecentGameCount}:s{HomeSpread}
```

The **signed** spread, not the magnitude: a line crossing zero swaps favorite and underdog, so `-3` and `+3` are genuinely different answers.

## Cost

One indexed read moves ahead of the cache check. The row is then handed to `BuildSpreadContextAsync` rather than re-queried, so **a miss costs exactly what it did before** — and a hit now avoids nine round trips instead of expiring hourly.

Against a database measured at one active connection under fifty concurrent VUs, an indexed read on the hot path is noise.

`IDateTimeProvider` drops out of the cache: with correctness handled by the key, the only remaining TTL decision is resolved-vs-unresolved, which needs no clock.

## Verification

- Build: SportsData.Producer — 0 errors, 0 warnings
- Tests: Producer **633 passed, 0 failed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnJySMvfUPeQSMufNNcKSK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Contest preview history now refreshes correctly when the home spread changes.
  * Resolved contest history remains available for seven days, while unresolved contests refresh every five minutes.
  * Reduced redundant spread lookups when loading contest previews.

* **New Features**
  * Preview history is automatically regenerated after new odds are added or the home spread changes.
  * Over/under-only odds changes do not trigger unnecessary preview-history regeneration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->