### PR TITLE
fix(api): sport gate on preview generation — MLB test leagues no longer burn DeepSeek tokens

### DIFF
--- a/src/SportsData.Api/Application/PickemGroups/PickemGroupMatchupAddedHandler.cs
+++ b/src/SportsData.Api/Application/PickemGroups/PickemGroupMatchupAddedHandler.cs
@@ -1,4 +1,4 @@
-using MassTransit;
+﻿using MassTransit;
 
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
@@ -54,6 +54,16 @@ namespace SportsData.Api.Application.PickemGroups
                 _logger.LogInformation(
                     "Matchup preview generation disabled by config. Skipping preview enqueue for contest {ContestId}.",
                     @event.ContestId);
+                return;
+            }
+
+            // Sport gate — mirrors PickemGroupWeekMatchupsGeneratedHandler;
+            // MatchupPreviewProcessor enforces the same policy as the choke point.
+            if (!MatchupPreviewPolicy.SupportsSport(@event.Sport))
+            {
+                _logger.LogInformation(
+                    "Preview generation not supported for {Sport}; skipping enqueue for contest {ContestId}.",
+                    @event.Sport, @event.ContestId);
                 return;
             }
 

--- a/src/SportsData.Api/Application/PickemGroups/PickemGroupWeekMatchupsGeneratedHandler.cs
+++ b/src/SportsData.Api/Application/PickemGroups/PickemGroupWeekMatchupsGeneratedHandler.cs
@@ -109,6 +109,17 @@ namespace SportsData.Api.Application.PickemGroups
                 return;
             }
 
+            // Sport gate (cheap early-out; MatchupPreviewProcessor enforces the
+            // same policy as the real choke point): no prompts, no enqueue —
+            // an MLB test league must not spend model tokens.
+            if (!MatchupPreviewPolicy.SupportsSport(@event.Sport))
+            {
+                _logger.LogInformation(
+                    "Preview generation not supported for {Sport}; skipping enqueue for {Count} contests.",
+                    @event.Sport, groupWeekMatchupsContestIds.Count);
+                return;
+            }
+
             var existingPreviews = await _dataContext.MatchupPreviews
                 .Where(p => groupWeekMatchupsContestIds.Contains(p.ContestId))
                 .ToListAsync(ct);

--- a/src/SportsData.Api/Application/Previews/MatchupPreviewPolicy.cs
+++ b/src/SportsData.Api/Application/Previews/MatchupPreviewPolicy.cs
@@ -1,0 +1,31 @@
+using SportsData.Core.Common;
+
+using System.Collections.Generic;
+
+namespace SportsData.Api.Application.Previews;
+
+/// <summary>
+/// Which sports may generate LLM matchup previews.
+/// </summary>
+/// <remarks>
+/// This is an engineering fact, not an ops toggle (contrast the
+/// ApiConfig.MatchupPreviewGenerationEnabled kill-switch): preview prompts
+/// exist ONLY for football. An unlisted sport falls through prompt
+/// resolution to the any-sport default and burns model tokens producing
+/// football-shaped text for the wrong sport. BaseballMlb in particular is a
+/// live-pipeline test sport — throwaway single-day leagues must never spend
+/// DeepSeek tokens (operator, 2026-09-02). Enforced at the single choke
+/// point (MatchupPreviewProcessor, which every producer funnels through)
+/// with cheap early-outs in the league event handlers; add a sport here
+/// only when its prompts actually exist.
+/// </remarks>
+public static class MatchupPreviewPolicy
+{
+    private static readonly HashSet<Sport> SupportedSports =
+    [
+        Sport.FootballNcaa,
+        Sport.FootballNfl
+    ];
+
+    public static bool SupportsSport(Sport sport) => SupportedSports.Contains(sport);
+}

--- a/src/SportsData.Api/Application/Previews/MatchupPreviewProcessor.cs
+++ b/src/SportsData.Api/Application/Previews/MatchupPreviewProcessor.cs
@@ -1,4 +1,4 @@
-using Microsoft.EntityFrameworkCore;
+﻿using Microsoft.EntityFrameworkCore;
 
 using SportsData.Api.Application.Previews.Models;
 using SportsData.Api.Application.UI.Matchups;
@@ -67,6 +67,19 @@ namespace SportsData.Api.Application.Previews
             _logger.LogInformation(
                 "Preview processing started. ContestId: {ContestId}, Sport: {Sport}, Mode: {Mode}, CorrelationId: {CorrelationId}",
                 command.ContestId, command.Sport, command.Mode, command.CorrelationId);
+
+            // Hard gate, before any DB or Producer work: prompts exist only
+            // for the sports MatchupPreviewPolicy lists. Everything that can
+            // enqueue this job (league handlers, the recurring generator,
+            // admin paths) funnels through here, so an unsupported sport can
+            // never reach the model regardless of which door it came in.
+            if (!MatchupPreviewPolicy.SupportsSport(command.Sport))
+            {
+                _logger.LogInformation(
+                    "Preview generation not supported for {Sport} — no prompts exist; skipping. ContestId={ContestId}",
+                    command.Sport, command.ContestId);
+                return;
+            }
 
             var rejectedPreview = await _dataContext.MatchupPreviews
                 .OrderByDescending(x => x.CreatedUtc)

--- a/test/unit/SportsData.Api.Tests.Unit/Application/Previews/MatchupPreviewProcessorTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/Previews/MatchupPreviewProcessorTests.cs
@@ -1,4 +1,4 @@
-using Moq;
+﻿using Moq;
 
 using SportsData.Api.Application.Previews;
 using SportsData.Api.Infrastructure.Prompts;
@@ -830,5 +830,40 @@ namespace SportsData.Api.Tests.Unit.Application.Previews
             Assert.Equal("this is not json", capture.RawResponse);
             Assert.NotNull(capture.ResponseValidationErrors);
         }
+
+        [Fact]
+        public async Task Process_UnsupportedSport_SkipsBeforeAnyWork()
+        {
+            // BaseballMlb has no prompts and is the live-pipeline test sport —
+            // a throwaway single-day league must never reach the model, or
+            // even the Producer round trip (MatchupPreviewPolicy).
+            var command = new GenerateMatchupPreviewsCommand
+            {
+                ContestId = Guid.NewGuid(),
+                Sport = Sport.BaseballMlb
+            };
+
+            var sut = Mocker.CreateInstance<MatchupPreviewProcessor>();
+
+            await sut.Process(command);
+
+            Mocker.GetMock<IContestClientFactory>()
+                .Verify(x => x.Resolve(It.IsAny<Sport>()), Times.Never);
+        }
+
+        [Theory]
+        [InlineData(Sport.FootballNcaa)]
+        [InlineData(Sport.FootballNfl)]
+        public void SupportedSports_AreExactlyTheFootballs(Sport sport)
+        {
+            Assert.True(MatchupPreviewPolicy.SupportsSport(sport));
+        }
+
+        [Fact]
+        public void BaseballMlb_IsNotSupported()
+        {
+            Assert.False(MatchupPreviewPolicy.SupportsSport(Sport.BaseballMlb));
+        }
+
     }
 }


### PR DESCRIPTION
## Context

Operator repro: creating a single-day **BaseballMlb** league (MLB is the live-pipeline *test* sport) fired preview-generated toasts. The league handlers enqueued `MatchupPreviewProcessor` per matchup; prompt resolution fell through to the any-sport default (no MLB prompts exist); DeepSeek produced football-shaped text for baseball on a throwaway league.

## Change

**`MatchupPreviewPolicy`** (Previews slice): `{FootballNcaa, FootballNfl}`. Enforced three layers deep:

- **`MatchupPreviewProcessor`** — hard gate at the top of `Process`, before any DB or Producer work. Every producer (both league event handlers, the recurring generator job, admin paths) funnels through here, so an unsupported sport cannot reach the model regardless of entry door.
- Both league event handlers — cheap early-outs beside the existing config kill-switch: no existing-previews query, no enqueues, no toasts.

## Deliberately not configuration-driven

Pre-registered before review: the allowlist mirrors an **engineering fact** — whether prompts for a sport exist in the codebase — not an operational preference. Config would let a label flip enable a sport whose prompts don't exist, recreating the exact failure this fixes via an ops knob. The dimensions are separated on purpose: `ApiConfig.MatchupPreviewGenerationEnabled` stays the ops toggle ("spend money right now?"); the policy is capability ("can this sport produce sane output?"). Capability changes when prompts get written — one line in the set, reviewed alongside them.

## Validation

- Tests pin both directions: `BaseballMlb` never touches `IContestClientFactory` (never-assertion), both footballs pass the policy
- API unit: **811/811** (4 new)
- Operator code review complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnJySMvfUPeQSMufNNcKSK


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Matchup previews are now generated only for NCAA and NFL football.
  * Unsupported sports are skipped before preview processing begins, preventing unnecessary work.
  * Added logging when preview generation is skipped for an unsupported sport.

* **Tests**
  * Added coverage confirming football support and rejection of baseball and other unsupported sports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->