### PR TITLE
feat(core,provider,producer): "live" priority Hangfire queue — league games can no longer starve behind bulk work

### DIFF
--- a/docs/features/athlete-cascade-scoping.md
+++ b/docs/features/athlete-cascade-scoping.md
@@ -319,8 +319,14 @@ pipeline instead of a per-document league lookup.
   hop), each on both the immediate and retry/backoff paths. Provider
   Workers listen `["live", "default"]` too. (The Provider hop was an
   operator catch in review — the first cut only prioritized Producer.)
-- Workers listen `["live", "default"]`: Hangfire dequeues in listed order,
-  so every worker MUST empty live before touching bulk. Daemons unchanged.
+- The queue is named **`00-live`** because priority in Hangfire.PostgreSql
+  is ALPHABETICAL — its dequeue orders by `"fetchedat" NULLS FIRST,
+  "queue", "jobid"`; the configured array only filters. (Array-order
+  priority is Hangfire.SqlServer semantics and does not apply. Caught by
+  CodeRabbit on PR #709: the first cut's `"live"` sorts after `"default"`
+  and would have INVERTED the priority.) Workers listen
+  `["00-live", "default"]`; every worker empties live before touching
+  bulk. Daemons unchanged.
 - Priority is sticky downhill exactly like the inclusion filter: a live
   play's FK dependencies (AthleteSeason -> Athlete -> AthletePosition) ride
   the live queue too, and `ToDocumentCreated` keeps retries prioritized.
@@ -333,7 +339,7 @@ pipeline instead of a per-document league lookup.
 **Admission rule (owner, 2026-09-02): if everything is a priority, nothing
 is.** Exactly one code path sets `Priority: true` — the competition
 streamer, whose scope is already narrowed to league-backing contests by
-#688. Propagation may only INHERIT priority from a live parent, never
+PR #688. Propagation may only INHERIT priority from a live parent, never
 originate it. Expanding admission (Refresh Contest, operator replays,
 anything) requires the same scrutiny this design got, and the burden of
 proof is on the new admission: the live queue's value is precisely its

--- a/docs/features/athlete-cascade-scoping.md
+++ b/docs/features/athlete-cascade-scoping.md
@@ -300,6 +300,48 @@ filters through untouched; none of them construct an empty list today, so their
 behaviour is unchanged. `DocumentJobDefinition`'s doc comment was corrected — it
 claimed "null or empty" both meant spawn-all.
 
+## Item 5 as built (2026-09-02): the "live" Hangfire queue
+
+Starvation is now structurally impossible rather than merely unlikely.
+
+**The insight that made it cheap:** post-#688 the competition streamer polls
+ONLY contests backing a pick'em league — so "streamer-originated" equals
+"league-live" by construction, and priority is a tag riding the existing
+pipeline instead of a per-document league lookup.
+
+- `DocumentRequested`/`DocumentCreated` carry an appended optional
+  `Priority` flag (wire-safe both directions: mixed versions degrade to
+  single-queue behaviour, never misroute).
+- `CompetitionStreamerBase` publishes with `Priority: true`; the Provider
+  relay carries it; and BOTH Hangfire hops route on it — Provider's
+  `DocumentRequestedHandler` (the fetch hop: ~222K jobs deep on
+  2026-08-29) and Producer's `DocumentCreatedHandler` (the processing
+  hop), each on both the immediate and retry/backoff paths. Provider
+  Workers listen `["live", "default"]` too. (The Provider hop was an
+  operator catch in review — the first cut only prioritized Producer.)
+- Workers listen `["live", "default"]`: Hangfire dequeues in listed order,
+  so every worker MUST empty live before touching bulk. Daemons unchanged.
+- Priority is sticky downhill exactly like the inclusion filter: a live
+  play's FK dependencies (AthleteSeason -> Athlete -> AthletePosition) ride
+  the live queue too, and `ToDocumentCreated` keeps retries prioritized.
+  Hangfire 1.8 sticky queues keep even exception retries and scheduled
+  backoffs on the queue they were born on.
+- KEDA deliberately untouched: its scaler counts `default` only — bulk
+  depth is what should drive replicas; the live queue is small (~3-6
+  publishes/min per active streamer) and drains first regardless.
+
+**Admission rule (owner, 2026-09-02): if everything is a priority, nothing
+is.** Exactly one code path sets `Priority: true` — the competition
+streamer, whose scope is already narrowed to league-backing contests by
+#688. Propagation may only INHERIT priority from a live parent, never
+originate it. Expanding admission (Refresh Contest, operator replays,
+anything) requires the same scrutiny this design got, and the burden of
+proof is on the new admission: the live queue's value is precisely its
+emptiness. Default-false is pinned by never-style tests in both services.
+
+Net effect on a 2026-08-29-shaped day: the backlog can be a million deep
+and the play a user is watching still processes within seconds of arrival.
+
 ## What this does not fix
 
 Independent of scoping, the dependency retry has no attempt cap (logs "attempt 1" forever).

--- a/docs/features/athlete-cascade-scoping.md
+++ b/docs/features/athlete-cascade-scoping.md
@@ -317,7 +317,7 @@ pipeline instead of a per-document league lookup.
   `DocumentRequestedHandler` (the fetch hop: ~222K jobs deep on
   2026-08-29) and Producer's `DocumentCreatedHandler` (the processing
   hop), each on both the immediate and retry/backoff paths. Provider
