### PR TITLE
fix(api,mobile): signup display name — provisioning-door profanity guard + the typed name actually persists

### DIFF
--- a/src/SportsData.Api/Application/Common/Moderation/ProfanityPolicy.cs
+++ b/src/SportsData.Api/Application/Common/Moderation/ProfanityPolicy.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -60,6 +60,17 @@ public static class ProfanityPolicy
         var collapsed = normalized.Replace(" ", string.Empty);
         return banned.Contains(collapsed);
     }
+
+    /// <summary>
+    /// Substitution form for PROVISIONING paths (signup / federated login):
+    /// returns null when the candidate is profane so the caller's existing
+    /// null-fallbacks take over (generated name at create, keep-current at
+    /// update). These paths must never REJECT — account creation cannot be
+    /// allowed to fail over a Google profile name — which is why this exists
+    /// alongside the rejecting validator rules used on deliberate renames.
+    /// </summary>
+    public static string? SanitizeOrNull(string? candidate) =>
+        ContainsProfanity(candidate) ? null : candidate;
 
     /// <summary>
     /// Lowercase, strip diacritics, fold leet substitutions, and replace every

--- a/src/SportsData.Api/Application/User/Commands/UpsertUser/UpsertUserCommandHandler.cs
+++ b/src/SportsData.Api/Application/User/Commands/UpsertUser/UpsertUserCommandHandler.cs
@@ -1,4 +1,6 @@
-using FluentValidation;
+﻿using FluentValidation;
+
+using SportsData.Api.Application.Common.Moderation;
 using Microsoft.EntityFrameworkCore;
 
 using SportsData.Api.Infrastructure.Data;
@@ -61,6 +63,17 @@ public class UpsertUserCommandHandler : IUpsertUserCommandHandler
             return new Failure<Guid>(default, ResultStatus.BadRequest, validationErrors);
         }
 
+        // Both provisioning doors (auth-middleware auto-provision via
+        // UserService, and web's POST /user) funnel through this handler, and
+        // the display name can arrive from an external source — a Firebase
+        // token's "name" claim carries the Google/typed profile name. Profane
+        // names are SUBSTITUTED (null -> generated at create / keep-current at
+        // update), never rejected: provisioning must not fail over a name.
+        // Deliberate renames go through UpdateDisplayName, which rejects with
+        // a message instead. Sanitized once here so every write site below —
+        // including the username seed — sees the same value.
+        var displayName = ProfanityPolicy.SanitizeOrNull(command.DisplayName);
+
         // Defense in depth. SignInProvider originates in an external token
         // claim, and an oversized value fails the INSERT — which does not
         // merely lose the provider label, it prevents the USER ROW FROM BEING
@@ -72,7 +85,7 @@ public class UpsertUserCommandHandler : IUpsertUserCommandHandler
 
         try
         {
-            return await UpsertUserInternalAsync(command, firebaseUid, signInProvider, cancellationToken);
+            return await UpsertUserInternalAsync(command, displayName, firebaseUid, signInProvider, cancellationToken);
         }
         catch (DbUpdateException ex) when (ex.IsUniqueConstraintViolation())
         {
@@ -99,7 +112,7 @@ public class UpsertUserCommandHandler : IUpsertUserCommandHandler
 
                 existingUser.Email = command.Email;
                 existingUser.SignInProvider = signInProvider;
-                existingUser.DisplayName = command.DisplayName ?? existingUser.DisplayName;
+                existingUser.DisplayName = displayName ?? existingUser.DisplayName;
                 existingUser.LastLoginUtc = DateTime.UtcNow;
 
                 try
@@ -138,6 +151,7 @@ public class UpsertUserCommandHandler : IUpsertUserCommandHandler
 
     private async Task<Result<Guid>> UpsertUserInternalAsync(
         UpsertUserCommand command,
+        string? displayName, // pre-sanitized by ExecuteAsync — never read command.DisplayName here
         string firebaseUid,
         string signInProvider,
         CancellationToken cancellationToken)
@@ -157,8 +171,8 @@ public class UpsertUserCommandHandler : IUpsertUserCommandHandler
                 Email = command.Email,
                 EmailVerified = false,
                 SignInProvider = signInProvider,
-                DisplayName = command.DisplayName ?? DisplayNameGenerator.Generate(),
-                Username = await ResolveUniqueUsernameAsync(command.Email, command.DisplayName, cancellationToken),
+                DisplayName = displayName ?? DisplayNameGenerator.Generate(),
+                Username = await ResolveUniqueUsernameAsync(command.Email, displayName, cancellationToken),
                 LastLoginUtc = DateTime.UtcNow,
                 CreatedUtc = DateTime.UtcNow
             };
@@ -178,7 +192,7 @@ public class UpsertUserCommandHandler : IUpsertUserCommandHandler
 
             user.Email = command.Email;
             user.SignInProvider = signInProvider;
-            user.DisplayName = command.DisplayName ?? user.DisplayName;
+            user.DisplayName = displayName ?? user.DisplayName;
             user.LastLoginUtc = DateTime.UtcNow;
         }
 

--- a/src/UI/sd-mobile/app/(auth)/sign-up.tsx
+++ b/src/UI/sd-mobile/app/(auth)/sign-up.tsx
@@ -80,20 +80,33 @@ export default function SignUpScreen() {
     try {
       // Retry path: if the first attempt's PATCH was rejected, the Firebase
       // account already exists and we are signed in — creating again would
-      // fail with email-already-in-use. Reuse the session; only the name run
-      // below is being retried.
+      // fail with email-already-in-use. Reuse the session, but ONLY for the
+      // same email: an edited email on retry must not silently save the name
+      // to the first account while the form shows a different address.
+      const existingUser = auth.currentUser;
+      if (
+        existingUser?.email &&
+        existingUser.email.toLowerCase() !== email.trim().toLowerCase()
+      ) {
+        // Keep the hold — releasing it here would let AuthGuard redirect the
+        // signed-in user into the app mid-error.
+        setError('email', {
+          message: `This signup already created an account for ${existingUser.email}. Keep that email here; you can change it later in Profile.`,
+        });
+        return;
+      }
       const firebaseUser =
-        auth.currentUser ??
+        existingUser ??
         (await createUserWithEmailAndPassword(auth, email.trim(), password)).user;
-      // Set the display name before downstream consumers read the profile;
-      // reload so the local user object reflects it immediately.
-      await updateProfile(firebaseUser, { displayName: displayName.trim() });
-      await firebaseUser.reload();
 
-      // Persist the typed name through the VALIDATED path. The first
-      // authenticated call also auto-provisions the backend account (the
-      // middleware creates it with a generated name because this token
-      // predates the profile update); this PATCH then applies the real one.
+      // Persist the typed name through the VALIDATED path FIRST — the
+      // Firebase profile is only written after the backend accepts, so a
+      // rejected name (profanity filter) never lands anywhere, not even at
+      // the identity provider. The first authenticated call here also
+      // auto-provisions the backend account (with a generated name, since
+      // this token predates any profile update); the PATCH applies the real
+      // one.
+      let nameAccepted = true;
       try {
         await usersApi.updateDisplayName(displayName.trim());
       } catch (patchErr: unknown) {
@@ -108,7 +121,15 @@ export default function SignUpScreen() {
         }
         // Transport failure: don't strand a created account on the sign-up
         // screen — proceed with the generated name; Profile can fix it later.
+        nameAccepted = false;
         console.warn('[SignUp] display name PATCH failed (non-validation)', patchErr);
+      }
+
+      if (nameAccepted) {
+        // Mirror the accepted name onto the Firebase profile; reload so the
+        // local user object reflects it immediately.
+        await updateProfile(firebaseUser, { displayName: displayName.trim() });
+        await firebaseUser.reload();
       }
       // Release the hold — AuthGuard in root _layout.tsx now redirects.
       useAuthStore.getState().setSignupHold(false);

--- a/src/UI/sd-mobile/app/(auth)/sign-up.tsx
+++ b/src/UI/sd-mobile/app/(auth)/sign-up.tsx
@@ -16,6 +16,8 @@ import { createUserWithEmailAndPassword, updateProfile } from 'firebase/auth';
 
 import { Text } from '@/src/components/ui/AppText';
 import { auth } from '@/src/lib/firebase';
+import { useAuthStore } from '@/src/stores/authStore';
+import { usersApi } from '@/src/services/api/usersApi';
 import { useColorScheme } from '@/src/lib/theme/ThemeContext';
 import { Button } from '@/src/components/ui/Button';
 import { Wordmark } from '@/src/components/brand/Wordmark';
@@ -62,14 +64,54 @@ export default function SignUpScreen() {
     defaultValues: { displayName: '', email: '', password: '' },
   });
 
+  // If the user abandons sign-up after a name rejection (back to welcome /
+  // sign-in), the hold must not outlive this screen — a stuck hold with a
+  // signed-in user would trap them in the auth group forever.
+  React.useEffect(
+    () => () => useAuthStore.getState().setSignupHold(false),
+    [],
+  );
+
   const onSubmit = async ({ displayName, email, password }: FormData) => {
+    // Hold AuthGuard's redirect while the typed display name is persisted —
+    // the PATCH below can reject (server profanity filter) and the rejection
+    // must land inline on THIS form, not after navigation.
+    useAuthStore.getState().setSignupHold(true);
     try {
-      const result = await createUserWithEmailAndPassword(auth, email.trim(), password);
+      // Retry path: if the first attempt's PATCH was rejected, the Firebase
+      // account already exists and we are signed in — creating again would
+      // fail with email-already-in-use. Reuse the session; only the name run
+      // below is being retried.
+      const firebaseUser =
+        auth.currentUser ??
+        (await createUserWithEmailAndPassword(auth, email.trim(), password)).user;
       // Set the display name before downstream consumers read the profile;
       // reload so the local user object reflects it immediately.
-      await updateProfile(result.user, { displayName: displayName.trim() });
-      await result.user.reload();
-      // AuthGuard in root _layout.tsx handles the redirect.
+      await updateProfile(firebaseUser, { displayName: displayName.trim() });
+      await firebaseUser.reload();
+
+      // Persist the typed name through the VALIDATED path. The first
+      // authenticated call also auto-provisions the backend account (the
+      // middleware creates it with a generated name because this token
+      // predates the profile update); this PATCH then applies the real one.
+      try {
+        await usersApi.updateDisplayName(displayName.trim());
+      } catch (patchErr: unknown) {
+        const serverMessage =
+          (patchErr as { response?: { data?: { errors?: { errorMessage?: string }[] } }; })
+            ?.response?.data?.errors?.[0]?.errorMessage;
+        if (serverMessage) {
+          // Validation rejection (e.g. "That display name isn't allowed.") —
+          // keep the hold, show it on the field, let the user fix and retry.
+          setError('displayName', { message: serverMessage });
+          return;
+        }
+        // Transport failure: don't strand a created account on the sign-up
+        // screen — proceed with the generated name; Profile can fix it later.
+        console.warn('[SignUp] display name PATCH failed (non-validation)', patchErr);
+      }
+      // Release the hold — AuthGuard in root _layout.tsx now redirects.
+      useAuthStore.getState().setSignupHold(false);
     } catch (err: unknown) {
       const code = (err as { code?: string })?.code ?? '';
       if (code === 'auth/email-already-in-use') {
@@ -87,6 +129,8 @@ export default function SignUpScreen() {
       } else {
         setError('root', { message: 'Sign up failed. Please try again.' });
       }
+      // No account materialized (or it pre-existed) — nothing to hold for.
+      useAuthStore.getState().setSignupHold(false);
     }
   };
 

--- a/src/UI/sd-mobile/app/(auth)/welcome.tsx
+++ b/src/UI/sd-mobile/app/(auth)/welcome.tsx
@@ -33,7 +33,7 @@ const features: ReadonlyArray<{
   {
     icon: 'bulb-outline',
     title: 'Pick Smarter',
-    body: 'Insider stats, matchup breakdowns, and AI-driven insights — every game.',
+    body: 'Insider stats, matchup breakdowns, and AI-driven insights - every game.',
   },
   {
     icon: 'trophy-outline',
@@ -43,7 +43,7 @@ const features: ReadonlyArray<{
   {
     icon: 'options-outline',
     title: 'Pick Your Way',
-    body: 'Straight up, against the spread, over/under — your call, every week.',
+    body: 'Straight up, against the spread, over/under - your call, every week.',
   },
 ];
 
@@ -62,8 +62,12 @@ export default function WelcomeScreen() {
         {/* Hero */}
         <View style={styles.hero}>
           <Wordmark size={36} />
+          {/* Deliberate two-line break — one sentence per line. As a single
+              string it wrapped wherever the viewport decided (observed:
+              "Friends." orphaned on line 2), which reads as an accident
+              rather than a slogan. The explicit newline pins the break. */}
           <Text style={[styles.tagline, { color: theme.text }]}>
-            Win Your Picks. Crush Your Friends.
+            Win Your Picks.{'\n'}Crush Your Friends.
           </Text>
           <Text style={[styles.subhead, { color: theme.textMuted }]}>
             Data-driven insights for every matchup.

--- a/src/UI/sd-mobile/app/_layout.tsx
+++ b/src/UI/sd-mobile/app/_layout.tsx
@@ -28,6 +28,7 @@ import 'react-native-reanimated';
 
 import { queryClient } from '@/src/lib/queryClient';
 import { useAuthInit, useAuth } from '@/src/hooks/useAuth';
+import { useAuthStore } from '@/src/stores/authStore';
 import { useOtaUpdates } from '@/src/hooks/useOtaUpdates';
 import { useRegisterPushDevice } from '@/src/hooks/useRegisterPushDevice';
 import { ThemeProvider, useThemeMode } from '@/src/lib/theme/ThemeContext';
@@ -94,6 +95,7 @@ if (Platform.OS !== 'web') {
  */
 function AuthGuard() {
   const { user, isInitialized } = useAuth();
+  const signupHold = useAuthStore((s) => s.signupHold);
   const segments = useSegments();
   const router = useRouter();
 
@@ -106,10 +108,13 @@ function AuthGuard() {
       // new welcome.tsx file yet at typecheck time; regenerates on next
       // expo start / build.
       router.replace('/(auth)/welcome' as never);
-    } else if (user && inAuthGroup) {
+    } else if (user && inAuthGroup && !signupHold) {
+      // signupHold: sign-up is still persisting the typed display name
+      // through the validated PATCH and may need to show a rejection
+      // inline — it releases the hold when done (see sign-up.tsx).
       router.replace('/(tabs)');
     }
-  }, [user, isInitialized, segments]);
+  }, [user, isInitialized, segments, signupHold]);
 
   return null;
 }

--- a/src/UI/sd-mobile/src/stores/authStore.ts
+++ b/src/UI/sd-mobile/src/stores/authStore.ts
@@ -8,18 +8,30 @@ interface AuthState {
   isLoading: boolean;
   /** True once onAuthStateChanged has fired for the first time */
   isInitialized: boolean;
+  /**
+   * Holds AuthGuard's redirect into the app while sign-up finishes its
+   * post-create work (persisting the typed display name through the
+   * validated PATCH, which can reject — e.g. the profanity filter — and
+   * needs the sign-up form still on screen to show the error inline).
+   * Without this, the guard navigates the moment Firebase signs the new
+   * user in, racing that work.
+   */
+  signupHold: boolean;
 
   setUser: (user: User | null) => void;
   setLoading: (loading: boolean) => void;
   setInitialized: (initialized: boolean) => void;
+  setSignupHold: (hold: boolean) => void;
 }
 
 export const useAuthStore = create<AuthState>((set) => ({
   user: null,
   isLoading: false,
   isInitialized: false,
+  signupHold: false,
 
   setUser: (user) => set({ user }),
   setLoading: (isLoading) => set({ isLoading }),
   setInitialized: (isInitialized) => set({ isInitialized }),
+  setSignupHold: (signupHold) => set({ signupHold }),
 }));

--- a/test/unit/SportsData.Api.Tests.Unit/Application/User/Commands/UpsertUser/UpsertUserCommandHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/User/Commands/UpsertUser/UpsertUserCommandHandlerTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+﻿using FluentAssertions;
 
 using Microsoft.EntityFrameworkCore;
 
@@ -649,7 +649,66 @@ public class UpsertUserCommandHandlerTests : ApiTestBase<UpsertUserCommandHandle
         user!.CreatedUtc.Should().BeCloseTo(originalCreatedUtc, TimeSpan.FromSeconds(1)); // Should preserve original
         user.LastLoginUtc.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(5)); // Should be updated
     }
+
+    // ── Provisioning-path profanity substitution ────────────────────────────
+    // Both provisioning doors (auth-middleware auto-provision and web's
+    // POST /user) funnel through this handler, and DisplayName can arrive
+    // from an external source (a Firebase token's "name" claim). Profane
+    // names are SUBSTITUTED — never rejected: account creation must not fail
+    // over a Google profile name. Deliberate renames go through
+    // UpdateDisplayName, which rejects with a message instead.
+
+    [Fact]
+    public async Task ExecuteAsync_ProfaneDisplayNameAtCreate_GetsGeneratedNameInsteadOfFailing()
+    {
+        var handler = Mocker.CreateInstance<UpsertUserCommandHandler>();
+
+        var result = await handler.ExecuteAsync(
+            new UpsertUserCommand { Email = "new@example.com", DisplayName = "fuck face" },
+            "firebase-profane-create",
+            "password");
+
+        result.IsSuccess.Should().BeTrue("provisioning must never fail over a name");
+        var user = await DataContext.Users.FirstAsync(u => u.FirebaseUid == "firebase-profane-create");
+        user.DisplayName.Should().NotBeNullOrWhiteSpace();
+        user.DisplayName.Should().NotContain("fuck");
+        user.Username.Should().NotContain("fuck", "the username seed must see the sanitized value too");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ProfaneDisplayNameOnUpdate_KeepsExistingName()
+    {
+        var handler = Mocker.CreateInstance<UpsertUserCommandHandler>();
+
+        await handler.ExecuteAsync(
+            new UpsertUserCommand { Email = "keep@example.com", DisplayName = "Clean Name" },
+            "firebase-profane-update",
+            "password");
+
+        var result = await handler.ExecuteAsync(
+            new UpsertUserCommand { Email = "keep@example.com", DisplayName = "sh1thead" },
+            "firebase-profane-update",
+            "password");
+
+        result.IsSuccess.Should().BeTrue();
+        var user = await DataContext.Users.FirstAsync(u => u.FirebaseUid == "firebase-profane-update");
+        user.DisplayName.Should().Be("Clean Name");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ScunthorpeNameAtCreate_IsPersistedVerbatim()
+    {
+        // The whole-word guarantee must hold on this path too: a federated
+        // login named Sexton (the operator's surname) keeps their name.
+        var handler = Mocker.CreateInstance<UpsertUserCommandHandler>();
+
+        var result = await handler.ExecuteAsync(
+            new UpsertUserCommand { Email = "sexton@example.com", DisplayName = "Randall Sexton" },
+            "firebase-sexton",
+            "google.com");
+
+        result.IsSuccess.Should().BeTrue();
+        var user = await DataContext.Users.FirstAsync(u => u.FirebaseUid == "firebase-sexton");
+        user.DisplayName.Should().Be("Randall Sexton");
+    }
 }
-
-
-

--- a/test/unit/SportsData.Api.Tests.Unit/Application/User/Commands/UpsertUser/UpsertUserCommandHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/User/Commands/UpsertUser/UpsertUserCommandHandlerTests.cs
@@ -669,7 +669,7 @@ public class UpsertUserCommandHandlerTests : ApiTestBase<UpsertUserCommandHandle
             "password");
 
         result.IsSuccess.Should().BeTrue("provisioning must never fail over a name");
-        var user = await DataContext.Users.FirstAsync(u => u.FirebaseUid == "firebase-profane-create");
+        var user = await DataContext.Users.AsNoTracking().FirstAsync(u => u.FirebaseUid == "firebase-profane-create");
         user.DisplayName.Should().NotBeNullOrWhiteSpace();
         user.DisplayName.Should().NotContain("fuck");
         user.Username.Should().NotContain("fuck", "the username seed must see the sanitized value too");
@@ -691,7 +691,7 @@ public class UpsertUserCommandHandlerTests : ApiTestBase<UpsertUserCommandHandle
             "password");
 
         result.IsSuccess.Should().BeTrue();
-        var user = await DataContext.Users.FirstAsync(u => u.FirebaseUid == "firebase-profane-update");
+        var user = await DataContext.Users.AsNoTracking().FirstAsync(u => u.FirebaseUid == "firebase-profane-update");
         user.DisplayName.Should().Be("Clean Name");
     }
 
@@ -708,7 +708,7 @@ public class UpsertUserCommandHandlerTests : ApiTestBase<UpsertUserCommandHandle
             "google.com");
 
         result.IsSuccess.Should().BeTrue();
-        var user = await DataContext.Users.FirstAsync(u => u.FirebaseUid == "firebase-sexton");
+        var user = await DataContext.Users.AsNoTracking().FirstAsync(u => u.FirebaseUid == "firebase-sexton");
         user.DisplayName.Should().Be("Randall Sexton");
     }
 }


