### PR TITLE
feat(producer): empty inclusion filter = document-only sourcing; play participants go FK-only

### DIFF
--- a/docs/features/athlete-cascade-scoping.md
+++ b/docs/features/athlete-cascade-scoping.md
@@ -41,7 +41,7 @@ up.
 
 ## The chain
 
-```
+```text
 Event sourced (all divisions, national slate)
   └─> Competition is new  ──> spawns EventCompetitionPlay + EventCompetitionDrive
         └─> Play processor resolves participants
@@ -108,7 +108,7 @@ probabilities and their athlete subtrees for every game in every division.
 before the 2026-08-29 flood and the flood happened anyway. Sampling the backlog that same
 night, with league-scoped streaming live, gave:
 
-```
+```text
  20  EventCompetitionPlay
  15  AthleteSeason
   3  Athlete

--- a/docs/features/athlete-cascade-scoping.md
+++ b/docs/features/athlete-cascade-scoping.md
@@ -1,0 +1,306 @@
+# Athlete cascade scoping — design
+
+**Status:** authorized 2026-09-01; items 1+2 implemented (PR pending)
+**Raised:** 2026-08-29, after the first live NCAAFB Saturday queued >1M documents
+
+## The problem, observed
+
+On 2026-08-29 the pipeline accumulated **over a million queued items** across three stages
+(Provider Hangfire ~222K, NCAA broker document-requested ~64K, Producer Hangfire ~748K)
+while a single pick'em league game sat starved behind it, showing zero plays two hours into
+the game. Purging all three restored latency to seconds, but the inflow that produced them
+is unchanged and will recur on every Saturday, worse on 09-05/06 with the full slate.
+
+The flood is not one bug. It is four defects that compose into a self-sustaining chain
+reaction, each multiplying the next.
+
+### It is a standing backlog, not a game-day spike
+
+The queue does not drain between slates. Sampling at 22:30 UTC on Saturday 08-29 showed the
+pipeline still processing plays and athlete cascades for **Friday night's** games:
+
+| ESPN event | Kickoff | Matchup |
+|---|---|---|
+| 401866616 | 2026-08-28T23:00Z | New Hampshire at UAlbany (CAA) |
+| 401868040 | 2026-08-28T22:00Z | William & Mary at Villanova (Patriot League) |
+| 401864494 | 2026-08-29T19:00Z | San José State at USC — *the league game* |
+
+More than 24 hours of lag, from a Friday slate consisting of a handful of small-division
+games. This is the key severity fact and it changes the risk assessment for 09-05/06 in two
+ways:
+
+1. The full FBS Saturday slate will land on a queue that is **already a day behind**, not on
+   an empty one.
+2. It explains why the league game starved. Live plays for a game users are actively
+   watching were queued behind day-old play-by-play for FCS games nobody picked. The
+   pipeline has no notion that one of those is worth more than the other.
+
+Which is also why "the queue reached equilibrium" was the wrong read on the night: inflow
+matching drain rate at a depth of ~1M is not equilibrium, it is a backlog that never catches
+up.
+
+## The chain
+
+```
+Event sourced (all divisions, national slate)
+  └─> Competition is new  ──> spawns EventCompetitionPlay + EventCompetitionDrive
+        └─> Play processor resolves participants
+              └─> AthleteSeason missing ──> PublishDependencyRequest(AthleteSeason)
+                    └─> AthleteSeason processor spawns, per athlete:
+                          ├─ AthleteImage (headshot)
+                          ├─ AthleteSeasonStatistics
+                          ├─ AthleteSeasonNote
+                          └─ Athlete (if missing)
+```
+
+Rough fan-out per game: ~150 plays x ~2-4 participants ≈ several hundred athlete
+references, deduping to roughly a roster's worth of unique athletes, each of which spawns
+**four more documents**. Multiply by every game in every division — including Division II
+and III games no user will ever pick — and the million becomes arithmetic rather than
+surprise.
+
+## Defect A — `isNew ||` bypasses the inclusion filter entirely
+
+`EventCompetitionDocumentProcessorBase.cs:372`, `FootballEventCompetitionDocumentProcessor.cs:49`,
+`EventCompetitionDriveDocumentProcessor.cs:200`, and the roster/leaders processors all guard
+spawning as:
+
+```csharp
+if (isNew || ShouldSpawn(DocumentType.EventCompetitionPlay, command))
+```
+
+For a **new** entity the filter is not consulted at all. Since bulk sourcing of a fresh
+slate means every competition is new, the inclusion filter is unenforceable in precisely
+the scenario that generates the load. Any narrowing we set upstream is silently discarded
+on first sight of an entity.
+
+## Defect B — a null or empty filter means "spawn everything"
+
+`DocumentProcessorBase.ShouldSpawn` (line 188):
+
+```csharp
+if (command.IncludeLinkedDocumentTypes == null || command.IncludeLinkedDocumentTypes.Count == 0)
+{
+    return true;   // default: spawn all
+}
+```
+
+The default is fail-open, and **there is no way to express "this document only, no
+children."** An empty list is indistinguishable from an absent one. So any request that
+doesn't explicitly enumerate its children gets the full subtree.
+
+This matters most at the participant hop. When a play needs an `AthleteSeason` it needs it
+**only to satisfy a foreign key** — it has no use for that athlete's headshot, season
+statistics, or notes. But `PublishDependencyRequest` cannot currently say so.
+
+Credit where due: `PublishDependencyRequest` already propagates the parent's filter down
+each hop (added for the Refresh Contest narrowing, `docs/refresh-contest-cascade-narrowing.md`).
+That machinery is correct and reusable — it just has nothing to propagate when the seed is
+unfiltered, and Defect A discards it anyway on new entities.
+
+## Defect C — no league scoping on the event-child cascade
+
+PR #688 league-scoped *stream scheduling*, so we only stream games backing a pick'em league.
+The document cascade never got the same treatment: we still source plays, drives,
+probabilities and their athlete subtrees for every game in every division.
+
+**Does #688 already make this moot? No — measured, not assumed.** #688 was deployed hours
+before the 2026-08-29 flood and the flood happened anyway. Sampling the backlog that same
+night, with league-scoped streaming live, gave:
+
+```
+ 20  EventCompetitionPlay
+ 15  AthleteSeason
+  3  Athlete
+  2  AthleteSeasonNote
+distinct ESPN events: 401866616, 401868040
+```
+
+Neither is a league game (the league game that night was 401864494). Both are FCS:
+New Hampshire at UAlbany (Coastal Athletic Association) and William & Mary at Villanova
+(Patriot League).
+
+The reason is that streaming and sourcing are different paths. The streamer is a *poller*,
+and #688 stopped it polling non-league games. The cascade is triggered by *document
+processing*: event documents for the full national slate still arrive via bulk/resource-index
+sourcing, and `isNew` (Defect A) fires the child spawn the moment one lands, with no league
+awareness anywhere in that path. Scoping the poller does not scope the cascade.
+
+## Defect D — SignalR broadcasts every play to every client
+
+`SportsData.Api/Application/Events/FootballPlayCompletedHandler.cs:38`:
+
+```csharp
+await _hubContext.Clients
+    .All
+    .SendAsync("FootballPlayCompleted", msg, context.CancellationToken);
+```
+
+`Clients.All`, with no groups and no league filter. Every play of every game in the pipeline
+is pushed to every connected browser and mobile client. Confirmed from the field on
+2026-08-29: the operator saw Furman (FCS, Southern Conference) play events in the browser
+dev console while watching an unrelated game.
+
+This is the surface that makes the cascade a **user-facing** cost rather than an internal
+one. It burns mobile data, battery and client CPU parsing messages the client immediately
+discards, and it scales as *(games sourced) x (connected clients)* — so it gets worse both
+as we add sports and as the user base grows. `BaseballPlayCompletedHandler` and
+`ContestStatusChangedHandler` want the same audit.
+
+Fix: broadcast to SignalR groups keyed by contest (or by league), with clients joining only
+the contests they are actually displaying. Note this is worth doing **regardless** of how
+Defects A-C land: even with the cascade perfectly league-scoped, a client watching one game
+should not receive play traffic for every other game in its league, let alone all of them.
+
+## Proposed fix
+
+Three changes, smallest blast radius first. Each is independently valuable and independently
+revertible.
+
+### 1. Make "no children" expressible (unblocks everything else)
+
+Add an explicit way for a request to declare it wants the document and nothing beneath it.
+
+**Decision (owner, 2026-09-01): no new flag.** A `SuppressChildSpawning` bool on the
+events was prototyped and rejected in review — two mechanisms answering the same
+question ("which children may spawn?") invites logical chaos, and
+`IncludeLinkedDocumentTypes` was created for precisely this situation. Instead, the
+filter's collapsed cases are split apart:
+
+- `null` — no filter, spawn everything (unchanged; in-flight messages unaffected)
+- `[]` (empty) — spawn **nothing**: the document is wanted for itself alone
+- non-empty — spawn only the listed types (unchanged)
+
+This needs no wire-contract change at all: the filter already round-trips
+Producer -> Provider -> Producer and already propagates hop-to-hop, so "empty"
+propagates identically. It is also strictly better under mixed versions than a new
+field: an old Provider relays `[]` verbatim, where it would silently drop an unknown
+bool. An old Producer consuming `[]` treats it as spawn-all — today's behaviour.
+
+Audited before adopting: every existing filter origin is either literal `null`, the
+static non-empty `ContestRefreshDocumentTypes` set, or operator HTTP pass-through.
+No code path computes a filter list that could collapse to empty. An operator
+explicitly posting `[]` to a sourcing endpoint now gets document-only sourcing —
+a new, useful capability rather than a hazard.
+
+### 2. Narrow the participant dependency request
+
+`FootballEventCompetitionPlayDocumentProcessor.BuildParticipantsAsync` (line 185) requests
+`AthleteSeason` purely for FK resolution. Mark that request with an empty inclusion
+filter. This alone removes
+the 4x-per-athlete multiplier — the largest single term in the fan-out — without touching
+what games we source.
+
+Same treatment for the `AthletePosition` request on line 203.
+
+**Consequence to accept explicitly:** athlete headshots, season statistics and notes will no
+longer arrive as a side effect of play processing. Anything that genuinely needs them
+(player pick'em scoring, rosters) must source them through a deliberate path rather than
+inheriting them by accident. Worth confirming against the player pick'em requirements before
+merge — this is the one place the change could take something away that a feature quietly
+depends on.
+
+### 3. Honour the filter for new entities, and league-scope the event children
+
+- Change `isNew || ShouldSpawn(...)` to consult the filter for new entities too. The `isNew`
+  short-circuit exists so first-time sourcing gets a complete tree; that intent is right for
+  a league game and wrong for the national slate, which is exactly what scoping decides.
+- Gate the event-child spawn on league membership using `IProvideApi.GetContestIdsInLeagues`
+  (the #688 machinery). Non-league events keep the cheap documents — event, status, score —
+  and skip plays, drives, probabilities and every athlete subtree beneath them.
+
+### 4. Scope the SignalR broadcast to groups
+
+Replace `Clients.All` with per-contest (or per-league) groups in the play and status
+handlers, and have clients join only what they display. Independent of 1-3 and separately
+shippable — it is the only item with a directly user-visible payoff, and it stands on its
+own merits even if the cascade were perfectly scoped.
+
+## Sequencing
+
+1 and 2 are a small, self-contained PR that removes most of the backend volume and can ship
+first. 4 is independent and can go in parallel — it is the one users would feel. 3 is the
+larger change and wants its own PR plus a plan for what we do about non-league history
+(see open questions).
+
+### 5. Priority separation for league work (follow-on)
+
+Even with volume cut, bulk sourcing and live league games sharing one FIFO queue means a
+league game can always end up behind a backfill. Scoping makes that unlikely; a separate
+queue (or priority) for contests backing a pick'em league makes it impossible. Worth doing
+once 1-3 land, since the 24-hour lag above shows the failure is not hypothetical.
+
+## Open questions for the owner
+
+- **Do we ever want non-league play-by-play?** Metrics/backtesting may want plays for games
+  outside any league. If so, scoping should route that work to a deliberate low-priority
+  backfill rather than the live path — not drop it.
+- **Does player pick'em depend on the athlete children arriving via the play cascade?**
+  **ANSWERED 2026-09-01 (from source): no.** The evidence chain:
+  1. Scoring consumes per-game `AthleteCompetitionStatistic` rows, produced by
+     `EventCompetitionAthleteStatisticsDocumentProcessor` from
+     `EventCompetitionAthleteStatistics` documents. Those documents are spawned from
+     three places -- the competitor roster processor, the leaders processor, and the
+     play processor itself (`participant.Statistics`) -- none of which are children
+     of `AthleteSeason`. Suppressing the AthleteSeason subtree cannot touch them.
+  2. The stats processor resolves the `AthleteSeason` row itself and publishes its
+     own dependency request when the row is missing. Item 2 still delivers the row;
+     only the enrichment children (image, season statistics, notes) are dropped.
+  3. Inside `AthleteSeasonDocumentProcessor`, the `Athlete` parent is a blocking FK
+     dependency (`PublishDependencyRequest` + throw/retry), not a ShouldSpawn-gated
+     child -- so suppression cannot orphan the row.
+  4. `AthleteImage` sources headshots the product is permanently barred from showing
+     (app-store constraint), and season statistics arriving via this accidental path
+     are the same corpus the fabrication audit slated for purge and rebuild through a
+     deliberate path. Losing accidental arrival is alignment, not regression.
+
+  Baseball's play processor resolves participants to null when missing and publishes
+  no dependency requests -- football is the only spawner on this hop.
+- **Replay of purged work:** the ~1M purged items were mostly non-league canonical data and
+  athlete crawl. Documents persist in Provider's Mongo, so this is replayable by choice, not
+  lost. Decide whether any of it is worth replaying or whether scoping makes it moot.
+
+## Implementation notes (items 1+2, as built)
+
+No event or command shape changed. The entire implementation is three behaviours in
+`DocumentProcessorBase`, two call sites in the football play processor, and comments.
+
+**`ShouldSpawn`** now distinguishes the three filter states: `null` -> spawn all
+(default, unchanged); empty -> spawn nothing, logged as a document-only request;
+non-empty -> only the listed types (unchanged).
+
+**`PublishChildDocumentRequest`** additionally refuses to publish when the command's
+filter is empty. This second check is what defends against the `isNew ||` call sites
+(Defect A): they bypass ShouldSpawn, but every child publish funnels through this
+choke point. It deliberately enforces ONLY the empty case — enforcing a non-empty
+filter there would implicitly decide the isNew-bypass question (item 3), which is a
+separate behavioural change. A unit test pins that boundary.
+
+**`PublishDependencyRequest`** gains an optional `includeLinkedDocumentTypes`
+override: when given, it replaces the command's filter on that one published request;
+otherwise the parent's filter propagates unchanged (existing behaviour). FK
+resolution is never blocked — a document-only AthleteSeason command still requests
+its missing Athlete parent, or the row could never persist.
+
+**Propagation is sticky downhill.** A document-only command publishes its own empty
+filter onto every FK request it makes, so the chain beneath a lean request stays
+lean: play -> AthleteSeason -> Athlete are all document-only. Nothing downstream can
+widen a filter it was handed.
+
+**The play processor** marks its two participant requests
+(`AthleteSeason`, `AthletePosition`) with `Array.Empty<DocumentType>()`.
+
+**Retry behaviour:** the filter already round-trips the
+`ExternalDocumentNotSourcedException` retry loop via `ToDocumentCreated`
+(pre-existing), so a document-only request stays document-only across retries.
+
+**Not affected (deliberately):** operator replay paths
+(`PublishDocumentEventsProcessor`, the ops endpoints) and all seed jobs pass their
+filters through untouched; none of them construct an empty list today, so their
+behaviour is unchanged. `DocumentJobDefinition`'s doc comment was corrected — it
+claimed "null or empty" both meant spawn-all.
+
+## What this does not fix
+
+Independent of scoping, the dependency retry has no attempt cap (logs "attempt 1" forever).
+That is a separate queued fix; it makes a flood durable but does not create one.

--- a/src/SportsData.Producer/Application/Documents/Processors/Commands/ProcessDocumentCommand.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/Commands/ProcessDocumentCommand.cs
@@ -45,9 +45,12 @@ public class ProcessDocumentCommand(
     public int AttemptCount { get; init; } = attemptCount;
 
     /// <summary>
-    /// Optional inclusion-only list of linked document types.
-    /// If provided and non-empty, downstream processors should only spawn linked documents
-    /// of types in this collection. If null or empty, all linked documents are processed.
+    /// Optional inclusion-only list of linked document types. Three meanings:
+    /// null = no filter, spawn all linked documents (default); EMPTY = spawn none —
+    /// this document is wanted for itself alone (FK-only dependency requests);
+    /// non-empty = spawn only the listed types. The filter propagates onto every
+    /// request this command publishes, so an empty filter keeps the entire chain
+    /// beneath it lean. See docs/features/athlete-cascade-scoping.md.
     /// </summary>
     public IReadOnlyCollection<DocumentType>? IncludeLinkedDocumentTypes { get; init; } = includeLinkedDocumentTypes;
 

--- a/src/SportsData.Producer/Application/Documents/Processors/DocumentProcessorBase.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/DocumentProcessorBase.cs
@@ -467,9 +467,12 @@ public abstract class DocumentProcessorBase<TDataContext> : IProcessDocuments
             CorrelationId: command.CorrelationId,
             CausationId: command.MessageId,
             PropertyBag: propertyBag,
-            // The per-call override (when given) replaces the command's filter for
-            // THIS request only; otherwise the parent's filter propagates unchanged.
-            // An empty filter is sticky downhill: a document-only command publishes
+            // A NON-NULL per-call override is applied to THIS request only; a null
+            // override means "inherit the parent's filter" (the ?? below). There is
+            // deliberately no way to force null past a filtered parent: that would
+            // let one hop WIDEN a narrowing set at the seed (e.g. Refresh Contest),
+            // and the cascade's contract is that filters only narrow downhill. An
+            // empty filter is sticky the same way: a document-only command publishes
             // its own empty filter onto every FK request it makes, so the chain
             // beneath a lean request stays lean (play -> AthleteSeason -> Athlete).
             IncludeLinkedDocumentTypes: (includeLinkedDocumentTypes ?? command.IncludeLinkedDocumentTypes)?.ToList()

--- a/src/SportsData.Producer/Application/Documents/Processors/DocumentProcessorBase.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/DocumentProcessorBase.cs
@@ -187,10 +187,26 @@ public abstract class DocumentProcessorBase<TDataContext> : IProcessDocuments
     /// <returns>True if the document should be spawned; false otherwise</returns>
     protected bool ShouldSpawn(DocumentType documentType, ProcessDocumentCommand command)
     {
-        // If no inclusion filter is specified, spawn all documents (default behavior)
-        if (command.IncludeLinkedDocumentTypes == null || command.IncludeLinkedDocumentTypes.Count == 0)
+        // No filter at all: spawn everything (default behaviour, unchanged).
+        if (command.IncludeLinkedDocumentTypes == null)
         {
             return true;
+        }
+
+        // An EMPTY filter means "this document only, no children". It used to be
+        // collapsed into the null case above, which left no way to express a
+        // dependency request that exists purely to satisfy a foreign key (a play
+        // participant needing an AthleteSeason row has no use for that athlete's
+        // headshot, season statistics, or notes — the 4x-per-athlete multiplier
+        // behind the 2026-08-29 flood). One vocabulary, three meanings: null = all,
+        // empty = none, non-empty = only these.
+        // See docs/features/athlete-cascade-scoping.md.
+        if (command.IncludeLinkedDocumentTypes.Count == 0)
+        {
+            _logger.LogInformation(
+                "Skipping spawn of {DocumentType}: empty inclusion filter (document-only request).",
+                documentType);
+            return false;
         }
 
         // If inclusion filter is specified, only spawn if the type is in the list
@@ -278,7 +294,8 @@ public abstract class DocumentProcessorBase<TDataContext> : IProcessDocuments
         ProcessDocumentCommand command,
         IHasRef? hasRef,
         TParentId parentId,
-        DocumentType documentType)
+        DocumentType documentType,
+        IReadOnlyCollection<DocumentType>? includeLinkedDocumentTypes = null)
     {
         using (_logger.BeginScope(new Dictionary<string, object?>
         {
@@ -319,7 +336,9 @@ public abstract class DocumentProcessorBase<TDataContext> : IProcessDocuments
 
             // Publish dependency request - track only after successful publish to allow retries if publish fails
             // Pass precomputed identity to avoid redundant Generate call
-            var published = await PublishDocumentRequestInternal(command, hasRef, parentId, documentType, "DEPENDENCY", identity);
+            var published = await PublishDocumentRequestInternal(
+                command, hasRef, parentId, documentType, "DEPENDENCY", identity,
+                includeLinkedDocumentTypes: includeLinkedDocumentTypes);
 
             // Only track when the publish actually occurred — early returns (URI/identity failure) must not mark as done
             if (published)
@@ -351,6 +370,24 @@ public abstract class DocumentProcessorBase<TDataContext> : IProcessDocuments
             ["ParentId"] = parentId?.ToString()
         }))
         {
+            // The empty-filter case is enforced here as well as in ShouldSpawn,
+            // because not every call site is gated — several processors spawn
+            // children unconditionally when an entity is new (the `isNew ||`
+            // pattern). Refusing the publish at the choke point makes a
+            // document-only request hold regardless of call-site discipline.
+            // Dependency requests (FK resolution) are NOT blocked — only children.
+            // Deliberately ONLY the empty case: enforcing a NON-empty filter here
+            // would implicitly decide the isNew-bypass question (item 3 of the
+            // design doc), which is a separate behavioural change.
+            if (command.IncludeLinkedDocumentTypes is { Count: 0 })
+            {
+                _logger.LogInformation(
+                    "⏭️ SKIP_CHILD_DOCUMENT: empty inclusion filter (document-only request). ChildDocumentType={ChildDocumentType}, ParentId={ParentId}",
+                    documentType,
+                    parentId?.ToString());
+                return;
+            }
+
             if (hasRef is null)
             {
                 _logger.LogWarning(
@@ -385,7 +422,8 @@ public abstract class DocumentProcessorBase<TDataContext> : IProcessDocuments
         DocumentType documentType,
         string requestType,
         ExternalRefIdentity? precomputedIdentity = null,
-        Dictionary<string, string>? propertyBag = null)
+        Dictionary<string, string>? propertyBag = null,
+        IReadOnlyCollection<DocumentType>? includeLinkedDocumentTypes = null)
     {
         ExternalRefIdentity identity;
         Uri uri;
@@ -429,7 +467,12 @@ public abstract class DocumentProcessorBase<TDataContext> : IProcessDocuments
             CorrelationId: command.CorrelationId,
             CausationId: command.MessageId,
             PropertyBag: propertyBag,
-            IncludeLinkedDocumentTypes: command.IncludeLinkedDocumentTypes?.ToList()
+            // The per-call override (when given) replaces the command's filter for
+            // THIS request only; otherwise the parent's filter propagates unchanged.
+            // An empty filter is sticky downhill: a document-only command publishes
+            // its own empty filter onto every FK request it makes, so the chain
+            // beneath a lean request stays lean (play -> AthleteSeason -> Athlete).
+            IncludeLinkedDocumentTypes: (includeLinkedDocumentTypes ?? command.IncludeLinkedDocumentTypes)?.ToList()
         ));
 
         _logger.LogInformation(

--- a/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Football/FootballEventCompetitionPlayDocumentProcessor.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Football/FootballEventCompetitionPlayDocumentProcessor.cs
@@ -1,4 +1,4 @@
-using Microsoft.EntityFrameworkCore;
+﻿using Microsoft.EntityFrameworkCore;
 
 using SportsData.Core.Common;
 using SportsData.Core.Common.Hashing;
@@ -182,8 +182,21 @@ public class FootballEventCompetitionPlayDocumentProcessor<TDataContext>
 
                 if (athleteSeasonId is null)
                 {
+                    // Empty filter = document only: this request exists purely to
+                    // satisfy the participant FK. The AthleteSeason row will persist
+                    // (its Athlete parent is a blocking dependency, which still flows),
+                    // but its child subtree — headshot, season statistics, notes — will
+                    // not spawn. That subtree was the largest single term in the
+                    // 2026-08-29 fan-out (~4 documents per unique athlete, across every
+                    // division), and nothing on the scoring path consumes it: per-game
+                    // stats arrive via EventCompetitionAthleteStatistics from the
+                    // roster/leaders/play spawns, and their processor resolves the
+                    // AthleteSeason row itself. Season-level data that is genuinely
+                    // wanted must be sourced deliberately, not inherited from a play.
+                    // See docs/features/athlete-cascade-scoping.md.
                     await PublishDependencyRequest<string?>(
-                        command, participant.Athlete, parentId: null, DocumentType.AthleteSeason);
+                        command, participant.Athlete, parentId: null, DocumentType.AthleteSeason,
+                        includeLinkedDocumentTypes: Array.Empty<DocumentType>());
                     anyMissing = true;
                 }
             }
@@ -200,8 +213,10 @@ public class FootballEventCompetitionPlayDocumentProcessor<TDataContext>
 
                 if (positionId is null)
                 {
+                    // Same FK-only treatment as the AthleteSeason request above.
                     await PublishDependencyRequest<string?>(
-                        command, participant.Position, parentId: null, DocumentType.AthletePosition);
+                        command, participant.Position, parentId: null, DocumentType.AthletePosition,
+                        includeLinkedDocumentTypes: Array.Empty<DocumentType>());
                     anyMissing = true;
                 }
             }

--- a/src/SportsData.Provider/Application/Jobs/Definitions/DocumentJobDefinition.cs
+++ b/src/SportsData.Provider/Application/Jobs/Definitions/DocumentJobDefinition.cs
@@ -55,8 +55,9 @@ namespace SportsData.Provider.Application.Jobs.Definitions
         /// <summary>
         /// Optional inclusion-only list of linked document types that downstream processors
         /// should honor when deciding which linked documents to spawn.
-        /// If null or empty, all linked documents are processed (default behavior).
-        /// If provided and non-empty, only linked documents of types in this collection will be spawned.
+        /// If null, all linked documents are processed (default behavior).
+        /// If empty, no linked documents are spawned (document-only sourcing).
+        /// If non-empty, only linked documents of types in this collection will be spawned.
         /// </summary>
         public IReadOnlyCollection<DocumentType>? IncludeLinkedDocumentTypes { get; set; }
     }

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/DocumentProcessorBaseTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/DocumentProcessorBaseTests.cs
@@ -1,4 +1,4 @@
-#nullable enable
+﻿#nullable enable
 
 using FluentAssertions;
 
@@ -304,6 +304,127 @@ public class DocumentProcessorBaseTests : ProducerTestBase<FootballDataContext>
             It.IsAny<CancellationToken>()), Times.Once);
     }
 