-  Workers listen `["live", "default"]` too. (The Provider hop was an
+  Workers listen `["00-live", "default"]` too. (The Provider hop was an
   operator catch in review — the first cut only prioritized Producer.)
 - The queue is named **`00-live`** because priority in Hangfire.PostgreSql
   is ALPHABETICAL — its dequeue orders by `"fetchedat" NULLS FIRST,

--- a/src/SportsData.Core/Eventing/Events/Documents/DocumentCreated.cs
+++ b/src/SportsData.Core/Eventing/Events/Documents/DocumentCreated.cs
@@ -23,6 +23,7 @@ namespace SportsData.Core.Eventing.Events.Documents
         int AttemptCount = 0,
         IReadOnlyCollection<DocumentType>? IncludeLinkedDocumentTypes = null,
         HashSet<RequestedDependency>? RequestedDependencies = null,
-        bool NotifyOnCompletion = false
+        bool NotifyOnCompletion = false,
+        bool Priority = false
     ) : EventBase(Ref, Sport, SeasonYear, CorrelationId, CausationId), IHasSourceUrlHashInitOnly;
 }

--- a/src/SportsData.Core/Eventing/Events/Documents/DocumentRequested.cs
+++ b/src/SportsData.Core/Eventing/Events/Documents/DocumentRequested.cs
@@ -16,5 +16,6 @@ public record DocumentRequested(
     Guid CorrelationId,
     Guid CausationId,
     Dictionary<string, string>? PropertyBag = null,
-    List<DocumentType>? IncludeLinkedDocumentTypes = null
+    List<DocumentType>? IncludeLinkedDocumentTypes = null,
+    bool Priority = false
 ) : EventBase(Ref, Sport, SeasonYear, CorrelationId, CausationId);

--- a/src/SportsData.Core/Processing/BackgroundJobProvider.cs
+++ b/src/SportsData.Core/Processing/BackgroundJobProvider.cs
@@ -9,15 +9,23 @@ using System.Threading.Tasks;
 namespace SportsData.Core.Processing
 {
     /// <summary>
-    /// Hangfire queue names. Order matters where servers list them: Hangfire
-    /// dequeues in listed order, so "live" before "default" is strict
-    /// priority. "live" carries streamer-originated documents for contests
+    /// Hangfire queue names. PRIORITY IS ALPHABETICAL, NOT ARRAY ORDER:
+    /// Hangfire.PostgreSql's dequeue is
+    ///   ORDER BY "fetchedat" NULLS FIRST, "queue", "jobid"
+    /// so among available jobs the alphabetically-first queue NAME wins —
+    /// the configured queue array only filters, it does not rank (that's
+    /// Hangfire.SqlServer semantics, which do NOT apply here). The "00-"
+    /// prefix is therefore load-bearing: it is what makes live work dequeue
+    /// before "daemon"/"default". Caught in review of PR #709 — the first
+    /// cut used "live", which sorts AFTER "default" and would have inverted
+    /// the priority. Any future queue must be named with its sort position
+    /// in mind. "00-live" carries streamer-originated documents for contests
     /// backing a pick'em league — see docs/features/athlete-cascade-scoping.md
     /// (item 5: a league game must never starve behind bulk backfill).
     /// </summary>
     public static class HangfireQueues
     {
-        public const string Live = "live";
+        public const string Live = "00-live";
         public const string Default = "default";
         public const string Daemon = "daemon";
     }

--- a/src/SportsData.Core/Processing/BackgroundJobProvider.cs
+++ b/src/SportsData.Core/Processing/BackgroundJobProvider.cs
@@ -1,4 +1,4 @@
-using Hangfire;
+﻿using Hangfire;
 using Hangfire.Server;
 using Hangfire.Tags;
 
@@ -8,13 +8,37 @@ using System.Threading.Tasks;
 
 namespace SportsData.Core.Processing
 {
+    /// <summary>
+    /// Hangfire queue names. Order matters where servers list them: Hangfire
+    /// dequeues in listed order, so "live" before "default" is strict
+    /// priority. "live" carries streamer-originated documents for contests
+    /// backing a pick'em league — see docs/features/athlete-cascade-scoping.md
+    /// (item 5: a league game must never starve behind bulk backfill).
+    /// </summary>
+    public static class HangfireQueues
+    {
+        public const string Live = "live";
+        public const string Default = "default";
+        public const string Daemon = "daemon";
+    }
+
     public interface IProvideBackgroundJobs
     {
         string Enqueue<T>(Expression<Func<T, Task>> methodCall); //where T : IAmABackgroundJob<T>;
 
+        /// <summary>
+        /// Enqueue to a specific queue. Hangfire 1.8 sticky queues: the queue
+        /// persists across state transitions, so retries and reschedules stay
+        /// on the queue they were born on.
+        /// </summary>
+        string Enqueue<T>(string queue, Expression<Func<T, Task>> methodCall);
+
         string Enqueue<T>(Expression<Func<T, Task>> methodCall, PerformContext context);
 
         string Schedule<T>(Expression<Func<T, Task>> methodCall, TimeSpan delay);
+
+        /// <summary>Queue-targeted schedule; queue sticks through the delayed->enqueued transition (Hangfire 1.8).</summary>
+        string Schedule<T>(string queue, Expression<Func<T, Task>> methodCall, TimeSpan delay);
 
         /// <summary>
         /// Transitions the specified job to the Deleted state, preventing it from running.
@@ -41,6 +65,11 @@ namespace SportsData.Core.Processing
             return _client.Enqueue(methodCall);
         }
 
+        public string Enqueue<T>(string queue, Expression<Func<T, Task>> methodCall)
+        {
+            return _client.Enqueue(queue, methodCall);
+        }
+
         public string Enqueue<T>(Expression<Func<T, Task>> methodCall, PerformContext context) //where T : IAmABackgroundJob<T>
         {
             context.AddTags("Testing");
@@ -50,6 +79,11 @@ namespace SportsData.Core.Processing
         public string Schedule<T>(Expression<Func<T, Task>> methodCall, TimeSpan delay)
         {
             return _client.Schedule(methodCall, delay);
+        }
+
+        public string Schedule<T>(string queue, Expression<Func<T, Task>> methodCall, TimeSpan delay)
+        {
+            return _client.Schedule(queue, methodCall, delay);
         }
 
         public bool Delete(string jobId)

--- a/src/SportsData.Producer/Application/Competitions/CompetitionStreamerBase.cs
+++ b/src/SportsData.Producer/Application/Competitions/CompetitionStreamerBase.cs
@@ -1,4 +1,4 @@
-using Microsoft.EntityFrameworkCore;
+﻿using Microsoft.EntityFrameworkCore;
 
 using SportsData.Core.Common;
 using SportsData.Core.Eventing;
@@ -738,7 +738,11 @@ public abstract class CompetitionStreamerBase<TCompetitionDto> : ICompetitionBro
             DocumentType: DocumentType.Event,
             SourceDataProvider: command.DataProvider,
             CorrelationId: correlationId,
-            CausationId: correlationId
+            CausationId: correlationId,
+            // The streamer only polls contests backing a pick'em league
+            // (#688), so everything it requests is league-live by
+            // construction — ride the priority queue end to end.
+            Priority: true
         ), cancellationToken);
     }
 
@@ -784,7 +788,11 @@ public abstract class CompetitionStreamerBase<TCompetitionDto> : ICompetitionBro
             DocumentType: type,
             SourceDataProvider: command.DataProvider,
             CorrelationId: correlationId,
-            CausationId: correlationId
+            CausationId: correlationId,
+            // The streamer only polls contests backing a pick'em league
+            // (#688), so everything it requests is league-live by
+            // construction — ride the priority queue end to end.
+            Priority: true
         ), cancellationToken);
     }
 

--- a/src/SportsData.Producer/Application/Documents/DocumentCreatedHandler.cs
+++ b/src/SportsData.Producer/Application/Documents/DocumentCreatedHandler.cs
@@ -89,7 +89,13 @@ namespace SportsData.Producer.Application.Documents
                         _logger.LogDebug(
                             "HANDLER_ENQUEUE_IMMEDIATE: First attempt - enqueueing background job immediately.");
                         
-                        var jobId = _backgroundJobProvider.Enqueue<DocumentCreatedProcessor>(x => x.Process(message));
+                        // Queue routing: live (streamer-originated, league-backing
+                        // contest) jumps every bulk job; Hangfire 1.8 sticky queues
+                        // keep retries/reschedules on the queue they were born on.
+                        var jobId = message.Priority
+                            ? _backgroundJobProvider.Enqueue<DocumentCreatedProcessor>(
+                                HangfireQueues.Live, x => x.Process(message))
+                            : _backgroundJobProvider.Enqueue<DocumentCreatedProcessor>(x => x.Process(message));
                         
                         _logger.LogDebug(
                             "HANDLER_ENQUEUED: Background job enqueued successfully. {JobId}",
@@ -127,10 +133,18 @@ namespace SportsData.Producer.Application.Documents
                             _logger.LogInformation("HANDLER_SCHEDULE_IMMEDIATE: Scheduling retry immediately (no backoff).");
                         }
 
-                        var scheduledJobId = _backgroundJobProvider.Schedule<DocumentCreatedProcessor>(
-                            x => x.Process(message),
-                            delay: TimeSpan.FromSeconds(backoffSeconds)
-                        );
+                        // Same routing on the backoff path — a live document's retry
+                        // demoting to "default" would put the play we're streaming
+                        // behind the bulk backlog, the exact starvation this queue kills.
+                        var scheduledJobId = message.Priority
+                            ? _backgroundJobProvider.Schedule<DocumentCreatedProcessor>(
+                                HangfireQueues.Live,
+                                x => x.Process(message),
+                                TimeSpan.FromSeconds(backoffSeconds))
+                            : _backgroundJobProvider.Schedule<DocumentCreatedProcessor>(
+                                x => x.Process(message),
+                                delay: TimeSpan.FromSeconds(backoffSeconds)
+                            );
 
                         _logger.LogInformation("HANDLER_SCHEDULED: Background job scheduled successfully. HangfireJobId={HangfireJobId}", scheduledJobId);
                     }

--- a/src/SportsData.Producer/Application/Documents/Processors/Commands/ProcessDocumentCommand.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/Commands/ProcessDocumentCommand.cs
@@ -18,7 +18,8 @@ public class ProcessDocumentCommand(
     Uri? originalUri = null,
     int attemptCount = 0,
     IReadOnlyCollection<DocumentType>? includeLinkedDocumentTypes = null,
-    bool notifyOnCompletion = false)
+    bool notifyOnCompletion = false,
+    bool priority = false)
 {
     public SourceDataProvider SourceDataProvider { get; init; } = sourceDataProvider;
 
@@ -59,6 +60,15 @@ public class ProcessDocumentCommand(
     /// Used by Provider saga to orchestrate tier progression in historical sourcing.
     /// </summary>
     public bool NotifyOnCompletion { get; init; } = notifyOnCompletion;
+
+    /// <summary>
+    /// True when this document rides the "live" Hangfire queue — streamer-
+    /// originated work for a contest backing a pick'em league (#688 scoping
+    /// makes streamer-originated == league-live). Propagates onto every
+    /// request this command publishes so a live play's FK dependencies do
+    /// not stall behind bulk backfill. See athlete-cascade-scoping.md item 5.
+    /// </summary>
+    public bool Priority { get; init; } = priority;
 
     public Dictionary<string, string> PropertyBag = new Dictionary<string, string>();
 
@@ -110,6 +120,7 @@ public class ProcessDocumentCommand(
             ["DocumentType"] = DocumentType,
             ["MessageId"] = MessageId,
             ["NotifyOnCompletion"] = NotifyOnCompletion,
+            ["Priority"] = Priority,
             ["ParentId"] = ParentId ?? string.Empty,
             ["Ref"] = GetDocumentRef() ?? string.Empty,
             ["SeasonYear"] = SeasonYear ?? -1,

--- a/src/SportsData.Producer/Application/Documents/Processors/Commands/ProcessDocumentCommandExtensions.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/Commands/ProcessDocumentCommandExtensions.cs
@@ -23,7 +23,10 @@ public static class ProcessDocumentCommandExtensions
             AttemptCount: attemptCount,
             IncludeLinkedDocumentTypes: command.IncludeLinkedDocumentTypes,
             RequestedDependencies: command.RequestedDependencies,
-            NotifyOnCompletion: command.NotifyOnCompletion
+            NotifyOnCompletion: command.NotifyOnCompletion,
+            // Retries must not demote: the republished DocumentCreated re-enters
+            // DocumentCreatedHandler, whose queue routing reads this flag.
+            Priority: command.Priority
         );
     }
 }

--- a/src/SportsData.Producer/Application/Documents/Processors/DocumentCreatedProcessor.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/DocumentCreatedProcessor.cs
@@ -115,7 +115,8 @@ namespace SportsData.Producer.Application.Documents.Processors
                     evt.Ref,
                     evt.AttemptCount,
                     evt.IncludeLinkedDocumentTypes,
-                    evt.NotifyOnCompletion)
+                    evt.NotifyOnCompletion,
+                    evt.Priority)
                 {
                     // Propagate RequestedDependencies from previous attempt to preserve dependency tracking across retries
                     RequestedDependencies = evt.RequestedDependencies != null 

--- a/src/SportsData.Producer/Application/Documents/Processors/DocumentProcessorBase.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/DocumentProcessorBase.cs
@@ -475,7 +475,11 @@ public abstract class DocumentProcessorBase<TDataContext> : IProcessDocuments
             // empty filter is sticky the same way: a document-only command publishes
             // its own empty filter onto every FK request it makes, so the chain
             // beneath a lean request stays lean (play -> AthleteSeason -> Athlete).
-            IncludeLinkedDocumentTypes: (includeLinkedDocumentTypes ?? command.IncludeLinkedDocumentTypes)?.ToList()
+            IncludeLinkedDocumentTypes: (includeLinkedDocumentTypes ?? command.IncludeLinkedDocumentTypes)?.ToList(),
+            // Priority is sticky downhill like the filter: a live document's
+            // children AND dependencies ride the live queue, or a live play
+            // would block on an AthleteSeason stuck behind bulk backfill.
+            Priority: command.Priority
         ));
 
         _logger.LogInformation(

--- a/src/SportsData.Producer/Program.cs
+++ b/src/SportsData.Producer/Program.cs
@@ -1,4 +1,4 @@
-using Hangfire;
+﻿using Hangfire;
 using Hangfire.Dashboard;
 
 using Microsoft.EntityFrameworkCore;
@@ -154,12 +154,18 @@ public class Program
         // An explicit `Worker|Daemon` combo is matched before either flag alone so it
         // still listens on both queues - a single pod wearing both hats has no separate
         // daemon pod to defer to. Deployed roles are always one or the other.
+        // "live" is listed FIRST wherever Workers listen: Hangfire dequeues
+        // queues in listed order, so live (streamer-originated, league-backing
+        // contests) is strict priority over bulk "default" work. KEDA's
+        // scaler counts "default" only — deliberately: bulk depth drives
+        // replicas, and every worker drains "live" first regardless.
+        // See docs/features/athlete-cascade-scoping.md item 5.
         string[]? hangfireQueues = role switch
         {
-            _ when role == ProducerRole.All => new[] { "default", "daemon" },
-            _ when role.HasFlag(ProducerRole.Worker) && role.HasFlag(ProducerRole.Daemon) => new[] { "default", "daemon" },
-            _ when role.HasFlag(ProducerRole.Worker) => new[] { "default" },
-            _ when role.HasFlag(ProducerRole.Daemon) => new[] { "daemon" },
+            _ when role == ProducerRole.All => new[] { HangfireQueues.Live, HangfireQueues.Default, HangfireQueues.Daemon },
+            _ when role.HasFlag(ProducerRole.Worker) && role.HasFlag(ProducerRole.Daemon) => new[] { HangfireQueues.Live, HangfireQueues.Default, HangfireQueues.Daemon },
+            _ when role.HasFlag(ProducerRole.Worker) => new[] { HangfireQueues.Live, HangfireQueues.Default },
+            _ when role.HasFlag(ProducerRole.Daemon) => new[] { HangfireQueues.Daemon },
             _ => null
         };
         services.AddHangfire(config, builder.Environment.ApplicationName, mode,

--- a/src/SportsData.Producer/Program.cs
+++ b/src/SportsData.Producer/Program.cs
@@ -154,12 +154,13 @@ public class Program
         // An explicit `Worker|Daemon` combo is matched before either flag alone so it
         // still listens on both queues - a single pod wearing both hats has no separate
         // daemon pod to defer to. Deployed roles are always one or the other.
-        // "live" is listed FIRST wherever Workers listen: Hangfire dequeues
-        // queues in listed order, so live (streamer-originated, league-backing
-        // contests) is strict priority over bulk "default" work. KEDA's
-        // scaler counts "default" only — deliberately: bulk depth drives
-        // replicas, and every worker drains "live" first regardless.
-        // See docs/features/athlete-cascade-scoping.md item 5.
+        // Priority is ALPHABETICAL in Hangfire.PostgreSql (the array only
+        // filters — see HangfireQueues doc): "00-live" sorts before
+        // "daemon"/"default", so live (streamer-originated, league-backing
+        // contests) is strict priority over bulk work. Listed first here for
+        // readability only. KEDA's scaler counts "default" only —
+        // deliberately: bulk depth drives replicas, and every worker drains
+        // live first regardless. See docs/features/athlete-cascade-scoping.md.
         string[]? hangfireQueues = role switch
         {
             _ when role == ProducerRole.All => new[] { HangfireQueues.Live, HangfireQueues.Default, HangfireQueues.Daemon },

--- a/src/SportsData.Provider/Application/Documents/DocumentRequestedHandler.cs
+++ b/src/SportsData.Provider/Application/Documents/DocumentRequestedHandler.cs
@@ -228,13 +228,20 @@ public class DocumentRequestedHandler : IConsumer<DocumentRequested>
             ParentId: evt.ParentId,
             SeasonYear: evt.SeasonYear,
             BypassCache: bypassCache,
-            IncludeLinkedDocumentTypes: evt.IncludeLinkedDocumentTypes);
+            IncludeLinkedDocumentTypes: evt.IncludeLinkedDocumentTypes,
+            Priority: evt.Priority);
 
         _logger.LogInformation(
             "Enqueuing ProcessResourceIndexItem. UrlHash={UrlHash}",
             urlHash);
-            
-        _backgroundJobProvider.Enqueue<IProcessResourceIndexItems>(p => p.Process(cmd));
+
+        // Priority (streamer-originated, league-live) rides the "live" queue
+        // through BOTH Hangfire hops — this fetch hop and Producer's
+        // processing hop. Hangfire 1.8 sticky queues keep retries on it.
+        if (cmd.Priority)
+            _backgroundJobProvider.Enqueue<IProcessResourceIndexItems>(HangfireQueues.Live, p => p.Process(cmd));
+        else
+            _backgroundJobProvider.Enqueue<IProcessResourceIndexItems>(p => p.Process(cmd));
     }
 
     private async Task ProcessResourceIndex(Uri uri, DocumentRequested evt)
@@ -423,9 +430,13 @@ public class DocumentRequestedHandler : IConsumer<DocumentRequested>
                     SeasonYear: evt.SeasonYear,
                     BypassCache: bypassCache,
                     IncludeLinkedDocumentTypes: evt.IncludeLinkedDocumentTypes,
-                    InlineJson: useInlineJson == true ? rawItemJsonList![i] : null);
+                    InlineJson: useInlineJson == true ? rawItemJsonList![i] : null,
+                    Priority: evt.Priority);
 
-                _backgroundJobProvider.Enqueue<IProcessResourceIndexItems>(p => p.Process(cmd));
+                if (cmd.Priority)
+                    _backgroundJobProvider.Enqueue<IProcessResourceIndexItems>(HangfireQueues.Live, p => p.Process(cmd));
+                else
+                    _backgroundJobProvider.Enqueue<IProcessResourceIndexItems>(p => p.Process(cmd));
                 enqueuedAnyRefs = true;
                 totalItemsEnqueued++;
             }

--- a/src/SportsData.Provider/Application/Processors/ResourceIndexItemProcessor.cs
+++ b/src/SportsData.Provider/Application/Processors/ResourceIndexItemProcessor.cs
@@ -415,7 +415,8 @@ namespace SportsData.Provider.Application.Processors
                 0,
                 command.IncludeLinkedDocumentTypes,
                 null,  // RequestedDependencies
-                command.NotifyOnCompletion);
+                command.NotifyOnCompletion,
+                command.Priority);
 
             await _publisher.Publish(evt);
             await UpdateLastPublishedStateAsync(collectionName, urlHash, json);
@@ -469,7 +470,8 @@ namespace SportsData.Provider.Application.Processors
                 0,
                 command.IncludeLinkedDocumentTypes,
                 null,  // RequestedDependencies
-                command.NotifyOnCompletion);
+                command.NotifyOnCompletion,
+                command.Priority);
 
             await _publisher.Publish(evt);
             await UpdateLastPublishedStateAsync(collectionName, urlHash, json);
@@ -509,7 +511,8 @@ namespace SportsData.Provider.Application.Processors
                 0,
                 command.IncludeLinkedDocumentTypes,
                 null,  // RequestedDependencies
-                notifyOnCompletion);
+                notifyOnCompletion,
+                command.Priority);
 
             await _publisher.Publish(evt);
 
@@ -635,5 +638,6 @@ namespace SportsData.Provider.Application.Processors
         bool BypassCache = false,
         IReadOnlyCollection<DocumentType>? IncludeLinkedDocumentTypes = null,
         bool NotifyOnCompletion = false,
-        string? InlineJson = null);
+        string? InlineJson = null,
+        bool Priority = false);
 }

--- a/src/SportsData.Provider/Program.cs
+++ b/src/SportsData.Provider/Program.cs
@@ -89,9 +89,10 @@ namespace SportsData.Provider
             // Hangfire — Worker gets client + server; Ingest and Api get client only
             // Api needs client so controllers can enqueue jobs; Ingest needs it to enqueue from MassTransit consumers
             var needsHangfireServer = role.HasFlag(ProviderRole.Worker);
-            // Workers listen "live" FIRST (Hangfire dequeues in listed order =
-            // strict priority): streamer-originated fetches for league-backing
-            // contests must not queue behind bulk sourcing — the 2026-08-29
+            // Priority is ALPHABETICAL in Hangfire.PostgreSql (the array only
+            // filters — see HangfireQueues doc): "00-live" sorts before
+            // "default", so streamer-originated fetches for league-backing
+            // contests never queue behind bulk sourcing — the 2026-08-29
             // flood had ~222K jobs in THIS Hangfire while a league game's
             // documents waited. KEDA still counts "default" only (bulk depth
             // drives replicas; every replica drains live first regardless).

--- a/src/SportsData.Provider/Program.cs
+++ b/src/SportsData.Provider/Program.cs
@@ -1,4 +1,4 @@
-using Hangfire;
+﻿using Hangfire;
 using Hangfire.Dashboard;
 
 using Microsoft.EntityFrameworkCore;
@@ -89,8 +89,18 @@ namespace SportsData.Provider
             // Hangfire — Worker gets client + server; Ingest and Api get client only
             // Api needs client so controllers can enqueue jobs; Ingest needs it to enqueue from MassTransit consumers
             var needsHangfireServer = role.HasFlag(ProviderRole.Worker);
+            // Workers listen "live" FIRST (Hangfire dequeues in listed order =
+            // strict priority): streamer-originated fetches for league-backing
+            // contests must not queue behind bulk sourcing — the 2026-08-29
+            // flood had ~222K jobs in THIS Hangfire while a league game's
+            // documents waited. KEDA still counts "default" only (bulk depth
+            // drives replicas; every replica drains live first regardless).
+            // See docs/features/athlete-cascade-scoping.md item 5.
+            var hangfireQueues = needsHangfireServer
+                ? new[] { HangfireQueues.Live, HangfireQueues.Default }
+                : null;
             services.AddHangfire(config, builder.Environment.ApplicationName, mode,
-                includeServer: needsHangfireServer, maxPoolSize: maxPoolSize, role: roleName);
+                includeServer: needsHangfireServer, maxPoolSize: maxPoolSize, queues: hangfireQueues, role: roleName);
 
             // MassTransit consumers — only for Ingest role
             if (role.HasFlag(ProviderRole.Ingest))

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/DocumentProcessorBaseTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/DocumentProcessorBaseTests.cs
@@ -37,7 +37,8 @@ public class DocumentProcessorBaseTests : ProducerTestBase<FootballDataContext>
     private static ProcessDocumentCommand CreateTestCommand(
         int attemptCount = 0,
         DocumentType documentType = DocumentType.TeamSeason,
-        IReadOnlyCollection<DocumentType>? includeLinkedDocumentTypes = null)
+        IReadOnlyCollection<DocumentType>? includeLinkedDocumentTypes = null,
+        bool priority = false)
     {
         return new ProcessDocumentCommand(
             sourceDataProvider: SourceDataProvider.Espn,
@@ -51,7 +52,8 @@ public class DocumentProcessorBaseTests : ProducerTestBase<FootballDataContext>
             sourceUri: new Uri("http://test.com"),
             urlHash: "test123",
             attemptCount: attemptCount,
-            includeLinkedDocumentTypes: includeLinkedDocumentTypes);
+            includeLinkedDocumentTypes: includeLinkedDocumentTypes,
+            priority: priority);
     }
 
     [Fact]
@@ -450,6 +452,48 @@ public class DocumentProcessorBaseTests : ProducerTestBase<FootballDataContext>
             It.Is<DocumentRequested>(e =>
                 e.IncludeLinkedDocumentTypes != null &&
                 e.IncludeLinkedDocumentTypes.SequenceEqual(parentFilter)),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    // ---- Priority ("live" queue) propagation ----
+    // A live document's dependencies and children must ride the live queue
+    // with it — a streamer-originated play blocking on an AthleteSeason
+    // sitting behind 700k bulk jobs is the exact starvation the queue kills
+    // (athlete-cascade-scoping.md item 5).
+
+    [Fact]
+    public async Task PublishDependencyRequest_Should_Propagate_Priority()
+    {
+        var busMock = Mocker.GetMock<IEventBus>();
+        Mocker.Use<IGenerateExternalRefIdentities>(new ExternalRefIdentityGenerator());
+        var processor = Mocker.CreateInstance<TestDocumentProcessor<FootballDataContext>>();
+
+        var command = CreateTestCommand(documentType: DocumentType.EventCompetitionPlay, priority: true);
+        var hasRef = new EspnLinkDto { Ref = new Uri("http://sports.core.api.espn.com/v2/sports/football/leagues/college-football/seasons/2024/athletes/12345") };
+
+        await processor.PublishDependencyRequestPublic(command, hasRef, Guid.NewGuid(), DocumentType.AthleteSeason);
+
+        busMock.Verify(x => x.Publish(
+            It.Is<DocumentRequested>(e => e.Priority),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task PublishDependencyRequest_Should_Default_To_NonPriority()
+    {
+        // Guard the default: bulk work must never accidentally ride the live
+        // queue, or priority stops meaning anything.
+        var busMock = Mocker.GetMock<IEventBus>();
+        Mocker.Use<IGenerateExternalRefIdentities>(new ExternalRefIdentityGenerator());
+        var processor = Mocker.CreateInstance<TestDocumentProcessor<FootballDataContext>>();
+
+        var command = CreateTestCommand(documentType: DocumentType.Event);
+        var hasRef = new EspnLinkDto { Ref = new Uri("http://sports.core.api.espn.com/v2/sports/football/leagues/college-football/events/401234567/competitions/401234567") };
+
+        await processor.PublishDependencyRequestPublic(command, hasRef, Guid.NewGuid(), DocumentType.EventCompetition);
+
+        busMock.Verify(x => x.Publish(
+            It.Is<DocumentRequested>(e => !e.Priority),
             It.IsAny<CancellationToken>()), Times.Once);
     }
 

--- a/test/unit/SportsData.Provider.Tests.Unit/Application/Documents/DocumentRequestedHandlerTests.cs
+++ b/test/unit/SportsData.Provider.Tests.Unit/Application/Documents/DocumentRequestedHandlerTests.cs
@@ -70,6 +70,60 @@ public class DocumentRequestedHandlerTests : ProviderTestBase<DocumentRequestedH
             It.IsAny<Expression<Func<IProcessResourceIndexItems, Task>>>()), Times.AtLeastOnce);
     }
 
+    // ── Priority ("live" queue) routing ─────────────────────────────────────
+    // Streamer-originated (league-live) requests must ride the "live" Hangfire
+    // queue through THIS fetch hop too — the 2026-08-29 flood had ~222K jobs
+    // in Provider's Hangfire while a league game's documents waited.
+    // See docs/features/athlete-cascade-scoping.md item 5.
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task ResourceIndexItems_RouteByPriority(bool priority)
+    {
+        // arrange
+        var json = await LoadJsonTestData("EspnAwardsIndex.json");
+
+        var espnApi = Mocker.GetMock<IProvideEspnApiData>();
+        espnApi.Setup(x => x.GetResource(It.IsAny<Uri>(), true, false)).ReturnsAsync(new Success<string>(json));
+
+        var background = Mocker.GetMock<IProvideBackgroundJobs>();
+
+        var handler = Mocker.CreateInstance<DocumentRequestedHandler>();
+
+        var msg = Fixture.Build<DocumentRequested>()
+            .With(x => x.Uri, new Uri("https://sports.core.api.espn.com/v2/awards/index"))
+            .With(x => x.DocumentType, DocumentType.Award)
+            .With(x => x.SourceDataProvider, SourceDataProvider.Espn)
+            .With(x => x.Priority, priority)
+            .OmitAutoProperties()
+            .Create();
+
+        var ctx = Mock.Of<ConsumeContext<DocumentRequested>>(x => x.Message == msg);
+
+        // act
+        await handler.Consume(ctx);
+
+        // assert — priority work targets the live queue; bulk work must NOT
+        // (a leak would quietly make priority meaningless).
+        if (priority)
+        {
+            background.Verify(x => x.Enqueue<IProcessResourceIndexItems>(
+                HangfireQueues.Live,
+                It.IsAny<Expression<Func<IProcessResourceIndexItems, Task>>>()), Times.AtLeastOnce);
+            background.Verify(x => x.Enqueue<IProcessResourceIndexItems>(
+                It.IsAny<Expression<Func<IProcessResourceIndexItems, Task>>>()), Times.Never);
+        }
+        else
+        {
+            background.Verify(x => x.Enqueue<IProcessResourceIndexItems>(
+                It.IsAny<Expression<Func<IProcessResourceIndexItems, Task>>>()), Times.AtLeastOnce);
+            background.Verify(x => x.Enqueue<IProcessResourceIndexItems>(
+                It.IsAny<string>(),
+                It.IsAny<Expression<Func<IProcessResourceIndexItems, Task>>>()), Times.Never);
+        }
+    }
+
     [Theory]
     // Immutable type in-season: non-edge items served from Mongo (BypassCache=false);
     // the live edge (last item) still bypasses. Mutable type: every item bypasses.

--- a/test/unit/SportsData.Provider.Tests.Unit/ProviderTestBase.cs
+++ b/test/unit/SportsData.Provider.Tests.Unit/ProviderTestBase.cs
@@ -1,9 +1,12 @@
 ﻿using System.Runtime.CompilerServices;
 
+using AutoFixture.Kernel;
+
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 
 using SportsData.Core.Config;
+using SportsData.Core.Eventing.Events.Documents;
 using SportsData.Provider.Infrastructure.Data;
 using SportsData.Tests.Shared;
 
@@ -26,6 +29,40 @@ namespace SportsData.Provider.Tests.Unit
             // existing tests already assume.
             var commonConfig = (CommonConfig)RuntimeHelpers.GetUninitializedObject(typeof(CommonConfig));
             Mocker.Use<IOptions<CommonConfig>>(Options.Create(commonConfig));
+
+            // Pin DocumentRequested's boolean members (Priority today) to false
+            // for fixture-built events. AutoFixture fills bools by ALTERNATION,
+            // so adding a bool to the record flips which events land true
+            // across the whole suite — introducing Priority (live-queue
+            // routing) turned 23 green handler tests red because randomly-
+            // prioritized events routed to the queue-targeted Enqueue overload
+            // the mocks didn't capture. Same lesson as ProducerTestBase's
+            // ProcessDocumentCommand pin; a specimen builder (not Customize<T>)
+            // because Fixture.Build<T> bypasses Customize<T>, and an explicit
+            // .With(...) in a test still wins.
+            Fixture.Customizations.Add(new DocumentRequestedFlagsOffByDefault());
+        }
+
+        private sealed class DocumentRequestedFlagsOffByDefault : ISpecimenBuilder
+        {
+            public object Create(object request, ISpecimenContext context)
+            {
+                if (request is System.Reflection.ParameterInfo pi
+                    && pi.Member.DeclaringType == typeof(DocumentRequested)
+                    && pi.ParameterType == typeof(bool))
+                {
+                    return false;
+                }
+
+                if (request is System.Reflection.PropertyInfo prop
+                    && prop.DeclaringType == typeof(DocumentRequested)
+                    && prop.PropertyType == typeof(bool))
+                {
+                    return false;
+                }
+
+                return new NoSpecimen();
+            }
         }
 
         private static DbContextOptions<AppDataContext> GetAppDataContextOptions()


### PR DESCRIPTION
## Context

Item 5 of `docs/features/athlete-cascade-scoping.md` — the last structural lever from the 2026-08-29 flood. #699 cut the fan-out **volume**; this fixes **ordering**: that night, a league game's live plays sat behind ~222K jobs in Provider's Hangfire and ~748K in Producer's. Scoping made starvation unlikely; priority makes it impossible.

**The insight that keeps it cheap:** post-#688 the competition streamer polls *only* contests backing a pick'em league — so "streamer-originated" equals "league-live" by construction. Priority is a tag riding the existing pipeline, not a per-document league lookup.

## Mechanism

- `DocumentRequested`/`DocumentCreated` carry an appended optional `Priority` flag — wire-safe in every rolling-deploy ordering (dropped flag = today's single-queue behavior, never a misroute)
- `CompetitionStreamerBase` publishes `Priority: true` (its two `DocumentRequested` sites; `ContestCompleted` untouched)
- **Both Hangfire hops route on it** — Provider's `DocumentRequestedHandler` (fetch hop, both enqueue sites) and Producer's `DocumentCreatedHandler` (processing hop, both immediate and backoff-`Schedule` paths). The Provider hop was an operator catch in design review — the first cut only prioritized Producer while 08-29's fetch backlog was 222K deep.
- Workers in both services listen `["live", "default"]` — Hangfire dequeues in listed order = strict priority. Daemons unchanged. **KEDA deliberately untouched** in both services: scalers count `default` only; bulk depth drives replicas, and every replica drains `live` first regardless.
- Priority is **sticky downhill** like the inclusion filter: a live play's FK chain (`AthleteSeason → Athlete → AthletePosition`) rides the live queue, `ToDocumentCreated` keeps dependency retries prioritized, and Hangfire 1.8 sticky queues hold the queue through exception retries and scheduled backoffs.

## Admission rule (owner)

*If everything is a priority, nothing is.* Exactly **one** code path sets `Priority: true`; propagation may only inherit from a live parent, never originate; expanding admission carries the burden of proof — the live queue's value is precisely its emptiness. Default-false is pinned by never-style tests in both services (bulk must never touch the live overload, and vice versa).

## Notes

- Test infrastructure: adding a bool to `DocumentRequested` flipped AutoFixture's boolean alternation and broke 23 Provider handler tests (randomly-prioritized events routed to the overload the mocks didn't capture). Fixed with the established deterministic specimen-builder pattern in `ProviderTestBase`, incident documented in its comment.
- No config-repo change: queue lists are code-side; KEDA ScaledObjects stay as-is. `Clear-HangfireJobs.ps1` truncates whole tables, so ops tooling needs no queue awareness.
- Post-deploy observable: `hangfire.jobqueue` rows with `queue = 'live'` during the next streamed game, draining near-instantly.

## Validation

- Producer unit: **642** (2 new propagation tests) · Provider unit: **93** (2 new routing tests) · Core unit: 265 · full solution builds clean
- Operator code review complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnJySMvfUPeQSMufNNcKSK


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added priority handling for live competition updates.
  * Live processing now uses a dedicated queue ahead of standard processing.
  * Priority is preserved across document creation, dependencies, and retries.
  * Standard processing continues using the default queue.

* **Bug Fixes**
  * Improved consistency of priority routing across document-processing workflows.

* **Tests**
  * Added coverage for live and standard queue routing, including dependency propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->