### PR TITLE
fix(mobile): surface the server's validation message on display-name save

### DIFF
--- a/src/UI/sd-mobile/app/(tabs)/profile.tsx
+++ b/src/UI/sd-mobile/app/(tabs)/profile.tsx
@@ -313,7 +313,16 @@ export default function ProfileScreen() {
       setEditingDisplayName(false);
     } catch (err) {
       console.warn('[ProfileScreen] display name update failed', err);
-      setDisplayNameMessage('Could not save display name. Try again.');
+      // Surface the server's validation message when there is one — e.g. the
+      // profanity filter's "That display name isn't allowed." The generic
+      // text below reads as a TRANSIENT failure, and a user whose name was
+      // rejected by policy would otherwise retry the same name forever.
+      // Same errors[0].errorMessage dig as create-league.tsx's onError
+      // (ToActionResult serializes failures as { errors: [{ errorMessage }] }).
+      const serverMessage =
+        (err as { response?: { data?: { errors?: { errorMessage?: string }[] } } })
+          ?.response?.data?.errors?.[0]?.errorMessage;
+      setDisplayNameMessage(serverMessage ?? 'Could not save display name. Try again.');
     } finally {
       setDisplayNameSaving(false);
     }


### PR DESCRIPTION
## Context

With the server-side profanity filter live (#704), a rejected display name returns 400 with "That display name isn't allowed." — but the mobile profile screen swallowed the body and always showed **"Could not save display name. Try again."** That reads as a *transient* failure, so a user whose name was rejected by policy would retry the same name forever.

## Change

The catch now digs `errors[0].errorMessage` from the `ToActionResult` failure shape — the same extraction already used by mobile `create-league.tsx`, web `SettingsPage.jsx`, and web `LeagueCreatePage.jsx`. Mobile display-name was audited as the **last of the four UGC-adjacent surfaces** still hiding the server's reason; the other three needed nothing. Falls back to the generic text for real transport errors.

## Validation

- `tsc --noEmit` clean; mobile suite 186/186
- Operator-validated on-device: filtered name shows the server's message; normal name saves
- Pure JS — OTA-eligible; can ride an `eas update` once the lane is proven, or the next EAS build

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnJySMvfUPeQSMufNNcKSK
