### PR TITLE
feat(mobile): deetsMeter + StatBot pick indicator on MatchupCard (web parity)

### DIFF
--- a/src/UI/sd-mobile/__tests__/components/features/games/DeetsMeter.test.tsx
+++ b/src/UI/sd-mobile/__tests__/components/features/games/DeetsMeter.test.tsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react-native';
+
+import { DeetsMeter } from '@/src/components/features/games/DeetsMeter';
+import type { ContestPrediction } from '@/src/types/models';
+
+const CID = '00000000-0000-0000-0000-000000000001';
+const AWAY_FSID = '00000000-0000-0000-0000-0000000000a1';
+const HOME_FSID = '00000000-0000-0000-0000-0000000000a2';
+
+const prediction = (overrides?: Partial<ContestPrediction>): ContestPrediction => ({
+  contestId: CID,
+  winnerFranchiseSeasonId: HOME_FSID,
+  winProbability: 0.72,
+  predictionType: 'StraightUp',
+  modelVersion: 'v1.1.2',
+  ...overrides,
+});
+
+const renderMeter = (
+  predictions: ContestPrediction[] | undefined,
+  pickType?: 'StraightUp' | 'AgainstTheSpread' | null
+) =>
+  render(
+    <DeetsMeter
+      predictions={predictions}
+      pickType={pickType}
+      homeFranchiseSeasonId={HOME_FSID}
+      awayFranchiseSeasonId={AWAY_FSID}
+    />
+  );
+
+describe('DeetsMeter', () => {
+  it('renders nothing when there are no predictions', () => {
+    renderMeter(undefined, null);
+    expect(screen.queryByTestId('deetsmeter')).toBeNull();
+  });
+
+  it('renders nothing when predictions exist but none are SU or ATS', () => {
+    renderMeter([prediction({ predictionType: 'OverUnder' })], null);
+    expect(screen.queryByTestId('deetsmeter')).toBeNull();
+  });
+
+  it('shows only the SU meter in a StraightUp league', () => {
+    renderMeter(
+      [
+        prediction(),
+        prediction({ predictionType: 'AgainstTheSpread', winProbability: 0.55 }),
+      ],
+      'StraightUp'
+    );
+    expect(screen.getByTestId('deetsmeter-su')).toBeTruthy();
+    expect(screen.queryByTestId('deetsmeter-ats')).toBeNull();
+  });
+
+  it('shows only the ATS meter in an AgainstTheSpread league', () => {
+    renderMeter(
+      [
+        prediction(),
+        prediction({ predictionType: 'AgainstTheSpread', winProbability: 0.55 }),
+      ],
+      'AgainstTheSpread'
+    );
+    expect(screen.queryByTestId('deetsmeter-su')).toBeNull();
+    expect(screen.getByTestId('deetsmeter-ats')).toBeTruthy();
+  });
+
+  it('shows both meters when pickType is not supplied (web parity)', () => {
+    renderMeter(
+      [
+        prediction(),
+        prediction({ predictionType: 'AgainstTheSpread', winProbability: 0.55 }),
+      ],
+      null
+    );
+    expect(screen.getByTestId('deetsmeter-su')).toBeTruthy();
+    expect(screen.getByTestId('deetsmeter-ats')).toBeTruthy();
+  });
+
+  it('computes home/away percentages when home is favored', () => {
+    // winProbability belongs to the WINNER side: home at 0.72 → 72 / 28.
+    renderMeter([prediction()], 'StraightUp');
+    expect(screen.getByText('72%')).toBeTruthy();
+    expect(screen.getByText('28%')).toBeTruthy();
+  });
+
+  it('inverts the percentage when away is favored', () => {
+    // Away at 0.72 → home is round(1 - 0.72) = 28, away the complement 72.
+    renderMeter(
+      [prediction({ winnerFranchiseSeasonId: AWAY_FSID })],
+      'StraightUp'
+    );
+    expect(screen.getByText('72%')).toBeTruthy();
+    expect(screen.getByText('28%')).toBeTruthy();
+  });
+
+  it('percentages always sum to 100 across rounding (web-verbatim math)', () => {
+    // 0.505 → home round(50.5) = 51, away = 100 - 51 = 49 (not round(49.5)=50).
+    renderMeter([prediction({ winProbability: 0.505 })], 'StraightUp');
+    expect(screen.getByText('51%')).toBeTruthy();
+    expect(screen.getByText('49%')).toBeTruthy();
+  });
+
+  it('renders the deetsMeter header', () => {
+    renderMeter([prediction()], 'StraightUp');
+    expect(screen.getByText('deetsMeter™')).toBeTruthy();
+  });
+});

--- a/src/UI/sd-mobile/__tests__/components/features/games/MatchupCard.live.test.tsx
+++ b/src/UI/sd-mobile/__tests__/components/features/games/MatchupCard.live.test.tsx
@@ -366,3 +366,37 @@ describe('MatchupCard — live updates', () => {
     expect(screen.queryByText('LIVE')).toBeNull();
   });
 });
+
+describe('MatchupCard — StatBot pick indicator', () => {
+  beforeEach(() => {
+    useContestUpdatesStore.setState(useContestUpdatesStore.getInitialState(), true);
+  });
+
+  it('shows the robot on the AI-predicted team and only that team', () => {
+    const matchup = buildFootballMatchup({
+      aiWinnerFranchiseSeasonId: '00000000-0000-0000-0000-0000000000b2', // home (BUF)
+    });
+
+    renderWithProviders(
+      <MatchupCard matchup={matchup} pick={undefined} onPick={jest.fn()} />,
+    );
+
+    // Exactly one robot, and it sits on the home button — asserted by there
+    // being one indicator while both teams render. Team shorts use
+    // getAllByText: with logoUri null the license-free placeholder ALSO
+    // prints the abbreviation, so each short appears twice by design.
+    expect(screen.getAllByTestId('ai-pick-indicator')).toHaveLength(1);
+    expect(screen.getAllByText('BUF').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('KC').length).toBeGreaterThan(0);
+  });
+
+  it('shows no robot when the matchup has no AI winner', () => {
+    const matchup = buildFootballMatchup();
+
+    renderWithProviders(
+      <MatchupCard matchup={matchup} pick={undefined} onPick={jest.fn()} />,
+    );
+
+    expect(screen.queryByTestId('ai-pick-indicator')).toBeNull();
+  });
+});

--- a/src/UI/sd-mobile/src/components/features/games/DeetsMeter.tsx
+++ b/src/UI/sd-mobile/src/components/features/games/DeetsMeter.tsx
@@ -1,0 +1,202 @@
+// deetsMeter — model win-probability bars (mobile port of
+// sd-ui/src/components/matchups/DeetsMeter.jsx).
+//
+// Renders up to two meters (SU / ATS) as a single bar split at the away-team
+// percentage: away color fills the left segment, home color the right. The
+// web version draws this with a hard-stop CSS linear-gradient; two
+// flex-weighted Views produce the identical visual with no gradient library.
+//
+// Meter selection mirrors web exactly: the league's pickType shows only its
+// own meter; a null/undefined pickType shows both. Renders nothing when the
+// matchup has no predictions (older contests, pipeline not yet run) — the
+// card simply tightens up, same as web.
+
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+
+import { getTheme } from '@/constants/Colors';
+import { useColorScheme } from '@/src/lib/theme/ThemeContext';
+import type { ContestPrediction, PickType } from '@/src/types/models';
+
+interface DeetsMeterProps {
+  predictions?: ContestPrediction[] | null;
+  /** League pick mode — filters which meters render (web parity). */
+  pickType?: PickType | null;
+  homeFranchiseSeasonId: string;
+  awayFranchiseSeasonId: string;
+}
+
+interface MeterData {
+  awayPercentage: number;
+  homePercentage: number;
+}
+
+/**
+ * Percentage math ported verbatim from web: the winProbability belongs to
+ * winnerFranchiseSeasonId; home gets round(p) or round(1-p) accordingly and
+ * away is the complement, so the two always sum to exactly 100.
+ */
+function getPredictionData(
+  prediction: ContestPrediction | undefined,
+  homeFranchiseSeasonId: string
+): MeterData | null {
+  if (!prediction) return null;
+
+  const isHomeFavored = prediction.winnerFranchiseSeasonId === homeFranchiseSeasonId;
+  const winProbability = prediction.winProbability;
+
+  const homePercentage = isHomeFavored
+    ? Math.round(winProbability * 100)
+    : Math.round((1 - winProbability) * 100);
+  const awayPercentage = 100 - homePercentage;
+
+  return { awayPercentage, homePercentage };
+}
+
+export function DeetsMeter({
+  predictions,
+  pickType,
+  homeFranchiseSeasonId,
+  awayFranchiseSeasonId,
+}: DeetsMeterProps) {
+  const scheme = useColorScheme();
+  const theme = getTheme(scheme);
+
+  const straightUpData = getPredictionData(
+    predictions?.find((p) => p.predictionType === 'StraightUp'),
+    homeFranchiseSeasonId
+  );
+  const atsData = getPredictionData(
+    predictions?.find((p) => p.predictionType === 'AgainstTheSpread'),
+    homeFranchiseSeasonId
+  );
+
+  // Nothing to show — render nothing, exactly like web.
+  if (!straightUpData && !atsData) {
+    return null;
+  }
+
+  // Deliberately muted, NOT team colors (owner call, 2026-09-01): a
+  // team-colored bar reads as authoritative, and this is a single model
+  // signal that can — and often does — disagree with StatBot's pick.
+  // Matches what the web app actually renders per theme (App.css
+  // --meter-*-fallback; its --away-color/--home-color hooks are never
+  // set): dark = grayscale #444/#666, light = the accent/accent-hover
+  // blue pair (#0077cc/#005fa3 — theme.tint is the same #0077cc).
+  const awayFill = scheme === 'dark' ? '#444' : theme.tint;
+  const homeFill = scheme === 'dark' ? '#666' : '#005fa3';
+
+  const renderMeter = (data: MeterData | null, label: string) => {
+    if (!data) return null;
+
+    const { awayPercentage, homePercentage } = data;
+
+    return (
+      <View style={styles.meterRow} testID={`deetsmeter-${label.toLowerCase()}`}>
+        <View style={[styles.meterBar, { borderColor: theme.border }]}>
+          {/* Hard-stop split at awayPercentage — web's linear-gradient
+              equivalent. Zero-width segments are legal flex values, so a
+              100/0 split renders as a solid bar rather than crashing. */}
+          <View style={{ flex: awayPercentage, backgroundColor: awayFill }} />
+          <View style={{ flex: homePercentage, backgroundColor: homeFill }} />
+
+          {/* Overlays — absolutely positioned atop the split bar. */}
+          <View style={styles.meterOverlay} pointerEvents="none">
+            <Text style={styles.meterPercentage}>{awayPercentage}%</Text>
+            <Text style={styles.meterPercentage}>{homePercentage}%</Text>
+          </View>
+          <View style={styles.meterMidline} pointerEvents="none" />
+          <View style={styles.meterLabelWrap} pointerEvents="none">
+            <Text style={styles.meterLabel}>{label}</Text>
+          </View>
+        </View>
+      </View>
+    );
+  };
+
+  // Which meters show is the league's mode: only SU in a StraightUp league,
+  // only ATS in a spread league, both when no mode is supplied (web parity).
+  const showSU = !pickType || pickType === 'StraightUp';
+  const showATS = !pickType || pickType === 'AgainstTheSpread';
+
+  return (
+    <View style={styles.container} testID="deetsmeter">
+      <Text style={[styles.header, { color: theme.tint }]}>deetsMeter™</Text>
+      <View style={styles.meters}>
+        {showSU && renderMeter(straightUpData, 'SU')}
+        {showATS && renderMeter(atsData, 'ATS')}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    paddingHorizontal: 12,
+    paddingBottom: 4,
+  },
+  header: {
+    fontSize: 12,
+    fontWeight: '600',
+    textAlign: 'center',
+    letterSpacing: 0.8,
+    marginBottom: 4,
+  },
+  meters: {
+    flexDirection: 'row',
+    gap: 16,
+  },
+  meterRow: {
+    flex: 1,
+    minWidth: 0,
+  },
+  meterBar: {
+    flexDirection: 'row',
+    height: 32,
+    borderRadius: 16,
+    borderWidth: 2,
+    overflow: 'hidden',
+    position: 'relative',
+  },
+  meterOverlay: {
+    ...StyleSheet.absoluteFillObject,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 8,
+    zIndex: 2,
+  },
+  meterMidline: {
+    position: 'absolute',
+    top: 0,
+    bottom: 0,
+    left: '50%',
+    width: 2,
+    marginLeft: -1,
+    backgroundColor: 'rgba(255, 255, 255, 0.3)',
+    zIndex: 1,
+  },
+  meterLabelWrap: {
+    ...StyleSheet.absoluteFillObject,
+    alignItems: 'center',
+    justifyContent: 'center',
+    zIndex: 3,
+  },
+  meterLabel: {
+    fontSize: 10,
+    fontWeight: '700',
+    color: 'rgba(255, 255, 255, 0.6)',
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+  },
+  meterPercentage: {
+    fontSize: 12,
+    fontWeight: '700',
+    color: '#ffffff',
+    textShadowColor: 'rgba(0, 0, 0, 0.5)',
+    textShadowOffset: { width: 0, height: 1 },
+    textShadowRadius: 2,
+  },
+});
+
+export default DeetsMeter;

