### PR TITLE
feat(web): add a public /support page for app-store Support URL

### DIFF
--- a/src/UI/sd-ui/src/App.js
+++ b/src/UI/sd-ui/src/App.js
@@ -17,6 +17,7 @@ import LandingPage from "./components/landing/LandingPage";
 import TermsPage from "./components/legal/TermsPage";
 import PrivacyPage from "./components/legal/PrivacyPage";
 import AccountDeletionPage from "./components/legal/AccountDeletionPage";
+import SupportPage from "./components/legal/SupportPage";
 import ErrorPage from "components/common/ErrorPage"; // ✅ reusable component
 import Gallery from "./components/gallery/Gallery";
 import ResultsPage from "./components/results/ResultsPage";
@@ -104,6 +105,11 @@ function AppRoutes() {
           {/* Public account-deletion page — the URL submitted in Google
               Play's Data Safety section. Must stay reachable without auth. */}
           <Route path="/account-deletion" element={<AccountDeletionPage />} />
+          {/* Public support page — the URL submitted as the Support URL in App
+              Store Connect and the Play Console. Reviewers visit it, and a
+              support URL that 404s is a rejection. Must stay reachable without
+              auth: people who need help often cannot sign in. */}
+          <Route path="/support" element={<SupportPage />} />
         </Routes>
       )}
     </>

--- a/src/UI/sd-ui/src/App.js
+++ b/src/UI/sd-ui/src/App.js
@@ -5,6 +5,7 @@ import {
   BrowserRouter as Router,
   Routes,
   Route,
+  Navigate,
   useNavigate,
   useLocation,
 } from "react-router-dom";
@@ -77,9 +78,19 @@ function AppRoutes() {
           short-circuit. Trailing slashes are stripped before matching — the
           router itself treats /terms/ as /terms, so the allowlist must too. */}
       {apiOffline &&
-      !["/terms", "/privacy", "/account-deletion", "/forgot-password"].includes(
-        location.pathname.replace(/\/+$/, "") || "/"
-      ) ? (
+      ![
+        "/terms",
+        "/privacy",
+        "/account-deletion",
+        // Support must survive an API outage above all the others: the page
+        // exists to tell people how to reach us, and "how do I get help" is
+        // exactly the question an outage produces. Without this entry a user
+        // hitting /support during a backend failure would be shown
+        // "We lost the ball trying to contact the server" instead of our
+        // contact address — and app-store reviewers check this URL.
+        "/support",
+        "/forgot-password",
+      ].includes(location.pathname.replace(/\/+$/, "") || "/") ? (
         <ErrorPage message="We lost the ball trying to contact the server." />
       ) : (
         <Routes>
@@ -110,6 +121,14 @@ function AppRoutes() {
               support URL that 404s is a rejection. Must stay reachable without
               auth: people who need help often cannot sign in. */}
           <Route path="/support" element={<SupportPage />} />
+          {/* Catch-all. Without it every unmatched path rendered a blank page,
+              because the SPA serves index.html for any URL and nothing claimed
+              the leftovers — so /contact, /help, /faq and every typo returned
+              HTTP 200 with no content. Sending them to the landing page is the
+              minimal honest fix; a dedicated 404 would be nicer and can come
+              later. Must stay LAST: React Router picks the best match, but
+              keeping it here makes the intent obvious to the next reader. */}
+          <Route path="*" element={<Navigate to="/" replace />} />
         </Routes>
       )}
     </>

--- a/src/UI/sd-ui/src/components/legal/SupportPage.jsx
+++ b/src/UI/sd-ui/src/components/legal/SupportPage.jsx
@@ -1,0 +1,88 @@
+import "./LegalPages.css";
+import { Link } from "react-router-dom";
+
+// Public support page. This URL is submitted as the Support URL in App Store
+// Connect and the Google Play Console, and reviewers do visit it — a support
+// URL that 404s, or that renders with no way to reach a human, is a rejection.
+//
+// Before this page existed the Support URL had to point at /privacy, which
+// technically satisfied the requirement (it carries a contact address) but made
+// support look like an afterthought. Keep a reachable contact address on this
+// page; that is the part being checked.
+//
+// Deliberately reachable without auth: people needing help are frequently the
+// people who cannot sign in.
+function SupportPage() {
+  return (
+    <div className="legal-page legal-page--policy">
+      <h2>sportDeets Support</h2>
+      <p className="legal-page__meta">
+        Help for the sportDeets iOS app, Android app, and sportdeets.com.
+      </p>
+
+      <section>
+        <h3>Contact Us</h3>
+        <p>
+          Email{" "}
+          <a href="mailto:help@sportdeets.com">help@sportdeets.com</a> and
+          we&apos;ll get back to you. We read every message.
+        </p>
+        <p>
+          It helps to include the device you&apos;re using, the name of the
+          league involved, and what you expected to happen.
+        </p>
+      </section>
+
+      <section>
+        <h3>Common Questions</h3>
+        <ul>
+          <li>
+            <strong>How do I join a league?</strong> Ask the league&apos;s
+            commissioner for an invitation, or browse public leagues from the
+            Leagues tab. Invitations expire, so if yours no longer works, ask
+            for a new one.
+          </li>
+          <li>
+            <strong>Why can&apos;t I change a pick?</strong> Picks lock when a
+            game starts. Anything still scheduled can be changed.
+          </li>
+          <li>
+            <strong>My scores look wrong.</strong> Scores update live during
+            games and settle shortly after a game goes final. If something still
+            looks wrong an hour after the final whistle, email us with the
+            matchup and we&apos;ll investigate.
+          </li>
+          <li>
+            <strong>I&apos;d rather not see betting lines.</strong> You can turn
+            that content off. Open Settings and disable the spread and odds
+            display; every surface in the app respects it.
+          </li>
+          <li>
+            <strong>Is sportDeets free?</strong> Yes. There are no entry fees,
+            no wagering, and no real money anywhere in the app.
+          </li>
+        </ul>
+      </section>
+
+      <section>
+        <h3>Account and Data</h3>
+        <ul>
+          <li>
+            <Link to="/account-deletion">Delete your account</Link> — how to
+            remove your account and what happens to your data.
+          </li>
+          <li>
+            <Link to="/privacy">Privacy Policy</Link> — what we collect and why.
+            Privacy-specific questions can go to{" "}
+            <a href="mailto:privacy@sportdeets.com">privacy@sportdeets.com</a>.
+          </li>
+          <li>
+            <Link to="/terms">Terms of Service</Link> — the rules of the road.
+          </li>
+        </ul>
+      </section>
+    </div>
+  );
+}
+
+export default SupportPage;


### PR DESCRIPTION
Needed for the iOS submission going out today.

## The problem

App Store Connect and the Play Console both require a **Support URL**, and reviewers visit it. We had no support page.

Worse, `/support` and `/contact` currently return **HTTP 200** — but only because the SPA serves `index.html` for every path. Neither has a route, and `App.js` has no `path="*"` catch-all, so anyone following those URLs lands on nothing. A support URL that renders blank is a rejection, and a slow one: it comes back days later.

The only honest candidate was `/privacy`, which renders and carries a contact address. That satisfies the letter of the requirement but makes support look like an afterthought.

## The page

Leads with `help@sportdeets.com`, then answers what people actually write in about:

- joining a league (and expired invitations)
- why a pick locked
- scores that look wrong mid-game
- turning off betting content
- whether the app is free

Links out to account deletion, privacy and terms, so one URL covers everything a reviewer or user might be hunting for.

**Reachable without auth**, deliberately — people who need help are frequently the people who can't sign in. Same reasoning as the account-deletion page.

The free-to-play wording ("no entry fees, no wagering, no real money") deliberately matches the Terms page and the App Store description. That consistency is load-bearing for review: Play's real-money-gambling policy and Apple's equivalent are both easier to clear when every surface says the same thing.

## Deployment note

**This must deploy before the Support URL can point at it.** Today's submission uses `/privacy`; Support URL is editable without a new binary or another review pass, so it switches over once the pipeline is healthy.

## Verification

- `eslint --max-warnings=0` — clean
- `vitest` — **83 passed**, 12 files
- `react-scripts build` — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnJySMvfUPeQSMufNNcKSK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a publicly accessible Support page.
  * Included contact options for general and privacy inquiries.
  * Added answers to common app questions.
  * Provided links for account and data-related requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->