### PR TITLE
fix(mobile): EAS runtimeVersion policy appVersion -> fingerprint

### DIFF
--- a/src/UI/sd-mobile/app.json
+++ b/src/UI/sd-mobile/app.json
@@ -100,7 +100,7 @@
     },
     "owner": "sportdeets",
     "runtimeVersion": {
-      "policy": "appVersion"
+      "policy": "fingerprint"
     },
     "updates": {
       "url": "https://u.expo.dev/7605ab96-0b46-4b5e-8940-3d492ead7d75"


### PR DESCRIPTION
## Why

The `appVersion` policy is the likely cause of the OTA attempt that broke testers on both platforms simultaneously: the runtime version is just the marketing version string, so an update reaches **any** installed build with the same `expo.version` — including builds whose natives differ from what the new JS bundle references. Native drift without a version bump = crash-on-launch for every installed client, both platforms at once.

## The fix

`fingerprint` hashes the actual native project (modules, config plugins, SDK). An update can only reach builds whose fingerprint matches exactly — the brick becomes impossible **by construction**: JS-only changes flow OTA; native changes make the update undeliverable to mismatched builds (forcing a store build) instead of fatal. SDK 55 supports it fully.

## Sequencing (time-sensitive)

Merge **before tonight's EAS builds** so those binaries carry fingerprint runtimes; tomorrow's `eas update` from the same tree then matches them for the two-device test.

Older binaries built under `appVersion` — including the build currently in App Store review — simply never match fingerprint updates: a safe no-op (they pick up changes via their next store build). No effect on the Apple submission itself; `runtimeVersion` is expo-updates metadata, not something App Review evaluates.

One-line diff; `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnJySMvfUPeQSMufNNcKSK


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Improved Expo update compatibility by adopting fingerprint-based runtime versioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->