### PR TITLE
fix(producer): turn off ContestUpdateJob's backfill mode before the full slate

### DIFF
--- a/src/SportsData.Producer/Application/Contests/ContestUpdateJob.cs
+++ b/src/SportsData.Producer/Application/Contests/ContestUpdateJob.cs
@@ -26,10 +26,23 @@ namespace SportsData.Producer.Application.Contests
     {
         // One-shot backfill: when true, ignore current-season-week scoping and enqueue
         // updates for every non-finalized contest in the most recent season whose start
-        // time has passed. Used to catch MLB up after mid-season onboarding. Flip back
-        // to false before steady-state deploys — the default per-week path is what runs
-        // in production.
-        private static readonly bool BackfillCurrentSeason = true;
+        // time has passed. Used to catch MLB up after mid-season onboarding.
+        //
+        // LEAVE THIS FALSE. It was left on after the MLB catch-up and ran daily in
+        // backfill mode for weeks before anyone noticed — the scope stayed small only
+        // because finalization was keeping up.
+        //
+        // The reason it must not be on during a season is the predicate itself:
+        // "StartDateUtc < now AND FinalizedUtc == null" matches every game CURRENTLY IN
+        // PROGRESS. This job is Cron.Daily, which Hangfire fires at midnight UTC —
+        // 8pm Eastern, i.e. the middle of a Saturday evening slate. On a full NCAAFB
+        // Saturday that means enqueueing a re-source, with the full child-document
+        // cascade, for every live game simultaneously. That is the exact shape of load
+        // that buried the pipeline on 2026-08-29.
+        //
+        // The per-week path below is what production wants: scoped to the current
+        // season week, which is bounded and predictable.
+        private static readonly bool BackfillCurrentSeason = false;
 
         private readonly ILogger<ContestUpdateJob<TDataContext>> _logger;
         private readonly TDataContext _dataContext;


### PR DESCRIPTION
@coderabbitai ignore

One-line flag flip, caught before running the job manually.

## What was wrong

`BackfillCurrentSeason` has been `true` since the MLB mid-season catch-up. Its own comment said *"Flip back to false before steady-state deploys"* — that never happened, and the job has run in backfill mode **daily** ever since. Confirmed in Seq: `BACKFILL_MODE` fired at `00:00:00 UTC` on 2026-09-01 for all three sports.

## Why it hasn't hurt yet

Finalization is keeping up, so the scope has stayed small:

| Sport | Contests matching the backfill predicate |
|---|---|
| NCAAFB | 1 |
| NFL | 0 |
| MLB | 85 |

~86 updates a day. Noise.

## Why it would have hurt on Saturday

The backfill predicate is:

```csharp
c.SeasonYear == currentSeasonYear &&
c.StartDateUtc < DateTime.UtcNow &&
c.FinalizedUtc == null
```

**That matches every game currently in progress.**

The job is `Cron.Daily`, and Hangfire fires that at **midnight UTC — 8pm Eastern**. On the full NCAAFB slate of 09-05/06, that lands in the middle of the Saturday evening games and enqueues a re-source, with the entire child-document cascade, for every live game simultaneously.

That is the exact shape of load that buried the pipeline on 08-29 — arriving on a timer, during the weekend the season actually starts, with 2,030 contests in the NCAAFB season.

## The fix

Flipped to `false`, so the job uses its per-week path: scoped to the current season week, bounded and predictable. Comment rewritten to explain the game-day hazard rather than just saying "flip it back," since the previous wording clearly wasn't enough.

## Follow-up worth considering

A `static readonly bool` that must be hand-flipped is a footgun by construction — it shipped on and stayed on for weeks. Moving it to AppConfig would make the state visible and let it be turned off without a deploy. Not doing that here to keep this change to one line before the weekend.

## Verification

- Build: SportsData.Producer — 0 errors, 0 warnings
- Tests: Producer **633 passed, 0 failed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnJySMvfUPeQSMufNNcKSK