### PR TITLE
feat(producer,web,mobile): spread-history facts earn their numbers — ATS distance guard + the games behind the count

### DIFF
--- a/src/SportsData.Core/Dtos/Canonical/ContestPreviewHistoryDto.cs
+++ b/src/SportsData.Core/Dtos/Canonical/ContestPreviewHistoryDto.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 
 namespace SportsData.Core.Dtos.Canonical
@@ -87,6 +87,31 @@ namespace SportsData.Core.Dtos.Canonical
 
         /// <summary>Earliest season in the corpus for this franchise — the honest search floor.</summary>
         public int SearchFloorSeason { get; set; }
+
+        /// <summary>
+        /// The games behind <see cref="CountLastFiveSeasons"/>, newest first,
+        /// capped at 10 — who was actually beaten (or lost to), with the
+        /// opponent's record that season as quality context. The count remains
+        /// the authority on totals; this list is its evidence.
+        /// </summary>
+        public List<PreviewMarginInstanceDto> WindowGames { get; set; } = [];
+    }
+
+    /// <summary>One qualifying game inside the five-season count window.</summary>
+    public class PreviewMarginInstanceDto
+    {
+        public DateTime GameDate { get; set; }
+
+        public int SeasonYear { get; set; }
+
+        public string Opponent { get; set; } = default!;
+
+        public int TeamScore { get; set; }
+
+        public int OpponentScore { get; set; }
+
+        /// <summary>Opponent's overall W-L that season ("7-5"); null when unsourced.</summary>
+        public string? OpponentSeasonRecord { get; set; }
     }
 
     /// <summary>

--- a/src/SportsData.Producer/Application/Contests/Queries/Matchups/GetContestPreviewHistory/ContestPreviewHistoryCache.cs
+++ b/src/SportsData.Producer/Application/Contests/Queries/Matchups/GetContestPreviewHistory/ContestPreviewHistoryCache.cs
@@ -150,7 +150,10 @@ public sealed class ContestPreviewHistoryCache : IContestPreviewHistoryCache
     {
         var spread = homeSpread?.ToString("0.##", CultureInfo.InvariantCulture) ?? "none";
 
-        return $"preview-history:v1:{query.ContestId}:{query.MeetingCount}:{query.RecentGameCount}:s{spread}";
+        // v2: ATS-pair distance guard (2026-09-01) changed the payload for
+        // wide spreads; the version bump retires 7-day-TTL v1 entries that
+        // would otherwise serve the stretched "35+ favorite" bullets.
+        return $"preview-history:v2:{query.ContestId}:{query.MeetingCount}:{query.RecentGameCount}:s{spread}";
     }
 
     /// <summary>

--- a/src/SportsData.Producer/Application/Contests/Queries/Matchups/GetContestPreviewHistory/GetContestPreviewHistoryQueryHandler.cs
+++ b/src/SportsData.Producer/Application/Contests/Queries/Matchups/GetContestPreviewHistory/GetContestPreviewHistoryQueryHandler.cs
@@ -1,4 +1,4 @@
-using Dapper;
+﻿using Dapper;
 
 using FluentValidation;
 
@@ -158,6 +158,19 @@ public class GetContestPreviewHistoryQueryHandler : IGetContestPreviewHistoryQue
     /// </summary>
     private static readonly double[] AtsKeyNumbers = [3, 7, 10, 14, 21, 28, 35];
 
+    /// <summary>
+    /// The ATS pair renders only when the chosen bucket actually describes the
+    /// line: within one touchdown. Past that, the cohort stops being evidence —
+    /// a 46.5-point favorite IS "a 35+ favorite", but that cohort's typical
+    /// member is a ~36-point spread and covering 35 says nothing about covering
+    /// 46.5 ("that's great, but it has zero bearing on a 46.5-point spread" —
+    /// owner, 2026-09-01, looking at Furman/Tennessee). The magnitude facts
+    /// above carry monster spreads; the ATS pair is omitted rather than
+    /// stretched. Widening the key-number ladder instead was rejected: cohorts
+    /// past 35 are too thin to say anything (the reason the buckets exist).
+    /// </summary>
+    private const double AtsBucketMaxDistancePoints = 7;
+
     private class SpreadTargetRow
     {
         public DateTime StartDateUtc { get; set; }
@@ -233,7 +246,7 @@ public class GetContestPreviewHistoryQueryHandler : IGetContestPreviewHistoryQue
         };
 
         var threshold = AtsKeyNumbers.Where(k => k <= magnitude).DefaultIfEmpty(0).Max();
-        if (threshold > 0)
+        if (threshold > 0 && magnitude - threshold <= AtsBucketMaxDistancePoints)
         {
             context.FavoriteAtsAsBigFavorite = await BuildAtsBucketFactAsync(
                 connection, favoriteFranchiseId, threshold, target.StartDateUtc, asFavorite: true, cancellationToken);
@@ -242,6 +255,16 @@ public class GetContestPreviewHistoryQueryHandler : IGetContestPreviewHistoryQue
         }
 
         return context;
+    }
+
+    private class MarginInstanceRow
+    {
+        public DateTime GameDate { get; set; }
+        public int SeasonYear { get; set; }
+        public string Opponent { get; set; } = default!;
+        public int TeamScore { get; set; }
+        public int OpponentScore { get; set; }
+        public string? OpponentSeasonRecord { get; set; }
     }
 
     private async Task<PreviewMarginFactDto> BuildMarginFactAsync(
@@ -302,6 +325,37 @@ public class GetContestPreviewHistoryQueryHandler : IGetContestPreviewHistoryQue
                 row.OpponentFranchiseSeasonId.Value, cancellationToken);
             fact.OpponentPriorSeasonRecord = await GetPriorSeasonOverallRecordAsync(
                 row.OpponentFranchiseSeasonId.Value, cancellationToken);
+        }
+
+        // The games BEHIND the count — "8 such wins" invites exactly one
+        // question ("against whom?") and this list answers it (owner ask,
+        // 2026-09-01). Fetched only when the count is non-zero; opponent
+        // records ride the same query (SQL lateral), so this is one round
+        // trip on an already off-request-path generation.
+        if (fact.CountLastFiveSeasons > 0)
+        {
+            var instances = await connection.QueryAsync<MarginInstanceRow>(
+                new CommandDefinition(
+                    _sqlProvider.GetFranchiseMarginInstances(),
+                    new
+                    {
+                        FranchiseId = franchiseId,
+                        Margin = margin,
+                        AsOf = asOf,
+                        WindowStartSeason = targetSeasonYear - 4,
+                        Won = won
+                    },
+                    cancellationToken: cancellationToken));
+
+            fact.WindowGames = instances.Select(x => new PreviewMarginInstanceDto
+            {
+                GameDate = x.GameDate,
+                SeasonYear = x.SeasonYear,
+                Opponent = x.Opponent,
+                TeamScore = x.TeamScore,
+                OpponentScore = x.OpponentScore,
+                OpponentSeasonRecord = x.OpponentSeasonRecord
+            }).ToList();
         }
 
         return fact;

--- a/src/SportsData.Producer/Infrastructure/Sql/GetFranchiseMarginInstances.sql
+++ b/src/SportsData.Producer/Infrastructure/Sql/GetFranchiseMarginInstances.sql
@@ -1,0 +1,77 @@
+-- The games BEHIND the margin fact's count: every qualifying win/loss by
+-- >= @Margin inside the five-season window, newest first, each with the
+-- opponent and the opponent's overall record that season. This is what
+-- turns "8 such wins in the last 5 seasons" into an argument — a reader
+-- can see WHO was actually beaten (docs/features: spread-contextualized
+-- history; owner ask 2026-09-01).
+--
+-- Same preview-safe frame as GetFranchiseMarginFact.sql: finalized,
+-- non-cancelled, strictly before @AsOf, preseason (TypeCode 1) excluded.
+-- Capped at 10 rows; the headline count remains the authority on totals.
+WITH franchise_games AS (
+    SELECT
+        c."StartDateUtc",
+        c."SeasonYear",
+        CASE WHEN fsHome."FranchiseId" = @FranchiseId
+             THEN fAway."DisplayName" ELSE fHome."DisplayName"
+        END AS "Opponent",
+        CASE WHEN fsHome."FranchiseId" = @FranchiseId
+             THEN c."HomeScore" ELSE c."AwayScore"
+        END AS "TeamScore",
+        CASE WHEN fsHome."FranchiseId" = @FranchiseId
+             THEN c."AwayScore" ELSE c."HomeScore"
+        END AS "OpponentScore",
+        CASE WHEN fsHome."FranchiseId" = @FranchiseId
+             THEN c."AwayTeamFranchiseSeasonId"
+             ELSE c."HomeTeamFranchiseSeasonId"
+        END AS "OpponentFranchiseSeasonId",
+        CASE WHEN fsHome."FranchiseId" = @FranchiseId
+             THEN c."HomeScore" - c."AwayScore"
+             ELSE c."AwayScore" - c."HomeScore"
+        END AS "OurMargin"
+    FROM public."Contest" c
+    INNER JOIN public."FranchiseSeason" fsAway ON fsAway."Id" = c."AwayTeamFranchiseSeasonId"
+    INNER JOIN public."Franchise" fAway ON fAway."Id" = fsAway."FranchiseId"
+    INNER JOIN public."FranchiseSeason" fsHome ON fsHome."Id" = c."HomeTeamFranchiseSeasonId"
+    INNER JOIN public."Franchise" fHome ON fHome."Id" = fsHome."FranchiseId"
+    LEFT JOIN public."SeasonPhase" sp ON sp."Id" = c."SeasonPhaseId"
+    WHERE (fsHome."FranchiseId" = @FranchiseId OR fsAway."FranchiseId" = @FranchiseId)
+      AND c."FinalizedUtc" IS NOT NULL
+      AND c."CancelledUtc" IS NULL
+      AND c."HomeScore" IS NOT NULL
+      AND c."AwayScore" IS NOT NULL
+      AND c."StartDateUtc" < @AsOf
+      AND (sp."TypeCode" IS NULL OR sp."TypeCode" <> 1)
+)
+SELECT
+    fg."StartDateUtc" AS "GameDate",
+    fg."SeasonYear",
+    fg."Opponent",
+    fg."TeamScore",
+    fg."OpponentScore",
+    rec."OpponentSeasonRecord"
+FROM franchise_games fg
+LEFT JOIN LATERAL (
+    -- Opponent's overall record THAT season, "W-L". Mirrors the C#
+    -- GetOverallRecordAsync (FranchiseSeasonRecord Type='total', stats
+    -- 'wins'/'losses'); absent stays NULL — never a fabricated 0-0.
+    SELECT CONCAT(
+        MAX(CASE WHEN st."Name" = 'wins'   THEN st."Value"::int END),
+        '-',
+        MAX(CASE WHEN st."Name" = 'losses' THEN st."Value"::int END)
+    ) AS "OpponentSeasonRecord"
+    FROM public."FranchiseSeasonRecord" r
+    INNER JOIN public."FranchiseSeasonRecordStat" st
+        ON st."FranchiseSeasonRecordId" = r."Id"
+    WHERE r."FranchiseSeasonId" = fg."OpponentFranchiseSeasonId"
+      AND r."Type" = 'total'
+    -- Both stats or nothing (feature honesty rule): a missing side must
+    -- yield NULL, never a half-record like "12-".
+    HAVING MAX(CASE WHEN st."Name" = 'wins'   THEN st."Value"::int END) IS NOT NULL
+       AND MAX(CASE WHEN st."Name" = 'losses' THEN st."Value"::int END) IS NOT NULL
+) rec ON TRUE
+WHERE fg."SeasonYear" >= @WindowStartSeason
+  AND ((@Won AND fg."OurMargin" >= @Margin)
+    OR (NOT @Won AND fg."OurMargin" <= -@Margin))
+ORDER BY fg."StartDateUtc" DESC
+LIMIT 10

--- a/src/SportsData.Producer/Infrastructure/Sql/ProducerSqlQueryProvider.cs
+++ b/src/SportsData.Producer/Infrastructure/Sql/ProducerSqlQueryProvider.cs
@@ -1,4 +1,4 @@
-using SportsData.Producer.Application.Contests.Queries.Matchups;
+﻿using SportsData.Producer.Application.Contests.Queries.Matchups;
 
 namespace SportsData.Producer.Infrastructure.Sql;
 
@@ -23,6 +23,7 @@ public class ProducerSqlQueryProvider
         "GetContestPriorSeasonResults.sql",
         "GetContestSpreadTarget.sql",
         "GetFranchiseMarginFact.sql",
+        "GetFranchiseMarginInstances.sql",
         "GetFranchiseAtsBucket.sql",
         "GetFranchiseSeasonCompetitionResults.sql",
         "GetFranchiseSeasonPreviewStats.sql",
@@ -114,6 +115,8 @@ public class ProducerSqlQueryProvider
     public string GetContestSpreadTarget() => Get("GetContestSpreadTarget.sql");
 
     public string GetFranchiseMarginFact() => Get("GetFranchiseMarginFact.sql");
+
+    public string GetFranchiseMarginInstances() => Get("GetFranchiseMarginInstances.sql");
 
     public string GetFranchiseAtsBucket() => Get("GetFranchiseAtsBucket.sql");
 