--- a/src/UI/sd-mobile/src/components/features/games/MatchupCard.tsx
+++ b/src/UI/sd-mobile/src/components/features/games/MatchupCard.tsx
@@ -1,10 +1,11 @@
 import React, { useMemo, useState } from 'react';
 import { View, TouchableOpacity, StyleSheet, Image } from 'react-native';
-import { Ionicons } from '@expo/vector-icons';
+import { Ionicons, MaterialCommunityIcons } from '@expo/vector-icons';
 import { Text } from '@/src/components/ui/AppText';
 import { useColorScheme } from '@/src/lib/theme/ThemeContext';
 import { Colors, getTheme } from '@/constants/Colors';
 import type { Matchup, UserPick, PickChoice, PreviewResponse, TeamComparisonData, PickType } from '@/src/types/models';
+import { DeetsMeter } from './DeetsMeter';
 import { matchupsApi } from '@/src/services/api/matchupsApi';
 import { teamCardApi } from '@/src/services/api/teamCardApi';
 import { useContestUpdate } from '@/src/stores/contestUpdatesStore';
@@ -357,6 +358,7 @@ function PickButton({
   isLocked,
   onPress,
   confidence,
+  isAiPick,
 }: {
   teamShort: string;
   isSelected: boolean;
@@ -365,6 +367,8 @@ function PickButton({
   onPress: () => void;
   /** Assigned confidence points — badged on the selected button. */
   confidence?: number | null;
+  /** StatBot's predicted winner — robot icon beside the team short (web parity). */
+  isAiPick?: boolean;
 }) {
   const scheme = useColorScheme();
   const theme = getTheme(scheme);
@@ -414,6 +418,18 @@ function PickButton({
       <Text style={[styles.pickBtnTeam, { color: teamColor }]} numberOfLines={1}>
         {teamShort}
       </Text>
+      {/* StatBot pick — robot beside the team short, mirroring web's lucide
+          <Bot /> in PickButton.jsx. Inherits teamColor so it stays legible
+          across selected/correct/incorrect button palettes. */}
+      {isAiPick && (
+        <View
+          style={styles.aiPickIcon}
+          testID="ai-pick-indicator"
+          accessibilityLabel="AI Selection"
+        >
+          <MaterialCommunityIcons name="robot" size={14} color={teamColor} />
+        </View>
+      )}
       {/* Confidence badge — only ever non-null in confidence leagues. */}
       {isSelected && confidence != null && (
         <View style={[styles.confidenceBadge, { borderColor: teamColor }]}>
@@ -469,6 +485,7 @@ function PickButtons({
         isLocked={locked}
         onPress={() => onPick('away', matchup.awayFranchiseSeasonId)}
         confidence={pickedAway ? confidence : null}
+        isAiPick={matchup.aiWinnerFranchiseSeasonId === matchup.awayFranchiseSeasonId}
       />
       <TouchableOpacity
         style={[styles.actionBtn, { backgroundColor: theme.separator }]}
@@ -500,6 +517,7 @@ function PickButtons({
         isLocked={locked}
         onPress={() => onPick('home', matchup.homeFranchiseSeasonId)}
         confidence={pickedHome ? confidence : null}
+        isAiPick={matchup.aiWinnerFranchiseSeasonId === matchup.homeFranchiseSeasonId}
       />
     </View>
   );
@@ -942,6 +960,16 @@ export function MatchupCard({ matchup, pick, onPress, onPressTeam, onPick, defer
         pickType={pickType}
       />
 
+      {/* deetsMeter — model win-probability bars (web parity: rendered
+          between the game status block and the pick buttons). Renders
+          nothing when the matchup carries no predictions. */}
+      <DeetsMeter
+        predictions={matchup.predictions}
+        pickType={pickType}
+        homeFranchiseSeasonId={matchup.homeFranchiseSeasonId}
+        awayFranchiseSeasonId={matchup.awayFranchiseSeasonId}
+      />
+
       {/* Inline pick buttons */}
       {onPick && (
         <PickButtons
@@ -1202,6 +1230,9 @@ const styles = StyleSheet.create({
   pickBtnTeam: {
     fontSize: 14,
     fontWeight: '700',
+  },
+  aiPickIcon: {
+    marginLeft: 4,
   },
   pickVsBox: {
     width: 28,

--- a/src/UI/sd-mobile/src/types/models.ts
+++ b/src/UI/sd-mobile/src/types/models.ts
@@ -175,7 +175,26 @@ export interface Matchup {
   isPreviewAvailable?: boolean;
   isPreviewReviewed?: boolean;
 
+  /**
+   * Model predictions for this contest (StatBot). One entry per prediction
+   * type; the deetsMeter renders StraightUp/AgainstTheSpread as win-probability
+   * bars. Present on the wire for every matchup that has been through the
+   * prediction pipeline; older contests may have none. Mirrors
+   * ContestPredictionDto on the API.
+   */
+  predictions?: ContestPrediction[];
+
   [key: string]: unknown;
+}
+
+/** Matches ContestPredictionDto on the API. */
+export interface ContestPrediction {
+  contestId: string;
+  winnerFranchiseSeasonId: string;
+  /** Probability (0..1) that winnerFranchiseSeasonId wins/covers, per predictionType. */
+  winProbability: number;
+  predictionType: PickType;
+  modelVersion: string;
 }
 
 // Response shape from GET /ui/leagues/{id}/matchups/{week}

--- a/src/UI/sd-ui/src/components/matchups/MatchupCard.css
+++ b/src/UI/sd-ui/src/components/matchups/MatchupCard.css
@@ -31,9 +31,7 @@
   height: 1.25em;
   display: inline-flex;
   align-items: center;
-  vertical-align: middle;
   transition: color 0.2s;
-  /* margin-bottom removed, spacing handled by flex gap */
 }
 .pick-button.selected {
   color: var(--text-inverse) !important;
@@ -587,7 +585,14 @@
   font-weight: bold;
   cursor: pointer;
   transition: all 0.3s ease;
-  text-align: center;
+  /* Flex, not text-align: the button mixes a text node with inline SVGs
+     (check/lock/robot icons), and baseline alignment sat the robot visibly
+     low beside the uppercase team short. Centering the cross axis aligns
+     every child the same way; the icons' vertical-align band-aids are
+     inert under flex. Existing icon margins still provide the spacing. */
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .pick-button:hover {

--- a/src/UI/sd-ui/src/components/matchups/PickButton.jsx
+++ b/src/UI/sd-ui/src/components/matchups/PickButton.jsx
@@ -51,7 +51,7 @@ function PickButton({
       {teamShort}
       {isAiPick && (
         <span title="AI Selection" aria-label="AI Selection">
-          <Bot className="ai-pick-indicator" style={{ marginLeft: 6, verticalAlign: 'middle' }} />
+          <Bot className="ai-pick-indicator" />
         </span>
       )}
     </button>


### PR DESCRIPTION
## Context

Mobile was missing the two model surfaces the web matchup card ships: the **StatBot pick** (robot icon on the predicted team's pick button) and the **deetsMeter** win-probability bars. Both were committed for the mobile app ahead of the 09-05/06 slate.

Pure UI change — zero backend work, zero new dependencies. Both fields already arrive on the shared league-matchups endpoint; `predictions` was on the wire but untyped on mobile.

## What changed

- **`models.ts`** — `ContestPrediction` interface (mirrors `ContestPredictionDto`) + `Matchup.predictions`.
- **`DeetsMeter.tsx` (new)** — port of sd-ui's `DeetsMeter`. Web draws a hard-stop CSS linear-gradient; two flex-weighted `View`s render the identical visual with no gradient library. Meter selection mirrors web exactly: the league's `pickType` shows only its own meter (SU/ATS), null shows both, no predictions renders nothing. Percentage math ported verbatim — home gets `round(p)` or `round(1-p)` by winner side, away is the complement, so the pair always sums to 100.
- **Muted colors, deliberately NOT team colors** (owner call): a team-colored bar reads as authoritative, and this is a single model signal that can — and often does — disagree with StatBot. Matches what web actually renders per theme (dark = grayscale `#444`/`#666`, light = the accent blue pair; web's `--away-color`/`--home-color` hooks are never set anywhere).
- **`MatchupCard.tsx`** — `PickButton` gains `isAiPick` and renders a robot glyph (`MaterialCommunityIcons`, existing icon package) beside the team short, inheriting the button's text color across selected/correct/incorrect palettes. Meter mounts between `GameStatus` and the pick row, matching web placement.

## Tests

- 9 new `DeetsMeter` tests: pickType filtering, null-render on no/irrelevant predictions, favored-side inversion, rounding-sum invariant (0.505 → 51/49, never 51/50).
- 2 StatBot indicator tests: exactly one robot on the AI side; none without an AI winner. Team-short assertions use `getAllByText` because the license-free logo placeholder also prints the abbreviation when a team has no logo.
- Full mobile suite: **189/189**, `tsc --noEmit` clean. Validated on-device by the operator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnJySMvfUPeQSMufNNcKSK
