### PR TITLE
feat(mobile): home screen polish — creation CTAs, first-place votes, poll card consistency

### DIFF
--- a/src/UI/sd-mobile/src/components/features/home/PrimarySlotOffSeasonCountdown.tsx
+++ b/src/UI/sd-mobile/src/components/features/home/PrimarySlotOffSeasonCountdown.tsx
@@ -112,7 +112,11 @@ export function PrimarySlotOffSeasonCountdown() {
   const eyebrow = allLive ? seasonLabel : `${seasonLabel} KICKOFFS`;
 
   const body = allLive
-    ? 'Jump into your leagues and lock in your picks before the next kickoff.'
+    // Creation wording even when everything is live — the actions row only
+    // offers create CTAs (the picks shortcut had a wrong-league hazard), so
+    // the copy must not steer to leagues a user may not have. Revisit with
+    // the all-live CTA redesign.
+    ? "Spin up a pick'em league and get your picks in before the next kickoff."
     : allGated
       ? "Leagues open soon - we'll be ready before Week\u00A01."
       : seasonYear
@@ -138,7 +142,7 @@ export function PrimarySlotOffSeasonCountdown() {
 
       {allLive ? (
         <Text style={[styles.headline, { color: theme.text }]}>
-          NCAAFB and NFL are underway — pick your week
+          NCAAFB and NFL are underway
         </Text>
       ) : (
         <View style={styles.headlineLines}>

--- a/src/UI/sd-mobile/src/components/features/home/PrimarySlotOffSeasonCountdown.tsx
+++ b/src/UI/sd-mobile/src/components/features/home/PrimarySlotOffSeasonCountdown.tsx
@@ -153,27 +153,23 @@ export function PrimarySlotOffSeasonCountdown() {
       <Text style={[styles.body, { color: theme.textMuted }]}>{body}</Text>
 
       <View style={styles.actions}>
-        {allLive ? (
-          <Button
-            title="Go to picks"
-            onPress={() => router.push('/(tabs)/picks' as never)}
-            size="md"
-            style={styles.actionButton}
-          />
-        ) : (
+        {/* Always the per-sport creation CTAs — including when everything is
+            live (owner call, 2026-09-01): the "Go to picks" shortcut had the
+            same wrong-league hazard for users without a league in the sport.
+            The all-live presentation may get a redesigned CTA once that state
+            is actually reached; until then, creation is the one action this
+            card offers. */}
+        {(
           phrases.map((s) => {
-            const isLive = s.phrase.status === 'live';
-            if (isLive) {
-              return (
-                <Button
-                  key={s.key}
-                  title={`Pick ${s.label} games`}
-                  onPress={() => router.push('/(tabs)/picks' as never)}
-                  size="md"
-                  style={styles.actionButton}
-                />
-              );
-            }
+            // Deliberately NO live special-case here (owner call, 2026-09-01):
+            // this card is a league-CREATION surface, and a "Pick {sport}
+            // games" CTA routed to the generic picks tab, which lands a user
+            // with zero leagues in that sport on some unrelated default
+            // league (observed: an NFL league for a no-NCAAFB user). A live
+            // sport that isn't gated still gets the create CTA below; users
+            // with leagues reach picks through the tab bar. It also kept the
+            // action row lopsided — a one-line label beside the two-line
+            // create/gated buttons.
 
             // Creation gated (e.g. NCAAFB awaiting AP Poll release) — show when it
             // opens instead of a create action. The server enforces the same gate.

--- a/src/UI/sd-mobile/src/components/features/home/RankingsCard.tsx
+++ b/src/UI/sd-mobile/src/components/features/home/RankingsCard.tsx
@@ -74,6 +74,9 @@ export function RankingsCard() {
         {topEntries.map((team, i) => {
           // The wire carries one logo URL — no theme variants (see rankingsApi).
           const logoSrc = team.franchiseLogoUrl;
+          // One fallback, used by BOTH the visible name and the a11y label —
+          // otherwise a missing name reads "Unknown" but announces "undefined".
+          const teamName = team.franchiseName || 'Unknown';
           return (
             <TouchableOpacity
               key={team.franchiseSeasonId || team.rank}
@@ -83,7 +86,7 @@ export function RankingsCard() {
               // Mirrors the visible row: rank, name, and (when shown) the
               // first-place votes — screen readers hear what sighted users see.
               accessibilityLabel={
-                `Open ${team.franchiseName}, ranked ${team.rank}` +
+                `Open ${teamName}, ranked ${team.rank}` +
                 ((team.firstPlaceVotes ?? 0) > 0
                   ? `, ${team.firstPlaceVotes} first-place votes`
                   : '')
@@ -108,7 +111,7 @@ export function RankingsCard() {
                   style={[styles.name, { color: theme.text }]}
                   numberOfLines={1}
                 >
-                  {team.franchiseName || 'Unknown'}
+                  {teamName}
                 </Text>
                 {(team.firstPlaceVotes ?? 0) > 0 && (
                   <Text style={[styles.firstPlaceVotes, { color: theme.textSecondary }]}>

--- a/src/UI/sd-mobile/src/components/features/home/RankingsCard.tsx
+++ b/src/UI/sd-mobile/src/components/features/home/RankingsCard.tsx
@@ -91,9 +91,24 @@ export function RankingsCard() {
               <View style={styles.logoSlot}>
                 {logoSrc ? <Image source={{ uri: logoSrc }} style={styles.logo} /> : null}
               </View>
-              <Text style={[styles.name, { color: theme.text }]} numberOfLines={1}>
-                {team.franchiseName || 'Unknown'}
-              </Text>
+              {/* name + AP-style first-place votes, e.g. "Ohio State (40)".
+                  The votes are their own element INSIDE the flex:1 block so
+                  they sit adjacent to the name (AP convention) while a long
+                  school name truncates before the votes do; zero/absent
+                  renders nothing — most ranked teams have no #1 votes. */}
+              <View style={styles.nameBlock}>
+                <Text
+                  style={[styles.name, { color: theme.text }]}
+                  numberOfLines={1}
+                >
+                  {team.franchiseName || 'Unknown'}
+                </Text>
+                {(team.firstPlaceVotes ?? 0) > 0 && (
+                  <Text style={[styles.firstPlaceVotes, { color: theme.textSecondary }]}>
+                    ({team.firstPlaceVotes})
+                  </Text>
+                )}
+              </View>
               <Text style={[styles.record, { color: theme.textSecondary }]}>
                 {team.wins}-{team.losses}
               </Text>
@@ -106,12 +121,15 @@ export function RankingsCard() {
 }
 
 const styles = StyleSheet.create({
+  // Card recipe matches JoinableLeaguesCard EXACTLY. The previous drift
+  // (borderWidth 1 vs hairline, 12 vertical padding, own marginBottom
+  // stacking with the scroll gap, eyebrow 12 vs 11) added up to visibly
+  // inconsistent insets between adjacent home cards. Per-card spacing
+  // overrides are a pattern we deliberately do not start on mobile.
   card: {
     borderRadius: 14,
-    borderWidth: 1,
-    paddingHorizontal: 16,
-    paddingVertical: 12,
-    marginBottom: 12,
+    borderWidth: StyleSheet.hairlineWidth,
+    padding: 16,
   },
   headerRow: {
     flexDirection: 'row',
@@ -120,7 +138,7 @@ const styles = StyleSheet.create({
     marginBottom: 4,
   },
   eyebrow: {
-    fontSize: 12,
+    fontSize: 11,
     fontWeight: '700',
     letterSpacing: 1.5,
   },
@@ -134,9 +152,17 @@ const styles = StyleSheet.create({
     paddingVertical: 7,
     gap: 8,
   },
+  // Left-aligned, not right: right-alignment inside the gutter meant the
+  // rank NEVER started at the card's 16px content line — even double
+  // digits sat ~9px deep, reading as an inset against the neighboring
+  // cards whose text all starts flush (measured 2026-09-01). minWidth
+  // still fixes the logo/name columns across rows.
   rank: {
-    minWidth: 22,
-    textAlign: 'right',
+    // No reserved gutter: this card only ever renders the top 5, so every
+    // rank is one digit and rows can't misalign — the row gap alone spaces
+    // rank/logo/name. (The full rankings screen, which does show double
+    // digits, is a different component.) A reserved column here just read
+    // as dead space between the digit and the logo.
     fontWeight: '700',
     fontVariant: ['tabular-nums'],
   },
@@ -149,9 +175,18 @@ const styles = StyleSheet.create({
     height: 20,
     resizeMode: 'contain',
   },
-  name: {
+  nameBlock: {
     flex: 1,
+    flexDirection: 'row',
+    alignItems: 'baseline',
+  },
+  name: {
+    flexShrink: 1,
     fontWeight: '500',
+  },
+  firstPlaceVotes: {
+    fontSize: 12,
+    marginLeft: 4,
   },
   record: {
     fontSize: 13,

--- a/src/UI/sd-mobile/src/components/features/home/RankingsCard.tsx
+++ b/src/UI/sd-mobile/src/components/features/home/RankingsCard.tsx
@@ -80,7 +80,14 @@ export function RankingsCard() {
               onPress={() => openTeam(team.franchiseSlug)}
               activeOpacity={0.6}
               accessibilityRole="button"
-              accessibilityLabel={`Open ${team.franchiseName}`}
+              // Mirrors the visible row: rank, name, and (when shown) the
+              // first-place votes — screen readers hear what sighted users see.
+              accessibilityLabel={
+                `Open ${team.franchiseName}, ranked ${team.rank}` +
+                ((team.firstPlaceVotes ?? 0) > 0
+                  ? `, ${team.firstPlaceVotes} first-place votes`
+                  : '')
+              }
               style={[
                 styles.row,
                 i > 0 && { borderTopWidth: StyleSheet.hairlineWidth, borderTopColor: theme.border },


### PR DESCRIPTION
## Context

Pre-EAS-build sweep of the mobile home screen, operator-validated on-device via Expo at each step. Rides the next build with #700 (deetsMeter/StatBot parity).

## PrimarySlotOffSeasonCountdown

- **Per-sport CTA is always creation-oriented.** The live special-case ("Pick {sport} games" → generic picks tab) landed users with zero leagues in that sport on an unrelated default league (observed: an NFL league for a no-NCAAFB user). Gated sports keep the "Opens {date}" chip; everything else gets "Create {sport} league".
- Same treatment for the all-live branch — the single "Go to picks" button carried the same wrong-league hazard. The all-live CTA may be redesigned when that state actually arrives (NFL kickoff week); comment marks the decision point.
- Side effect: the action row is symmetric again (the one-line live label beside two-line buttons was the lopsidedness).

## RankingsCard

- **AP-style first-place votes** beside the team name — "Ohio State (40)" — only when > 0. Own element inside the flex block so a long school name truncates before the votes do. Render-only; the DTO field was already typed.
- **Card recipe now matches JoinableLeaguesCard exactly** (hairline border, padding 16, no private marginBottom, eyebrow 11). The prior drift stacked into visibly inconsistent insets between adjacent home cards — pixel-measured, ~2px horizontal plus larger vertical drift. Per-card spacing overrides are a pattern deliberately not started on mobile; comments record the rule.
- **Rank gutter removed.** Right-alignment inside a reserved 22px column meant the rank never started at the content line — even double digits sat ~9px deep (proven with a +10-to-every-rank on-device experiment). This card only renders the top 5, so every rank is one digit and rows cannot misalign; the full rankings screen is a separate component.

## Validation

- `tsc --noEmit` clean; mobile suite **189/189**
- Operator-validated visually on-device after each change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnJySMvfUPeQSMufNNcKSK


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added sport-specific league creation actions for live, eligible sports.
  * Added first-place vote counts beside team names in rankings when available.
  * Added disabled opening-date actions for sports that are not yet available.

* **UI Improvements**
  * Updated all-live messaging and actions to promote league creation.
  * Updated rankings card spacing, borders, labels, and text layout.
  * Improved team-name truncation and accessibility labels for clearer rankings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->