--- a/src/UI/sd-mobile/src/components/features/games/StatsComparisonModal.tsx
+++ b/src/UI/sd-mobile/src/components/features/games/StatsComparisonModal.tsx
@@ -290,7 +290,7 @@ function priorSeasonRecordLabel(summary: ContestPriorSeasonSummary | null | unde
 // Deterministic sentences composed from server-computed facts — every number
 // comes from a query, never from prose. Mirrors the web dialog's wording.
 
-type LineFact = { head: string; detail: string };
+type LineFact = { head: string; detail: string; windowGames?: string[] };
 
 function marginFactSentence(
   teamName: string,
@@ -318,9 +318,18 @@ function marginFactSentence(
         })`
       : '';
   const times = fact.countLastFiveSeasons;
+  // The games behind the count, newest first — "8 such wins" invites exactly
+  // one question ("against whom?") and these lines answer it. Web twin:
+  // TeamComparison.jsx marginFactSentence.
+  const windowGames = (fact.windowGames ?? []).map((gm) => {
+    const yr = `'${String(gm.seasonYear).slice(-2)}`;
+    const rec = gm.opponentSeasonRecord ? ` (${gm.opponentSeasonRecord})` : '';
+    return `${yr} ${gm.opponent} ${gm.teamScore}-${gm.opponentScore}${rec}`;
+  });
   return {
     head: `Last time ${teamName} ${won ? 'won' : 'lost'} by ${magnitude}+:`,
     detail: `${when} — ${won ? 'beat' : 'lost to'} ${opponent} ${ourScore ?? '—'}-${theirScore ?? '—'}${quality}. ${times} such ${won ? 'win' : 'loss'}${times === 1 ? '' : won ? 's' : 'es'} in the last 5 seasons.`,
+    windowGames,
   };
 }
 
@@ -499,6 +508,18 @@ export function StatsComparisonModal({
                         <Text style={[styles.lineFactText, { color: theme.text }]}>
                           <Text style={styles.lineFactHead}>{f.head}</Text> {f.detail}
                         </Text>
+                        {(f.windowGames?.length ?? 0) > 0 && (
+                          <View style={styles.lineFactGames}>
+                            {f.windowGames!.map((g, j) => (
+                              <Text
+                                key={j}
+                                style={[styles.lineFactGame, { color: theme.textMuted }]}
+                              >
+                                {g}
+                              </Text>
+                            ))}
+                          </View>
+                        )}
                       </View>
                     ))}
                   </>
@@ -946,6 +967,15 @@ const styles = StyleSheet.create({
   },
   lineFactHead: {
     fontWeight: '700',
+  },
+  // Evidence list under a margin fact — muted, tabular, one game per line.
+  lineFactGames: {
+    marginTop: 4,
+    gap: 1,
+  },
+  lineFactGame: {
+    fontSize: 12,
+    fontVariant: ['tabular-nums'],
   },
 
   barTrack: {

--- a/src/UI/sd-mobile/src/types/models.ts
+++ b/src/UI/sd-mobile/src/types/models.ts
@@ -387,6 +387,19 @@ export interface ContestMarginFact {
   opponentPriorSeasonRecord?: string | null;
   countLastFiveSeasons: number;
   searchFloorSeason: number;
+  /** The games behind the count, newest first (server caps at 10). */
+  windowGames?: ContestMarginInstance[];
+}
+
+/** One qualifying game inside the five-season count window. */
+export interface ContestMarginInstance {
+  gameDate: string;
+  seasonYear: number;
+  opponent: string;
+  teamScore: number;
+  opponentScore: number;
+  /** Opponent's overall W-L that season ("7-5"); null when unsourced. */
+  opponentSeasonRecord?: string | null;
 }
 
 /** ATS record conditioned on spread size ("as a 35+ underdog") — market tier (~2022+). */

--- a/src/UI/sd-ui/src/components/teams/TeamComparison.css
+++ b/src/UI/sd-ui/src/components/teams/TeamComparison.css
@@ -662,6 +662,21 @@
   color: var(--text-primary);
 }
 
+/* The games behind a margin fact's count — compact evidence list. Muted and
+   smaller than the sentence it supports; two columns when space allows so
+   eight entries don't dominate the dialog. */
+.line-fact-games {
+  list-style: none;
+  margin: 0.3rem 0 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 0.1rem 1rem;
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  font-variant-numeric: tabular-nums;
+}
+
 .line-fact-detail {
   color: var(--text-primary);
 }

--- a/src/UI/sd-ui/src/components/teams/TeamComparison.jsx
+++ b/src/UI/sd-ui/src/components/teams/TeamComparison.jsx
@@ -668,9 +668,18 @@ export default function TeamComparison({
           })`
         : "";
     const times = fact.countLastFiveSeasons;
+    // The games behind the count, newest first — "8 such wins" invites
+    // exactly one question ("against whom?") and this line answers it.
+    // Compact: 'YY opponent score (their record). Server caps at 10.
+    const windowGames = (fact.windowGames ?? []).map((g) => {
+      const yr = `'${String(g.seasonYear).slice(-2)}`;
+      const rec = g.opponentSeasonRecord ? ` (${g.opponentSeasonRecord})` : "";
+      return `${yr} ${g.opponent} ${g.teamScore}-${g.opponentScore}${rec}`;
+    });
     return {
       head: `Last time ${teamName} ${won ? "won" : "lost"} by ${fmtLine(magnitude)}+:`,
       detail: `${when} — ${won ? "beat" : "lost to"} ${opponent} ${ourScore}-${theirScore}${quality}. ${times} such ${won ? "win" : "loss"}${times === 1 ? "" : won ? "s" : "es"} in the last 5 seasons.`,
+      windowGames,
     };
   };
 
@@ -707,6 +716,13 @@ export default function TeamComparison({
           <div className="line-fact" key={i}>
             <span className="line-fact-head">{f.head}</span>{" "}
             <span className="line-fact-detail">{f.detail}</span>
+            {f.windowGames?.length > 0 && (
+              <ul className="line-fact-games">
+                {f.windowGames.map((g, j) => (
+                  <li key={j}>{g}</li>
+                ))}
+              </ul>
+            )}
           </div>
         ))}
       </div>


### PR DESCRIPTION
## Context

Operator review of the Furman/Tennessee (-46.5) preview surfaced two problems in "The Line" block (spread-contextualized history, #659):

## 1. ATS distance guard

Key-number bucketing snapped 46.5 down to the 35+ bucket → "as a 35+ favorite: covered 8 of 11". True, but evidentially empty: that cohort's typical member is a ~36-point spread; covering 35 says nothing about covering 46.5. *"That's great, but it has zero bearing on a 46.5-point spread."*

The ATS pair now renders only when the bucket sits within **one touchdown** of the actual line (`AtsBucketMaxDistancePoints = 7`) — omitted rather than stretched past that. Widening the key-number ladder was rejected: cohorts past 35 are too thin to say anything, which is why the buckets exist.

| Spread | Bucket | ATS pair |
|---|---|---|
| 37.5 | 35 | shown |
| 41.5 | 35 | shown (edge) |
| 46.5 | 35 | omitted |
| 6.5 | 3 | shown (unchanged) |

## 2. The games behind the count

"8 such wins in the last 5 seasons" invites exactly one question — **against whom?** Each margin fact now carries its windowed qualifying games (newest first, cap 10): opponent, score, and the opponent's overall record that season. New `GetFranchiseMarginInstances.sql` joins the record laterally, preserving the feature's both-stats-or-nothing honesty rule (absent record stays null, never `"12-"`). Fetched only when the count is non-zero — one extra round trip on an off-request-path generation.

Rendered on web (two-column muted grid under the fact, TeamComparison) and mobile (stacked muted lines, StatsComparisonModal). **The mobile half is OTA-eligible** — pure JS, can ride tomorrow's `eas update` test.

## Cache

Payload shape changed → preview-history key bumped `v1` → `v2`, retiring 7-day-TTL entries carrying the stretched bullets. Entries regenerate lazily + via the line-move regeneration job; no invalidation dance.

## Validation

- Producer unit: 640 passed · Web: vitest 83/83, `eslint --max-warnings=0` clean · Mobile: `tsc` clean, jest 186/186
- Note: the spread-context slice has no unit coverage (Dapper-over-DbConnection); pinning the guard inequality would require exposing internals, which repo rules forbid. The guard is a single reviewed comparison.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnJySMvfUPeQSMufNNcKSK


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Margin and spread insights now include up to 10 recent qualifying games as supporting evidence.
  * Evidence shows the game date, season, opponent, score, and available opponent record.
  * Supporting game details are displayed directly beneath applicable facts in comparison views.

* **Improvements**
  * ATS facts are hidden when the selected key-number range is more than seven points below the live spread, improving relevance.
  * Evidence lists use compact, responsive formatting for easier scanning on mobile and desktop.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->