### PR DESCRIPTION
## Context

Operator testing found signup accepted the display name "fuck face" — and behind it, **two bugs, one masking the other**:

1. **The typed name was never persisted** (pre-existing, every email signup): `sign-up.tsx` sets the name via Firebase `updateProfile` *after* account creation, but the app's first API call carries a token minted *before* that — no `name` claim — so the auth middleware auto-provisions the backend account with `DisplayNameGenerator.Generate()`. Later tokens carry the name, but the row already exists and is never reconsidered.
2. **The provisioning path had no profanity check** — masked for email signups by bug 1, but wide open for federated logins (a Google profile name lands verbatim), and it would have opened fully the moment bug 1 was fixed.

## Server

`ProfanityPolicy.SanitizeOrNull` — a profane incoming name is **substituted, never rejected** (provisioning must not fail over a Google profile name): `null` falls through to the generator at create / keep-current at update. Sanitized **once** in `UpsertUserCommandHandler` — the single choke both provisioning doors share (middleware auto-provision delegates here via `UserService`; web POSTs here directly) — and threaded to every write site **including the username seed**, closing a second-field leak. Deliberate renames keep the rejecting `UpdateDisplayName` path (#704).

## Mobile

Signup now persists the typed name through that validated PATCH:
- New `signupHold` on the auth store keeps `AuthGuard` from redirecting into the app mid-flow, so a rejection ("That display name isn't allowed.") lands **inline on the sign-up form**
- Retry reuses the signed-in session instead of re-calling `createUser` (which would fail `email-already-in-use`)
- Transport failures release the hold and proceed with the generated name — never strand a created account
- Hold released on unmount so abandoning signup can't trap the auth group

Rides along (welcome screen): slogan line break pinned (`Win Your Picks.` / `Crush Your Friends.` — was orphaning "Friends.") and em-dashes → hyphens in feature copy per operator preference.

## Validation

- API unit: **807/807** (3 new: profane-at-create → generated name + clean username seed; profane-on-update → keeps existing; **"Randall Sexton" persists verbatim** through the provisioning door)
- Mobile: `tsc` clean, 186/186
- Operator-validated on-device: inline rejection on the form, corrected name persists to Profile, slogan renders as two lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnJySMvfUPeQSMufNNcKSK


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Profane display names are safely handled during account creation and updates.
  * Sign-up validation errors appear on the display-name field.
  * Sign-up retries and profile persistence are handled more reliably without premature navigation.

* **UI Improvements**
  * Authentication redirects wait until sign-up profile saving completes.
  * Updated welcome-screen wording and tagline formatting.

* **Tests**
  * Added coverage for profane names, existing-name preservation, and valid names containing sensitive substrings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->