+    // ---- Empty-filter ("document only") semantics ----
+    // IncludeLinkedDocumentTypes has three meanings: null = spawn all (default,
+    // unchanged), EMPTY = spawn nothing, non-empty = only the listed types. The
+    // empty case exists because a dependency request that only satisfies a foreign
+    // key (a play participant needing an AthleteSeason row) has no use for the
+    // subtree beneath it (Defect B in docs/features/athlete-cascade-scoping.md).
+    // These tests pin the three behaviours that make it airtight: ShouldSpawn
+    // refuses, the child publish choke point refuses even for ungated call sites,
+    // and the empty filter propagates onto every request the command publishes.
+
+    [Fact]
+    public void ShouldSpawn_Should_Return_True_When_Filter_Is_Null()
+    {
+        // The default is unchanged: no filter means spawn everything.
+        var processor = Mocker.CreateInstance<TestDocumentProcessor<FootballDataContext>>();
+        var command = CreateTestCommand();
+
+        processor.ShouldSpawnPublic(DocumentType.AthleteImage, command).Should().BeTrue();
+    }
+
+    [Fact]
+    public void ShouldSpawn_Should_Return_False_When_Filter_Is_Empty()
+    {
+        // An empty filter is no longer collapsed into the null case: it means
+        // "this document only, no children".
+        var processor = Mocker.CreateInstance<TestDocumentProcessor<FootballDataContext>>();
+        var command = CreateTestCommand(includeLinkedDocumentTypes: new List<DocumentType>());
+
+        processor.ShouldSpawnPublic(DocumentType.AthleteImage, command).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task PublishChildDocumentRequest_Should_Not_Publish_When_Filter_Is_Empty()
+    {
+        // Several processors spawn children unconditionally when an entity is new
+        // (the isNew short-circuit bypasses ShouldSpawn). The choke point must hold
+        // regardless of call-site discipline.
+        var busMock = Mocker.GetMock<IEventBus>();
+        Mocker.Use<IGenerateExternalRefIdentities>(new ExternalRefIdentityGenerator());
+        var processor = Mocker.CreateInstance<TestDocumentProcessor<FootballDataContext>>();
+
+        var command = CreateTestCommand(includeLinkedDocumentTypes: new List<DocumentType>());
+        var hasRef = new EspnLinkDto { Ref = new Uri("http://sports.core.api.espn.com/v2/sports/football/leagues/college-football/seasons/2024/athletes/12345/statistics") };
+
+        await processor.PublishChildDocumentRequestPublic(command, hasRef, Guid.NewGuid(), DocumentType.AthleteSeasonStatistics);
+
+        busMock.Verify(x => x.Publish(
+            It.IsAny<DocumentRequested>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task PublishChildDocumentRequest_Should_Publish_When_Filter_Is_NonEmpty()
+    {
+        // Deliberately narrow: the choke point enforces ONLY the empty case.
+        // A non-empty filter must not be enforced there — that would implicitly
+        // decide the isNew-bypass question (item 3 of the design doc), which is a
+        // separate behavioural change. This test pins the boundary.
+        var busMock = Mocker.GetMock<IEventBus>();
+        Mocker.Use<IGenerateExternalRefIdentities>(new ExternalRefIdentityGenerator());
+        var processor = Mocker.CreateInstance<TestDocumentProcessor<FootballDataContext>>();
+
+        var command = CreateTestCommand(
+            includeLinkedDocumentTypes: new List<DocumentType> { DocumentType.EventCompetition });
+        var hasRef = new EspnLinkDto { Ref = new Uri("http://sports.core.api.espn.com/v2/sports/football/leagues/college-football/seasons/2024/athletes/12345/statistics") };
+
+        await processor.PublishChildDocumentRequestPublic(command, hasRef, Guid.NewGuid(), DocumentType.AthleteSeasonStatistics);
+
+        busMock.Verify(x => x.Publish(
+            It.IsAny<DocumentRequested>(),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task PublishDependencyRequest_Should_Still_Publish_When_Filter_Is_Empty()
+    {
+        // An empty filter blocks children, never FK resolution — a document-only
+        // AthleteSeason command must still be able to request its missing Athlete
+        // parent, or the row could never persist. The published request carries the
+        // empty filter forward so the FK chain stays lean.
+        var busMock = Mocker.GetMock<IEventBus>();
+        Mocker.Use<IGenerateExternalRefIdentities>(new ExternalRefIdentityGenerator());
+        var processor = Mocker.CreateInstance<TestDocumentProcessor<FootballDataContext>>();
+
+        var command = CreateTestCommand(includeLinkedDocumentTypes: new List<DocumentType>());
+        var hasRef = new EspnLinkDto { Ref = new Uri("http://sports.core.api.espn.com/v2/sports/football/leagues/college-football/athletes/12345") };
+
+        await processor.PublishDependencyRequestPublic(command, hasRef, Guid.NewGuid(), DocumentType.Athlete);
+
+        busMock.Verify(x => x.Publish(
+            It.Is<DocumentRequested>(e =>
+                e.IncludeLinkedDocumentTypes != null &&
+                e.IncludeLinkedDocumentTypes.Count == 0),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task PublishDependencyRequest_Should_Apply_PerCall_Filter_Override()
+    {
+        // An unfiltered command (a play) can mark ONE dependency request (its
+        // participant's AthleteSeason) as document-only without affecting its own
+        // filter or its other requests.
+        var busMock = Mocker.GetMock<IEventBus>();
+        Mocker.Use<IGenerateExternalRefIdentities>(new ExternalRefIdentityGenerator());
+        var processor = Mocker.CreateInstance<TestDocumentProcessor<FootballDataContext>>();
+
+        var command = CreateTestCommand(documentType: DocumentType.EventCompetitionPlay);
+        var hasRef = new EspnLinkDto { Ref = new Uri("http://sports.core.api.espn.com/v2/sports/football/leagues/college-football/seasons/2024/athletes/12345") };
+
+        await processor.PublishDependencyRequestPublic(
+            command, hasRef, Guid.NewGuid(), DocumentType.AthleteSeason,
+            includeLinkedDocumentTypes: Array.Empty<DocumentType>());
+
+        command.IncludeLinkedDocumentTypes.Should().BeNull("the override must not mutate the command");
+        busMock.Verify(x => x.Publish(
+            It.Is<DocumentRequested>(e =>
+                e.IncludeLinkedDocumentTypes != null &&
+                e.IncludeLinkedDocumentTypes.Count == 0),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
     [Fact]
     public async Task PublishDependencyRequest_Should_Not_Publish_When_Identity_Generation_Throws()
     {
@@ -363,9 +484,24 @@ public class TestDocumentProcessor<TDataContext> : DocumentProcessorBase<TDataCo
         ProcessDocumentCommand command,
         IHasRef? hasRef,
         TParentId parentId,
+        DocumentType documentType,
+        IReadOnlyCollection<DocumentType>? includeLinkedDocumentTypes = null)
+    {
+        return PublishDependencyRequest(command, hasRef, parentId, documentType, includeLinkedDocumentTypes);
+    }
+
+    public bool ShouldSpawnPublic(DocumentType documentType, ProcessDocumentCommand command)
+    {
+        return ShouldSpawn(documentType, command);
+    }
+
+    public Task PublishChildDocumentRequestPublic<TParentId>(
+        ProcessDocumentCommand command,
+        IHasRef? hasRef,
+        TParentId parentId,
         DocumentType documentType)
     {
-        return PublishDependencyRequest(command, hasRef, parentId, documentType);
+        return PublishChildDocumentRequest(command, hasRef, parentId, documentType);
     }
 }
 

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/DocumentProcessorBaseTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/DocumentProcessorBaseTests.cs
@@ -426,6 +426,34 @@ public class DocumentProcessorBaseTests : ProducerTestBase<FootballDataContext>
     }
 
     [Fact]
+    public async Task PublishDependencyRequest_Should_Inherit_Parent_Filter_When_Override_Is_Null()
+    {
+        // A null override means "inherit", NOT "force the default null filter".
+        // This is deliberate: if a caller could force null past a filtered parent,
+        // one hop could WIDEN a narrowing set at the seed (e.g. Refresh Contest's
+        // set), and the cascade's contract is that filters only narrow downhill.
+        var busMock = Mocker.GetMock<IEventBus>();
+        Mocker.Use<IGenerateExternalRefIdentities>(new ExternalRefIdentityGenerator());
+        var processor = Mocker.CreateInstance<TestDocumentProcessor<FootballDataContext>>();
+
+        var parentFilter = new List<DocumentType> { DocumentType.EventCompetitionStatus };
+        var command = CreateTestCommand(
+            documentType: DocumentType.Event,
+            includeLinkedDocumentTypes: parentFilter);
+        var hasRef = new EspnLinkDto { Ref = new Uri("http://sports.core.api.espn.com/v2/sports/football/leagues/college-football/events/401234567/competitions/401234567") };
+
+        await processor.PublishDependencyRequestPublic(
+            command, hasRef, Guid.NewGuid(), DocumentType.EventCompetition,
+            includeLinkedDocumentTypes: null);
+
+        busMock.Verify(x => x.Publish(
+            It.Is<DocumentRequested>(e =>
+                e.IncludeLinkedDocumentTypes != null &&
+                e.IncludeLinkedDocumentTypes.SequenceEqual(parentFilter)),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
     public async Task PublishDependencyRequest_Should_Not_Publish_When_Identity_Generation_Throws()
     {
         // Arrange

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/EventCompetitionOddsDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/EventCompetitionOddsDocumentProcessorTests.cs
@@ -233,6 +233,11 @@ namespace SportsData.Producer.Tests.Unit.Application.Documents.Processors.Provid
                 .With(x => x.DocumentType, DocumentType.EventCompetitionOdds)
                 .With(x => x.Document, json)
                 .With(x => x.UrlHash, "url-hash")
+                // Explicit, not fixture-supplied: this test asserts the completion
+                // event below, and the test base now pins the command's behavioural
+                // flags to false by default (they used to arrive by boolean-alternation
+                // accident — see ProducerTestBase).
+                .With(x => x.NotifyOnCompletion, true)
                 .OmitAutoProperties()
                 .Create();
 

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/FootballEventCompetitionDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/FootballEventCompetitionDocumentProcessorTests.cs
@@ -1,4 +1,4 @@
-using AutoFixture;
+﻿using AutoFixture;
 
 using FluentAssertions;
 
@@ -285,7 +285,11 @@ namespace SportsData.Producer.Tests.Unit.Application.Documents.Processors.Provid
                 .With(x => x.DocumentType, DocumentType.EventCompetition)
                 .With(x => x.Document, documentJson)
                 .With(x => x.UrlHash, competitionIdentity.UrlHash)
-                .With(x => x.IncludeLinkedDocumentTypes, new List<DocumentType>())
+                // Explicit null (= no filter, spawn all). This override exists to
+                // defeat AutoFixture's random list fill; it used to pass an empty
+                // list, which meant the same thing until empty became "spawn
+                // nothing" (docs/features/athlete-cascade-scoping.md).
+                .With(x => x.IncludeLinkedDocumentTypes, (IReadOnlyCollection<DocumentType>)null!)
                 .Create();
 
             // act
@@ -523,7 +527,11 @@ namespace SportsData.Producer.Tests.Unit.Application.Documents.Processors.Provid
                 .With(x => x.DocumentType, DocumentType.EventCompetition)
                 .With(x => x.Document, documentJson)
                 .With(x => x.UrlHash, competitionIdentity.UrlHash)
-                .With(x => x.IncludeLinkedDocumentTypes, new List<DocumentType>())
+                // Explicit null (= no filter, spawn all). This override exists to
+                // defeat AutoFixture's random list fill; it used to pass an empty
+                // list, which meant the same thing until empty became "spawn
+                // nothing" (docs/features/athlete-cascade-scoping.md).
+                .With(x => x.IncludeLinkedDocumentTypes, (IReadOnlyCollection<DocumentType>)null!)
                 .Create();
 
             // act

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/FootballEventCompetitionPlayDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/FootballEventCompetitionPlayDocumentProcessorTests.cs
@@ -1,4 +1,4 @@
-#nullable enable
+﻿#nullable enable
 
 using AutoFixture;
 
@@ -632,12 +632,23 @@ public class FootballEventCompetitionPlayDocumentProcessorTests : ProducerTestBa
             .FirstOrDefaultAsync(x => x.CompetitionId == competitionId);
         play.Should().BeNull("the play must be withheld until its participants are sourced");
 
+        // Both participant requests are FK-only: they must carry an EMPTY inclusion
+        // filter (document only, no children) so the AthleteSeason row arrives
+        // WITHOUT its child subtree (headshot, season statistics, notes) — the
+        // 4x-per-athlete multiplier behind the 2026-08-29 flood.
+        // See docs/features/athlete-cascade-scoping.md.
         bus.Verify(x => x.Publish(
-            It.Is<DocumentRequested>(d => d.DocumentType == DocumentType.AthleteSeason),
+            It.Is<DocumentRequested>(d =>
+                d.DocumentType == DocumentType.AthleteSeason &&
+                d.IncludeLinkedDocumentTypes != null &&
+                d.IncludeLinkedDocumentTypes.Count == 0),
             It.IsAny<CancellationToken>()),
             Times.AtLeastOnce);
         bus.Verify(x => x.Publish(
-            It.Is<DocumentRequested>(d => d.DocumentType == DocumentType.AthletePosition),
+            It.Is<DocumentRequested>(d =>
+                d.DocumentType == DocumentType.AthletePosition &&
+                d.IncludeLinkedDocumentTypes != null &&
+                d.IncludeLinkedDocumentTypes.Count == 0),
             It.IsAny<CancellationToken>()),
             Times.AtLeastOnce);
     }
@@ -713,7 +724,10 @@ public class FootballEventCompetitionPlayDocumentProcessorTests : ProducerTestBa
             .Should().BeFalse();
 
         bus.Verify(x => x.Publish(
-            It.Is<DocumentRequested>(d => d.DocumentType == DocumentType.AthleteSeason),
+            It.Is<DocumentRequested>(d =>
+                d.DocumentType == DocumentType.AthleteSeason &&
+                d.IncludeLinkedDocumentTypes != null &&
+                d.IncludeLinkedDocumentTypes.Count == 0),
             It.IsAny<CancellationToken>()),
             Times.AtLeastOnce);
     }

--- a/test/unit/SportsData.Producer.Tests.Unit/ProducerTestBase.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/ProducerTestBase.cs
@@ -1,10 +1,11 @@
-using AutoFixture;
+﻿using AutoFixture;
 using AutoFixture.Kernel;
 
 using AutoMapper;
 
 using Microsoft.EntityFrameworkCore;
 
+using SportsData.Producer.Application.Documents.Processors.Commands;
 using SportsData.Producer.Infrastructure.Data.Common;
 using SportsData.Producer.Infrastructure.Data.Entities;
 using SportsData.Producer.Infrastructure.Data.Football;
@@ -38,6 +39,21 @@ public abstract class ProducerTestBase<T> : UnitTestBase<T>
         Fixture.Customizations.Add(new TypeRelay(typeof(CompetitionStatusBase), typeof(FootballCompetitionStatus)));
         Fixture.Customizations.Add(new TypeRelay(typeof(CompetitionCompetitorBase), typeof(FootballCompetitionCompetitor)));
 
+        // Pin ProcessDocumentCommand's boolean flags (NotifyOnCompletion today) to
+        // false for fixture-built commands. AutoFixture fills booleans by
+        // ALTERNATION, so which flag lands true depends on how many bools the
+        // fixture handed out before it — adding a bool parameter anywhere in the
+        // command flips the parity for every test downstream. Discovered 2026-09-01
+        // when a prototype bool on the command turned two green AthleteSeason guard
+        // tests red: NotifyOnCompletion silently became true and the base class
+        // published DocumentProcessingCompleted, failing their "publishes nothing"
+        // assertions. EventCompetitionOddsDocumentProcessorTests had already been
+        // bitten and pins the flag per call site. A specimen builder (not
+        // Customize<T>) because Fixture.Build<T> bypasses Customize<T> — this
+        // intercepts the ctor-parameter and property requests themselves, and an
+        // explicit .With(...) in a test still wins.
+        Fixture.Customizations.Add(new ProcessDocumentCommandFlagsOffByDefault());
+
         // Override mapper with Producer-specific mapping profile
         var mapperConfig = new MapperConfiguration(c =>
         {
@@ -46,6 +62,28 @@ public abstract class ProducerTestBase<T> : UnitTestBase<T>
         });
         var mapper = mapperConfig.CreateMapper();
         Mocker.Use(typeof(IMapper), mapper);
+    }
+
+    private sealed class ProcessDocumentCommandFlagsOffByDefault : ISpecimenBuilder
+    {
+        public object Create(object request, ISpecimenContext context)
+        {
+            if (request is System.Reflection.ParameterInfo pi
+                && pi.Member.DeclaringType == typeof(ProcessDocumentCommand)
+                && pi.ParameterType == typeof(bool))
+            {
+                return false;
+            }
+
+            if (request is System.Reflection.PropertyInfo prop
+                && prop.DeclaringType == typeof(ProcessDocumentCommand)
+                && prop.PropertyType == typeof(bool))
+            {
+                return false;
+            }
+
+            return new NoSpecimen();
+        }
     }
 
     private static DbContextOptions<FootballDataContext> GetFootballDataContextOptions()


### PR DESCRIPTION
## Context

Items 1+2 of `docs/features/athlete-cascade-scoping.md` (included in this PR) — the first slice of the fix for the 2026-08-29 flood: >1M queued documents across three stages while a pick'em league game sat starved 24 hours behind FCS play-by-play. The largest single term in that fan-out was the athlete subtree dragged in by play participants: every unresolved `AthleteSeason` FK pulled in the athlete's headshot, season statistics, and notes (~4 documents per unique athlete, across every division, including games no user can pick).

## What changed

`IncludeLinkedDocumentTypes` previously collapsed `null` and `[]` into one meaning (spawn everything), so "this document only, no children" was inexpressible. The cases are now split:

| Filter | Meaning |
|---|---|
| `null` | no filter — spawn everything (unchanged; in-flight messages unaffected) |
| `[]` | spawn **nothing** — the document is wanted for itself alone |
| non-empty | only the listed types (unchanged) |

A `SuppressChildSpawning` bool on the events was prototyped and rejected in owner review — two mechanisms answering "which children may spawn?" invites logical chaos, and the filter exists for precisely this situation. The filter approach needs **no wire-contract change**: it already round-trips Producer → Provider → Producer and propagates hop-to-hop. Mixed versions during rolling deploy degrade to today's spawn-everything, never to over-suppression.

## Enforcement (belt and suspenders)

- **`ShouldSpawn`** returns false on an empty filter.
- **`PublishChildDocumentRequest`** refuses to publish on an empty filter — the choke point that defends against ungated call sites (the `isNew ||` pattern; e.g. `FootballAthleteDocumentProcessor`'s career-statistics spawn has no gate at all). Deliberately enforces ONLY the empty case: enforcing a non-empty filter there would implicitly decide the isNew-bypass question (item 3 of the design doc), which is a separate change. A unit test pins that boundary.
- **`PublishDependencyRequest`** is never blocked — FK resolution must flow or a document-only request could never persist. The empty filter is sticky downhill: play → AthleteSeason → Athlete → AthletePosition all stay lean, each row persisting via the existing dependency/retry loop while every enrichment spawn is cut. The play still persists as canonical data.

## Safety verified before merge

- **Player pick'em scoring is untouched**: it consumes per-game `EventCompetitionAthleteStatistics`, spawned by the roster/leaders/play processors — not the AthleteSeason subtree — and its processor resolves the `AthleteSeason` row itself. Full evidence chain in the design doc.
- **Audited every filter origin**: literal `null`, the static non-empty `ContestRefreshDocumentTypes` set, or operator HTTP pass-through. Nothing computes a list that could collapse to empty. Two unit tests encoded the old "empty = all" idiom (to defeat AutoFixture's random ctor fill) and now pass explicit `null`.
- Baseball's participant hop publishes no dependency requests; football is the only spawner.

## Test hygiene (same PR)

`ProducerTestBase` now pins `ProcessDocumentCommand`'s bool flags to false for fixture-built commands via a specimen builder — AutoFixture fills bools by alternation, so adding any bool to the command flips which flag lands true across the suite (discovered when a prototype bool turned two green AthleteSeason guard tests red). `EventCompetitionOddsDocumentProcessorTests` sets `NotifyOnCompletion` explicitly instead of receiving it by parity accident.

## Validation

- Producer unit: **639 passed, 0 failed** (7 new tests)
- Provider unit: 91 passed · Core unit: 265 passed
- Full solution builds clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnJySMvfUPeQSMufNNcKSK


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added precise control over linked-document processing: omitted filters include all linked documents, empty filters include none, and selected filters include only specified types.
  - Propagated linked-document filters through published requests, with targeted overrides for dependency requests.
  - Restricted football participant requests to required documents, reducing unnecessary cascading data.

- **Documentation**
  - Added design documentation covering cascade scoping, backlog contributors, implemented fixes, retry behavior, and open questions.

- **Tests**
  - Added coverage validating filter propagation, empty-filter behavior, dependency requests, and notification settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->