### PR TITLE
feat(api): server-side profanity filter for display names and league names

### DIFF
--- a/src/SportsData.Api/Application/Common/Moderation/ProfanityPolicy.cs
+++ b/src/SportsData.Api/Application/Common/Moderation/ProfanityPolicy.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using System.Text;
 
 namespace SportsData.Api.Application.Common.Moderation;
@@ -68,13 +67,17 @@ public static class ProfanityPolicy
     /// </summary>
     private static string Normalize(string value)
     {
-        var lowered = value.ToLowerInvariant().Normalize(NormalizationForm.FormD);
+        // FormKD, not FormD: canonical decomposition alone handles diacritics
+        // but leaves COMPATIBILITY characters intact, so full-width letters
+        // (e.g. “ｆｕｃｋ”) sailed through as non-a-z and matched nothing.
+        // Compatibility decomposition folds them to ASCII before matching.
+        var lowered = value.ToLowerInvariant().Normalize(NormalizationForm.FormKD);
         var sb = new StringBuilder(lowered.Length);
 
         foreach (var ch in lowered)
         {
             if (CharUnicodeInfo.GetUnicodeCategory(ch) == UnicodeCategory.NonSpacingMark)
-                continue; // diacritic — drop it (é→e came from FormD)
+                continue; // diacritic — drop it (é→e came from the FormKD decomposition)
 
             var folded = ch switch
             {

--- a/src/SportsData.Api/Application/Common/Moderation/ProfanityPolicy.cs
+++ b/src/SportsData.Api/Application/Common/Moderation/ProfanityPolicy.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+
+namespace SportsData.Api.Application.Common.Moderation;
+
+/// <summary>
+/// Profanity check for user-authored labels (display names, league names).
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Whole-word matching ONLY — never substring.</strong> These are
+/// names, and substring matching is the classic Scunthorpe problem: it blocks
+/// Sexton, Dickinson, Cummings, Hancock — real surnames, including the
+/// operator's. A candidate is rejected only when a normalized TOKEN equals a
+/// banned word, or the entire input collapsed to letters equals one (which
+/// catches spacing/punctuation evasion like "f.u.c.k").
+/// </para>
+/// <para>
+/// Normalization before matching: lowercase, diacritics stripped, common
+/// leet substitutions folded (0→o, 1→i, 3→e, 4→a, 5→s, 7→t, $→s, @→a, !→i),
+/// then split on every non-letter. "S3xt0n" therefore normalizes to "sexton"
+/// and still passes — the guarantee comes from whole-word equality, not from
+/// the normalizer being conservative.
+/// </para>
+/// <para>
+/// The wordlist is an embedded resource next to this file — one word per
+/// line, '#' comments allowed. It is deliberately curated for the NAME
+/// context (precision over recall): a miss is a moderation follow-up, a
+/// false positive blocks a real person's actual name. This filter is one
+/// layer; the operator can always remove content server-side.
+/// </para>
+/// </remarks>
+public static class ProfanityPolicy
+{
+    private static readonly Lazy<HashSet<string>> BannedWords = new(LoadWordList);
+
+    /// <summary>
+    /// True when the candidate contains a banned word as a whole token, or
+    /// collapses (letters-only) to one. Null/whitespace is not profane —
+    /// required-ness is a separate validation concern.
+    /// </summary>
+    public static bool ContainsProfanity(string? candidate)
+    {
+        if (string.IsNullOrWhiteSpace(candidate))
+            return false;
+
+        var normalized = Normalize(candidate);
+        var banned = BannedWords.Value;
+
+        foreach (var token in normalized.Split(' ', StringSplitOptions.RemoveEmptyEntries))
+        {
+            if (banned.Contains(token))
+                return true;
+        }
+
+        var collapsed = normalized.Replace(" ", string.Empty);
+        return banned.Contains(collapsed);
+    }
+
+    /// <summary>
+    /// Lowercase, strip diacritics, fold leet substitutions, and replace every
+    /// remaining non-letter with a space (token boundary).
+    /// </summary>
+    private static string Normalize(string value)
+    {
+        var lowered = value.ToLowerInvariant().Normalize(NormalizationForm.FormD);
+        var sb = new StringBuilder(lowered.Length);
+
+        foreach (var ch in lowered)
+        {
+            if (CharUnicodeInfo.GetUnicodeCategory(ch) == UnicodeCategory.NonSpacingMark)
+                continue; // diacritic — drop it (é→e came from FormD)
+
+            var folded = ch switch
+            {
+                '0' => 'o',
+                '1' => 'i',
+                '3' => 'e',
+                '4' => 'a',
+                '5' => 's',
+                '7' => 't',
+                '$' => 's',
+                '@' => 'a',
+                '!' => 'i',
+                _ => ch
+            };
+
+            sb.Append(folded is >= 'a' and <= 'z' ? folded : ' ');
+        }
+
+        return sb.ToString();
+    }
+
+    private static HashSet<string> LoadWordList()
+    {
+        var assembly = typeof(ProfanityPolicy).Assembly;
+        var resourceName = assembly
+            .GetManifestResourceNames()
+            .FirstOrDefault(n => n.EndsWith("profanity-wordlist.txt", StringComparison.OrdinalIgnoreCase))
+            ?? throw new InvalidOperationException(
+                "Embedded resource profanity-wordlist.txt not found — check the csproj EmbeddedResource entry.");
+
+        using var stream = assembly.GetManifestResourceStream(resourceName)!;
+        using var reader = new StreamReader(stream);
+
+        var words = new HashSet<string>(StringComparer.Ordinal);
+        while (reader.ReadLine() is { } line)
+        {
+            var word = line.Trim();
+            if (word.Length == 0 || word.StartsWith('#'))
+                continue;
+            words.Add(word.ToLowerInvariant());
+        }
+
+        return words;
+    }
+}

--- a/src/SportsData.Api/Application/Common/Moderation/profanity-wordlist.txt
+++ b/src/SportsData.Api/Application/Common/Moderation/profanity-wordlist.txt
@@ -1,0 +1,117 @@
+# Banned words for user-authored labels (display names, league names).
+# One word per line; '#' starts a comment. Matching is WHOLE-WORD ONLY after
+# normalization (see ProfanityPolicy) — never substring — so real surnames
+# like Sexton, Dickinson, Cummings, Hancock are unaffected by entries here.
+#
+# Curated for the NAME context: precision over recall. A miss is a manual
+# moderation follow-up; a false positive blocks someone's actual name.
+# Known tradeoff, deliberate: "dick"/"willy"/"fanny" are legitimate given
+# names but are listed because their abusive use in pick'em league contexts
+# vastly outnumbers the legitimate one; remove here if that call changes.
+
+# ── Core profanity ──
+fuck
+fucker
+fucking
+fucked
+motherfucker
+shit
+shits
+shithead
+shitty
+bullshit
+ass
+asshole
+assholes
+asshat
+asswipe
+dumbass
+jackass
+bitch
+bitches
+bastard
+damn
+goddamn
+crap
+piss
+pissed
+prick
+douche
+douchebag
+wanker
+bollocks
+arse
+arsehole
+twat
+
+# ── Sexual/anatomical ──
+dick
+dickhead
+cock
+cocks
+penis
+vagina
+pussy
+pussies
+cunt
+tits
+titties
+boobs
+dildo
+blowjob
+handjob
+rimjob
+cum
+cumshot
+jizz
+semen
+anal
+porn
+porno
+sex
+sexy
+milf
+whore
+slut
+sluts
+hooker
+willy
+fanny
+schlong
+boner
+horny
+
+# ── Slurs (racial, ethnic, homophobic, ableist) ──
+nigger
+nigga
+niggas
+chink
+gook
+spic
+wetback
+kike
+raghead
+towelhead
+beaner
+coon
+darkie
+fag
+faggot
+fags
+dyke
+tranny
+homo
+queer
+retard
+retarded
+spastic
+midget
+
+# ── Hate/violence adjacent ──
+nazi
+hitler
+kkk
+rape
+rapist
+pedo
+pedophile

--- a/src/SportsData.Api/Application/UI/Leagues/Commands/CreateLeagueRequestBaseValidator.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Commands/CreateLeagueRequestBaseValidator.cs
@@ -1,6 +1,7 @@
 using FluentValidation;
 
 using SportsData.Api.Application.Common.Enums;
+using SportsData.Api.Application.Common.Moderation;
 using SportsData.Core.Common;
 
 namespace SportsData.Api.Application.UI.Leagues.Commands;
@@ -21,6 +22,13 @@ public abstract class CreateLeagueRequestBaseValidator<TRequest> : AbstractValid
         RuleFor(x => x.Name)
             .NotEmpty()
             .WithMessage("League name is required.");
+
+        // League names are the app's most public user-authored text (they
+        // surface in the joinable-leagues browse for strangers). Same
+        // whole-word profanity policy as display names.
+        RuleFor(x => x.Name)
+            .Must(v => !ProfanityPolicy.ContainsProfanity(v))
+            .WithMessage("That league name isn't allowed.");
 
         RuleFor(x => x.PickType)
             .Must(IsDefinedEnumName<PickType>)

--- a/src/SportsData.Api/Application/User/Commands/UpdateDisplayName/UpdateDisplayNameCommandValidator.cs
+++ b/src/SportsData.Api/Application/User/Commands/UpdateDisplayName/UpdateDisplayNameCommandValidator.cs
@@ -1,5 +1,7 @@
 using FluentValidation;
 
+using SportsData.Api.Application.Common.Moderation;
+
 namespace SportsData.Api.Application.User.Commands.UpdateDisplayName;
 
 public class UpdateDisplayNameCommandValidator : AbstractValidator<UpdateDisplayNameCommand>
@@ -18,5 +20,11 @@ public class UpdateDisplayNameCommandValidator : AbstractValidator<UpdateDisplay
             .MaximumLength(MaxLength)
             .When(x => !string.IsNullOrWhiteSpace(x.DisplayName))
             .WithMessage($"Display name must not exceed {MaxLength} characters.");
+
+        // Whole-word profanity check (see ProfanityPolicy — substring matching
+        // is deliberately NOT used; real surnames must pass).
+        RuleFor(x => x.DisplayName)
+            .Must(v => !ProfanityPolicy.ContainsProfanity(v))
+            .WithMessage("That display name isn't allowed.");
     }
 }

--- a/src/SportsData.Api/SportsData.Api.csproj
+++ b/src/SportsData.Api/SportsData.Api.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
 	<TargetFramework>net10.0</TargetFramework>
@@ -42,6 +42,7 @@
 
   <ItemGroup>
     <EmbeddedResource Include="Infrastructure\Data\Canonical\Sql\GetMatchupByContestId.sql" />
+    <EmbeddedResource Include="Application\Common\Moderation\profanity-wordlist.txt" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/unit/SportsData.Api.Tests.Unit/Application/Common/Moderation/ProfanityPolicyTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/Common/Moderation/ProfanityPolicyTests.cs
@@ -1,0 +1,99 @@
+using FluentAssertions;
+
+using SportsData.Api.Application.Common.Moderation;
+
+using Xunit;
+
+namespace SportsData.Api.Tests.Unit.Application.Common.Moderation;
+
+/// <summary>
+/// The load-bearing guarantee here is the Scunthorpe suite: this filter
+/// matches WHOLE WORDS ONLY, so real surnames containing banned substrings
+/// must always pass. The operator's own surname is Sexton — that test is not
+/// hypothetical, and it must never regress to substring matching.
+/// </summary>
+public class ProfanityPolicyTests
+{
+    // ── Scunthorpe suite: real names that substring matching would block ────
+
+    [Theory]
+    [InlineData("Sexton")]              // the operator's surname
+    [InlineData("Randall Sexton")]
+    [InlineData("S3xton")]              // leet-normalizes to "sexton" — still a whole word
+    [InlineData("Dickinson")]
+    [InlineData("Cummings")]
+    [InlineData("Hancock")]
+    [InlineData("Scunthorpe United")]   // the namesake
+    [InlineData("Cassandra")]           // contains "ass"
+    [InlineData("Matt Titsworth")]      // contains "tits"
+    public void RealNames_AreNotProfane(string candidate)
+    {
+        ProfanityPolicy.ContainsProfanity(candidate).Should().BeFalse(
+            $"'{candidate}' is a legitimate name and whole-word matching must let it through");
+    }
+
+    // ── Plain profanity as a standalone token ───────────────────────────────
+
+    [Theory]
+    [InlineData("fuck")]
+    [InlineData("total asshole")]
+    [InlineData("The Assholes")]
+    [InlineData("Shit Show")]
+    [InlineData("league of sluts")]
+    public void ProfaneTokens_AreBlocked(string candidate)
+    {
+        ProfanityPolicy.ContainsProfanity(candidate).Should().BeTrue();
+    }
+
+    // ── Evasion that normalization must catch ───────────────────────────────
+
+    [Theory]
+    [InlineData("f.u.c.k")]             // collapsed letters equal a banned word
+    [InlineData("f u c k")]
+    [InlineData("F-U-C-K")]
+    [InlineData("a$$hole")]             // $→s: token "asshole"
+    [InlineData("sh1thead")]            // 1→i: token "shithead"
+    [InlineData("b!tch")]               // !→i
+    [InlineData("N1gger")]              // leet slur
+    [InlineData("c.u.n.t")]
+    public void LeetAndSeparatorEvasion_IsBlocked(string candidate)
+    {
+        ProfanityPolicy.ContainsProfanity(candidate).Should().BeTrue(
+            $"'{candidate}' normalizes to a banned whole word");
+    }
+
+    // ── Documented recall boundary (deliberate, not a bug) ──────────────────
+
+    [Fact]
+    public void GluedCompounds_NotOnTheList_Pass()
+    {
+        // "bigslut" is one token and equals no listed word. Whole-word
+        // matching trades this recall for the precision that keeps real
+        // names safe; the fix for a compound that shows up in the wild is
+        // adding it to the wordlist, never switching to substring matching.
+        ProfanityPolicy.ContainsProfanity("BigSlut69").Should().BeFalse();
+    }
+
+    // ── Clean input ─────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("Gridiron Gurus")]
+    [InlineData("Saturday Slate")]
+    [InlineData("The 12th Man")]
+    [InlineData("Touchdown Toms")]
+    [InlineData("José's League")]       // diacritics must not break normalization
+    public void CleanNames_Pass(string candidate)
+    {
+        ProfanityPolicy.ContainsProfanity(candidate).Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void NullOrWhitespace_IsNotProfane(string? candidate)
+    {
+        // Required-ness is a separate validation rule's job.
+        ProfanityPolicy.ContainsProfanity(candidate).Should().BeFalse();
+    }
+}

--- a/test/unit/SportsData.Api.Tests.Unit/Application/Common/Moderation/ProfanityPolicyTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/Common/Moderation/ProfanityPolicyTests.cs
@@ -24,6 +24,7 @@ public class ProfanityPolicyTests
     [InlineData("Cummings")]
     [InlineData("Hancock")]
     [InlineData("Scunthorpe United")]   // the namesake
+    [InlineData("Ｓｅｘｔｏｎ")]         // full-width Sexton - FormKD folding must not create a false positive
     [InlineData("Cassandra")]           // contains "ass"
     [InlineData("Matt Titsworth")]      // contains "tits"
     public void RealNames_AreNotProfane(string candidate)
@@ -56,6 +57,8 @@ public class ProfanityPolicyTests
     [InlineData("b!tch")]               // !→i
     [InlineData("N1gger")]              // leet slur
     [InlineData("c.u.n.t")]
+    [InlineData("ｆｕｃｋ")]             // full-width Latin - FormKD folds to ascii
+    [InlineData("ＦＵＣＫ")]             // full-width uppercase
     public void LeetAndSeparatorEvasion_IsBlocked(string candidate)
     {
         ProfanityPolicy.ContainsProfanity(candidate).Should().BeTrue(


### PR DESCRIPTION
## Context

User-authored text — display names (editable from mobile settings) and league names (publicly browsable by strangers in the joinable-leagues rail) — had no content validation. This adds the authoritative server-side check, and it upgrades the moderation posture in the Apple 2.1 response from "operator-removed after the fact" to "validated server-side."

## Design

**`ProfanityPolicy`** in `Application/Common/Moderation` (two slices consume it — the second use case earns the shared home per repo convention):

- **Whole-word matching ONLY, never substring.** These are names; substring matching is the Scunthorpe problem by construction — it blocks Sexton, Dickinson, Cummings, Hancock. The test suite pins those surnames permanently, and the class doc forbids regressing to substring matching.
- **Normalization before matching**: lowercase → strip diacritics → fold leet (`0/1/3/4/5/7/$/@/!` → `o/i/e/a/s/t/s/a/i`) → non-letters become token boundaries, plus a collapsed-whole-input equality check. Catches `f.u.c.k`, `a$$hole`, `sh1thead`, `b!tch`. `S3xton` normalizes to `sexton` and *still passes* — the guarantee is whole-word equality, not timid normalization.
- **Wordlist is a curated embedded resource** (~110 entries, comments allowed) — tuning is a text edit, no code change. Header documents the deliberate tradeoffs: precision over recall in the name context; ambiguous given names (`dick`) listed because abusive use dominates in pick'em contexts; glued compounds (`BigSlut69`) are a known, test-documented recall gap whose fix is adding words — never substring matching.

**Wiring**: FluentValidation rules in `UpdateDisplayNameCommandValidator` ("That display name isn't allowed.") and `CreateLeagueRequestBaseValidator` ("That league name isn't allowed." — covers every sport's create path). Rejection over silent rewrite: we never edit someone's name for them.

## Validation

- 31 new tests: Scunthorpe suite (incl. leet variants of real surnames), evasion suite, documented recall boundaries, clean/null cases
- Full API unit suite: **801/801**
- Operator reviewed the behavior and wordlist as-is

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnJySMvfUPeQSMufNNcKSK


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added profanity filtering for league names and display-name updates.
  - Detects profanity despite capitalization, accents, leetspeak, separator variations, and full-width characters.
  - Preserves legitimate names containing similar substrings and allows blank or whitespace-only values.
  - Added clear validation messages when a name is rejected.

- **Tests**
  - Added coverage for profanity detection, evasion patterns, clean and legitimate names, compound words, and empty inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->