### PR TITLE
feat(api,web): Model Consensus Lab — week matrix, OpenRouter gateway, model provenance

### DIFF
--- a/docs/features/model-consensus-lab.md
+++ b/docs/features/model-consensus-lab.md
@@ -128,7 +128,26 @@ live pick until weeks of season data justify the swap.
 - Baseline rows in the matrix — confirmed in?
 - deetsMeter as the abstention tie-break — confirmed?
 - Once stable: auto-run the audition weekly for league-backing contests, or
-  keep admin-triggered?
+  keep admin-triggered? (Cost is a non-issue: owner measured ~$0.15-0.20
+  per game across six models — a full league-covered week runs under $5.)
+
+## Future (owner ideas 2026-09-03, deliberately not started)
+
+- **Panel consensus into the production preview prompt** — injected as a
+  decided GIVEN ("model predicts, LLM explains"), never a hint: anchoring
+  would launder the panel's chalk bias into confident prose. Sequenced
+  AFTER the Phase 4 evidence gate proves the panel beats the baselines.
+- **Audition the preview PROSE itself** (most accurate/factual/logical
+  model earns public display). The corpus already accrues for free —
+  capture rows store every model's full raw response. First mechanically
+  checkable rung: factuality diff of cited stats vs the PayloadJson the
+  model was given. Style/logic scoring needs a judge; LLM-as-judge
+  circularity (judge and contestant share training data) is the noted
+  risk to solve first.
+- **Admin prose-review surface** — the original point of the lab, beyond
+  pick accuracy: read each model's generated preview side by side with
+  its pick (all in MatchupPreviewPrompt today; drill-down from a matrix
+  cell). Next web work after Phase 1 ships.
 
 ## Constraints carried forward
 

--- a/docs/features/model-consensus-lab.md
+++ b/docs/features/model-consensus-lab.md
@@ -1,0 +1,139 @@
+# Model Consensus Lab — design
+
+**Status:** authorized 2026-09-03 (discussion in-session); Phase 1 built
+
+**Decision amendment (2026-09-03):** the 2026-08-08 model-strategy decision
+(docs/metrics-modeling/matchup-preview-data-inputs.md §6) chose first-party
+clients only and passed on OpenRouter. That call predated the many-model
+audition ambition; the owner revised it. Taxonomy matters (owner's
+correction): OpenRouter is NOT a provider — it is a gateway we communicate
+through. Providers stay who they are (Anthropic makes Claude however we
+reach it); the route lives on the Model row as `Gateway` (None |
+OpenRouter). First-party clients remain preferred for production panel
+seats (IP path, exact identity, SPOF isolation).
+**Owner intent:** run the exact same prompt against every model we can reach,
+score picks against actuals in a matrix, and — once the evidence supports it —
+make StatBot's visible prediction the CONSENSUS of a small panel (minimum 2,
+realistically 3 models). Models get added and discarded over time; the
+methodology does not change. Admin-only throughout.
+
+## Two phases of life, two transports
+
+**Audition (breadth):** every candidate model runs through **OpenRouter** —
+one account, one OpenAI-compatible API, every provider's models. Its entire
+value is exactly this use case: same prompt, many models, no per-provider
+signups, one bill. Acceptable trust surface for admin-only experiments
+(prompts already transit DeepSeek today). Routing markup is noise at
+experiment scale.
+
+**Production panel (the chosen ~3): direct per-provider clients.** Two
+reasons this is not optional:
+1. **No shared single point of failure** — a panel routed through one
+   aggregator loses ALL panelists in one outage; direct clients fail
+   independently, and 2-of-3 still resolves with one provider down.
+2. Native structured-output modes, no markup, keys in cluster secrets where
+   everything else lives. The `IProvideAiCommunication` abstraction already
+   exists (DeepSeek, Ollama); each new provider is a day of work behind it.
+
+**Promotion rule:** before a model graduates from audition to panel,
+re-validate it through the direct client — aggregator routing can differ
+subtly (sampling defaults, host selection for open models). The panel is
+scored on exactly what production will call.
+
+## Architecture
+
+- **Model registry**: the EXISTING `Model` + `ModelProvider` entities
+  (designed 2026-08-08 for exactly this work; admin CRUD already lives at
+  the `models` / `model-providers` routes). No new catalog table — the
+  first Phase 1 build invented a duplicate `AiModelCatalogEntry` and was
+  reworked 2026-09-03 when the owner caught it. `Model` gained `Gateway`
+  (None | OpenRouter — a routing attribute, not a provider): a routed row
+  keeps its TRUE provider (Anthropic makes Claude however we reach it) and
+  carries the gateway's namespaced ApiModelId (exact ids only — provider
+  aliases silently swap weights mid-season). The same weights reached
+  directly vs via the gateway are DIFFERENT evaluands — two rows under the
+  same provider, kept apart by (ModelProviderId, ApiModelId) since gateway
+  ids are namespaced. Gateway is identity (create-only, like ApiModelId).
+  Bonus the duplicate lacked: `KnowledgeCutoffUtc` +
+  evidence lets the scoring harness classify each run's contamination risk,
+  and cost-per-MTok rides on the row.
+- **Evaluation run**: NOT a new table — `MatchupPreviewPrompt` already
+  charters itself as "the backtest corpus (payload x model x prompt vs
+  actual outcome)" and its Experiment mode already stores the exact prompt
+  + raw response without ever writing a MatchupPreview. Phase 1 extends it
+  with the queryable measurements: ModelId (no FK — the Model string stays
+  provenance, same pattern as PromptId), parsed SU/ATS picks, actual
+  prompt/completion tokens, latency. Parsed picks persist even when
+  validation flags problems — the matrix scores the pick; the problems
+  column records the caveat.
+- **Fan-out runner**: admin-triggered (Hangfire job), one evaluation per
+  active Model under an active, lab-reachable provider. Parse failure /
+  refusal / timeout is a first-class outcome ("abstained") — never
+  retry-until-it-parses.
+- **Client factory**: resolves a Model row to an evaluation client — the
+  row's `Gateway` picks the route (OpenRouterClient with the row's
+  ApiModelId today); for direct routes the provider's `Kind` picks the
+  first-party implementation as panel seats are earned.
+  `CanResolve(gateway, kind)` is the single source of truth for
+  reachability — an unreachable route is a logged skip, never a Hangfire
+  retry loop. Existing preview pipeline untouched.
+
+## The matrix (admin UI, Phase 2)
+
+Rows = models; per contest: SU pick / ATS pick cells; actuals fill in on
+finalization; running SU% / ATS% accuracy columns accumulate. **Baseline
+rows keep everyone honest:** always-home, always-favorite (spread), and
+deetsMeter (the statistical model already predicts these games).
+
+The honest caution the baselines exist for: LLMs share training data and
+biases and mostly lean chalk — a consensus of N models may converge on
+"pick the favorite." The matrix's first job is to prove or DISPROVE that
+any model or ensemble beats the naive baselines and our own statistical
+model. Cheap disproof before shipping is a success outcome.
+
+## Consensus resolver (Phase 4, dark until evidence)
+
+Panel of 3 (odd -> simple majority cannot tie on a binary pick). Residual
+mechanics: an abstention leaves 2 that can split — **deetsMeter breaks the
+tie** (statistics settle the LLM disagreement; pending owner confirmation).
+The resolver is VERSIONED like modelVersion, so every historical StatBot
+pick stays attributable to the rule that made it. Runs dark beside the
+live pick until weeks of season data justify the swap.
+
+## Phasing
+
+1. **Registry + OpenRouter client + fan-out + persistence** — BUILT
+   2026-09-03 (reworked same day onto the existing Model/ModelProvider
+   entities): Model.Gateway (None | OpenRouter), OpenRouterClient
+   (IProvideModelEvaluation: content + tokens + latency; temperature 0.1 —
+   the lab compares models, sampling noise muddies that), gateway-keyed
+   client resolver (direct routes deliberately unreachable until a panel
+   seat is earned), model gate at the TOP of MatchupPreviewProcessor (an
+   inactive model costs nothing — not even a Producer round trip), and
+   POST admin/matchup/preview/{contestId}/experiment/panel fanning out one
+   Experiment per active, lab-reachable model (25-model budget guard).
+   AppConfig keys: CommonConfig:OpenRouterClientConfig:{ApiKey,BaseUrl}.
+   Seed roster: sql/pgsql/seed_model_lab.sql (idempotent; ids verified
+   against OpenRouter's live catalog 2026-09-03; cutoffs transcribed from
+   llm-training-dates.md UNVERIFIED — the Model Manager's evidence/verified
+   fields are the follow-through). ModelProviderKind.GatewayOnly (99)
+   covers long-tail makers with no first-party client (xAI et al.).
+2. Matrix UI in the admin area + scoring-on-finalization + baselines.
+3. Season data accumulates; audition decides the panel; direct clients for
+   the chosen 3.
+4. Consensus resolver behind a flag, dark comparison, swap on evidence.
+
+## Open questions (owner)
+
+- Baseline rows in the matrix — confirmed in?
+- deetsMeter as the abstention tie-break — confirmed?
+- Once stable: auto-run the audition weekly for league-backing contests, or
+  keep admin-triggered?
+
+## Constraints carried forward
+
+- Prompts NEVER in source control (repo is public); the harness stores
+  prompt REFERENCES to existing prompt entities only.
+- A per-run budget cap even though experiment spend is approved — a runaway
+  loop across N paid APIs deserves a ceiling, not trust.
+- Admin-only surface end to end until the Phase 4 swap.

--- a/docs/metrics-modeling/matchup-preview-data-inputs.md
+++ b/docs/metrics-modeling/matchup-preview-data-inputs.md
@@ -623,7 +623,15 @@ model/prompt choice before real generations start):
      goes non-nullable.
 
      **Provider strategy — DECIDED 2026-08-08: first-party clients
-     only.** Keep the existing DeepSeek client; add sibling
+     only. AMENDED 2026-09-03:** the owner revised this for the Model
+     Consensus Lab's many-model audition (a breadth ambition this
+     decision predates) — OpenRouter admitted, but as what it is: a
+     GATEWAY, not a provider. The route lives on the Model row
+     (Model.Gateway: None | OpenRouter); providers stay who make the
+     models, so cutoff/cost metadata stays truthful. First-party
+     clients remain preferred for production panel seats; see
+     docs/features/model-consensus-lab.md.
+     Keep the existing DeepSeek client; add sibling
      IProvideAiCommunication implementations for Anthropic, OpenAI, and
      Google, resolved by a factory keyed off the Model row's provider —
      the platform's established typed-client/factory idiom. Evaluated

--- a/sql/pgsql/seed_model_lab.sql
+++ b/sql/pgsql/seed_model_lab.sql
@@ -1,0 +1,77 @@
+-- Model Consensus Lab seed: providers + an initial OpenRouter-routed
+-- audition roster. Source of truth for cutoffs/risk:
+-- docs/metrics-modeling/llm-training-dates.md; design:
+-- docs/features/model-consensus-lab.md.
+--
+-- ApiModelIds are OpenRouter's namespaced ids, verified against the live
+-- catalog 2026-09-03 (exact ids only — aliases silently swap weights).
+-- Costs are OpenRouter pass-through per-MTok as of the same date.
+-- CutoffVerifiedUtc is deliberately NULL everywhere: cutoffs here are
+-- transcribed claims — verify against provider docs in the Model Manager
+-- (that is what the evidence/verified columns are for).
+--
+-- Idempotent: fixed UUIDs + ON CONFLICT DO NOTHING (any unique clash —
+-- id, name, or (provider, api id) — skips the row rather than erroring).
+-- Target DB: API (AppDataContext).
+
+-- Providers. Kind maps to a first-party client implementation;
+-- 99 = GatewayOnly (no first-party client; reachable only via gateway).
+INSERT INTO "ModelProvider" ("Id", "Name", "Kind", "Description", "IsActive", "CreatedUtc", "CreatedBy")
+VALUES
+  ('a0000000-0000-0000-0000-000000000001', 'DeepSeek',  0, 'Incumbent production provider (direct client exists)', TRUE, NOW() AT TIME ZONE 'utc', '00000000-0000-0000-0000-000000000000'),
+  ('a0000000-0000-0000-0000-000000000002', 'Anthropic', 1, NULL, TRUE, NOW() AT TIME ZONE 'utc', '00000000-0000-0000-0000-000000000000'),
+  ('a0000000-0000-0000-0000-000000000003', 'OpenAI',    2, NULL, TRUE, NOW() AT TIME ZONE 'utc', '00000000-0000-0000-0000-000000000000'),
+  ('a0000000-0000-0000-0000-000000000004', 'Google',    3, NULL, TRUE, NOW() AT TIME ZONE 'utc', '00000000-0000-0000-0000-000000000000'),
+  ('a0000000-0000-0000-0000-000000000005', 'xAI',       99, 'Gateway-only (no first-party client); disable retrieval for backtests', TRUE, NOW() AT TIME ZONE 'utc', '00000000-0000-0000-0000-000000000000')
+ON CONFLICT DO NOTHING;
+
+-- Models, all Gateway = 1 (OpenRouter). KnowledgeCutoffUtc = declared
+-- TRAINING cutoff (NULL = unpublished, harness treats as higher-risk).
+INSERT INTO "Model" (
+  "Id", "ModelProviderId", "Name", "ApiModelId", "Gateway",
+  "ReleaseDate", "KnowledgeCutoffUtc", "CutoffEvidence", "CutoffVerifiedUtc",
+  "InputCostPerMTok", "OutputCostPerMTok", "IsActive", "IsDefault",
+  "CreatedUtc", "CreatedBy")
+VALUES
+  ('b0000000-0000-0000-0000-000000000001', 'a0000000-0000-0000-0000-000000000002',
+   'Claude Sonnet 4.6', 'anthropic/claude-sonnet-4.6', 1,
+   '2026-01-01', '2025-08-01', 'llm-training-dates.md: Aug 2025 — DISPUTED (one source claims training to Jan 2026); verify at docs.anthropic.com before trusting lower-risk', NULL,
+   3.00, 15.00, TRUE, FALSE, NOW() AT TIME ZONE 'utc', '00000000-0000-0000-0000-000000000000'),
+
+  ('b0000000-0000-0000-0000-000000000002', 'a0000000-0000-0000-0000-000000000002',
+   'Claude Haiku 4.5', 'anthropic/claude-haiku-4.5', 1,
+   '2025-10-01', '2025-07-01', 'llm-training-dates.md: Jul 2025 (lower-risk full 2025 season; cheap floor)', NULL,
+   1.00, 5.00, TRUE, FALSE, NOW() AT TIME ZONE 'utc', '00000000-0000-0000-0000-000000000000'),
+
+  ('b0000000-0000-0000-0000-000000000003', 'a0000000-0000-0000-0000-000000000003',
+   'GPT-5.2', 'openai/gpt-5.2', 1,
+   '2025-12-01', '2025-08-31', 'llm-training-dates.md: Aug 31 2025 — NCAA wk0/1 sits INSIDE training; per-game comparison handles the boundary', NULL,
+   1.75, 14.00, TRUE, FALSE, NOW() AT TIME ZONE 'utc', '00000000-0000-0000-0000-000000000000'),
+
+  ('b0000000-0000-0000-0000-000000000004', 'a0000000-0000-0000-0000-000000000004',
+   'Gemini 3.1 Pro', 'google/gemini-3.1-pro-preview', 1,
+   '2026-02-01', '2025-01-01', 'llm-training-dates.md: Jan 2025 (lower-risk full season + current capability); verify via model card', NULL,
+   2.00, 12.00, TRUE, FALSE, NOW() AT TIME ZONE 'utc', '00000000-0000-0000-0000-000000000000'),
+
+  ('b0000000-0000-0000-0000-000000000005', 'a0000000-0000-0000-0000-000000000005',
+   'Grok 4.3', 'x-ai/grok-4.3', 1,
+   NULL, '2025-12-01', 'llm-training-dates.md: Dec 2025 (higher-risk Sep-Nov); server-side Web/X search MUST stay disabled for backtests', NULL,
+   1.25, 2.50, TRUE, FALSE, NOW() AT TIME ZONE 'utc', '00000000-0000-0000-0000-000000000000'),
+
+  ('b0000000-0000-0000-0000-000000000006', 'a0000000-0000-0000-0000-000000000001',
+   'DeepSeek V3.1', 'deepseek/deepseek-chat-v3.1', 1,
+   '2025-08-01', NULL, 'Provider publishes no cutoff (~Jul 2024 inferred, unofficial) — NULL = treated higher-risk by design', NULL,
+   0.25, 0.95, TRUE, FALSE, NOW() AT TIME ZONE 'utc', '00000000-0000-0000-0000-000000000000'),
+
+  -- The production incumbent, reached DIRECTLY (Gateway 0 = None) — the
+  -- same weights as the OpenRouter row above but a different evaluand.
+  -- IsDefault TRUE: production Generate stamps MatchupPreview.ModelId
+  -- from this row when its ApiModelId matches the wired DeepSeek client
+  -- (CommonConfig:DeepSeekClientConfig:Model = "deepseek-chat").
+  -- Gateway None is unreachable by the lab resolver, so this row is NOT
+  -- a matrix column — it exists as production provenance.
+  ('b0000000-0000-0000-0000-000000000007', 'a0000000-0000-0000-0000-000000000001',
+   'DeepSeek Chat (production, direct)', 'deepseek-chat', 0,
+   NULL, NULL, 'Provider publishes no cutoff — NULL = treated higher-risk by design', NULL,
+   0.27, 1.10, TRUE, TRUE, NOW() AT TIME ZONE 'utc', '00000000-0000-0000-0000-000000000000')
+ON CONFLICT DO NOTHING;

--- a/sql/pgsql/seed_model_lab.sql
+++ b/sql/pgsql/seed_model_lab.sql
@@ -35,27 +35,27 @@ INSERT INTO "Model" (
 VALUES
   ('b0000000-0000-0000-0000-000000000001', 'a0000000-0000-0000-0000-000000000002',
    'Claude Sonnet 4.6', 'anthropic/claude-sonnet-4.6', 1,
-   '2026-01-01', '2025-08-01', 'llm-training-dates.md: Aug 2025 — DISPUTED (one source claims training to Jan 2026); verify at docs.anthropic.com before trusting lower-risk', NULL,
+   '2026-02-17', '2025-08-01', 'llm-training-dates.md: Aug 2025 — DISPUTED (one source claims training to Jan 2026); verify at docs.anthropic.com before trusting lower-risk', NULL,
    3.00, 15.00, TRUE, FALSE, NOW() AT TIME ZONE 'utc', '00000000-0000-0000-0000-000000000000'),
 
   ('b0000000-0000-0000-0000-000000000002', 'a0000000-0000-0000-0000-000000000002',
    'Claude Haiku 4.5', 'anthropic/claude-haiku-4.5', 1,
-   '2025-10-01', '2025-07-01', 'llm-training-dates.md: Jul 2025 (lower-risk full 2025 season; cheap floor)', NULL,
+   '2025-10-15', '2025-07-01', 'llm-training-dates.md: Jul 2025 (lower-risk full 2025 season; cheap floor)', NULL,
    1.00, 5.00, TRUE, FALSE, NOW() AT TIME ZONE 'utc', '00000000-0000-0000-0000-000000000000'),
 
   ('b0000000-0000-0000-0000-000000000003', 'a0000000-0000-0000-0000-000000000003',
    'GPT-5.2', 'openai/gpt-5.2', 1,
-   '2025-12-01', '2025-08-31', 'llm-training-dates.md: Aug 31 2025 — NCAA wk0/1 sits INSIDE training; per-game comparison handles the boundary', NULL,
+   '2025-12-10', '2025-08-31', 'llm-training-dates.md: Aug 31 2025 — NCAA wk0/1 sits INSIDE training; per-game comparison handles the boundary', NULL,
    1.75, 14.00, TRUE, FALSE, NOW() AT TIME ZONE 'utc', '00000000-0000-0000-0000-000000000000'),
 
   ('b0000000-0000-0000-0000-000000000004', 'a0000000-0000-0000-0000-000000000004',
    'Gemini 3.1 Pro', 'google/gemini-3.1-pro-preview', 1,
-   '2026-02-01', '2025-01-01', 'llm-training-dates.md: Jan 2025 (lower-risk full season + current capability); verify via model card', NULL,
+   '2026-02-19', '2025-01-01', 'llm-training-dates.md: Jan 2025 (lower-risk full season + current capability); verify via model card', NULL,
    2.00, 12.00, TRUE, FALSE, NOW() AT TIME ZONE 'utc', '00000000-0000-0000-0000-000000000000'),
 
   ('b0000000-0000-0000-0000-000000000005', 'a0000000-0000-0000-0000-000000000005',
    'Grok 4.3', 'x-ai/grok-4.3', 1,
-   NULL, '2025-12-01', 'llm-training-dates.md: Dec 2025 (higher-risk Sep-Nov); server-side Web/X search MUST stay disabled for backtests', NULL,
+   '2026-04-30', '2025-12-01', 'llm-training-dates.md: Dec 2025 (higher-risk Sep-Nov); server-side Web/X search MUST stay disabled for backtests', NULL,
    1.25, 2.50, TRUE, FALSE, NOW() AT TIME ZONE 'utc', '00000000-0000-0000-0000-000000000000'),
 
   ('b0000000-0000-0000-0000-000000000006', 'a0000000-0000-0000-0000-000000000001',

--- a/src/SportsData.Api/Application/Admin/AdminController.cs
+++ b/src/SportsData.Api/Application/Admin/AdminController.cs
@@ -206,7 +206,7 @@ namespace SportsData.Api.Application.Admin
         /// </summary>
         [HttpGet]
         [Route("model-lab/matrix")]
-        public async Task<IActionResult> GetModelLabMatrix(
+        public async Task<ActionResult<Queries.GetModelLabMatrix.ModelLabMatrixDto>> GetModelLabMatrix(
             [FromServices] Queries.GetModelLabMatrix.IGetModelLabMatrixQueryHandler handler,
             [FromQuery] Sport sport = Sport.FootballNcaa,
             [FromQuery] int seasonYear = 0,
@@ -222,9 +222,7 @@ namespace SportsData.Api.Application.Admin
                 },
                 cancellationToken);
 
-            return result.IsSuccess
-                ? Ok(result.Value)
-                : UnprocessableEntity(result);
+            return result.ToActionResult();
         }
 
         /// <summary>

--- a/src/SportsData.Api/Application/Admin/AdminController.cs
+++ b/src/SportsData.Api/Application/Admin/AdminController.cs
@@ -19,6 +19,8 @@ using SportsData.Api.Application.Admin.Queries.GetMatchupPreviewCaptures;
 using SportsData.Api.Application.Admin.SignalRDebug;
 using SportsData.Api.Application.Contests.Commands.GenerateGameRecap;
 using SportsData.Api.Application.Previews;
+using Microsoft.EntityFrameworkCore;
+using SportsData.Api.Infrastructure.Data;
 using SportsData.Api.Application.Scoring;
 using SportsData.Api.Application.UI.Contest.Commands.SubmitContestPredictions;
 using SportsData.Api.Application.UI.Contest.Dtos;
@@ -178,17 +180,109 @@ namespace SportsData.Api.Application.Admin
         public IActionResult RunContestPreviewExperiment(
             [FromRoute] Guid contestId,
             [FromQuery] Sport sport = Sport.FootballNcaa,
-            [FromQuery] Guid? promptId = null)
+            [FromQuery] Guid? promptId = null,
+            [FromQuery] Guid? modelId = null)
         {
+            // modelId (optional): run against that Model row instead of the
+            // production client — the Model Lab's single-cell fill-in.
             var cmd = new GenerateMatchupPreviewsCommand
             {
                 ContestId = contestId,
                 Sport = sport,
                 Mode = PreviewGenerationMode.Experiment,
-                PromptId = promptId
+                PromptId = promptId,
+                ModelId = modelId
             };
             _backgroundJobProvider.Enqueue<IGenerateMatchupPreviews>(p => p.Process(cmd));
             return Accepted(new { cmd.CorrelationId });
+        }
+
+        /// <summary>
+        /// Model Consensus Lab week matrix: every contest any pick'em league
+        /// carries for (sport, season, week) x every active lab-reachable
+        /// model, with each pair's latest experiment picks. Missing cells
+        /// are generated one at a time via the experiment endpoint's
+        /// modelId parameter. See docs/features/model-consensus-lab.md.
+        /// </summary>
+        [HttpGet]
+        [Route("model-lab/matrix")]
+        public async Task<IActionResult> GetModelLabMatrix(
+            [FromServices] Queries.GetModelLabMatrix.IGetModelLabMatrixQueryHandler handler,
+            [FromQuery] Sport sport = Sport.FootballNcaa,
+            [FromQuery] int seasonYear = 0,
+            [FromQuery] int week = 0,
+            CancellationToken cancellationToken = default)
+        {
+            var result = await handler.ExecuteAsync(
+                new Queries.GetModelLabMatrix.GetModelLabMatrixQuery
+                {
+                    Sport = sport,
+                    SeasonYear = seasonYear,
+                    Week = week
+                },
+                cancellationToken);
+
+            return result.IsSuccess
+                ? Ok(result.Value)
+                : UnprocessableEntity(result);
+        }
+
+        /// <summary>
+        /// Model Consensus Lab fan-out: run the SAME experiment (same prompt
+        /// assembly, same contest) against every active Model whose provider
+        /// the lab can reach — one capture row per model, never a
+        /// MatchupPreview. The audition in one call. Model/ModelProvider
+        /// rows are managed by the existing admin CRUD (models /
+        /// model-providers routes). See docs/features/model-consensus-lab.md.
+        /// </summary>
+        [HttpPost]
+        [Route("matchup/preview/{contestId}/experiment/panel")]
+        public async Task<IActionResult> RunContestPreviewPanel(
+            [FromRoute] Guid contestId,
+            [FromServices] AppDataContext dataContext,
+            [FromServices] IAiModelClientResolver modelClientResolver,
+            [FromQuery] Sport sport = Sport.FootballNcaa,
+            [FromQuery] Guid? promptId = null,
+            CancellationToken cancellationToken = default)
+        {
+            // Budget guard: experiment spend is approved, runaway loops are
+            // not. 25 models per fan-out is far above any realistic audition.
+            const int maxPanelSize = 25;
+
+            var candidates = await dataContext.Models
+                .AsNoTracking()
+                .Where(x => x.IsActive && x.ModelProvider!.IsActive)
+                .OrderBy(x => x.Name)
+                .Select(x => new { x.Id, x.Name, x.Gateway, x.ModelProvider!.Kind })
+                .ToListAsync(cancellationToken);
+
+            // The resolver is the single source of truth for which routes
+            // have a lab client (today: the OpenRouter gateway; direct
+            // first-party clients arrive with panel promotion).
+            var models = candidates
+                .Where(x => modelClientResolver.CanResolve(x.Gateway, x.Kind))
+                .Take(maxPanelSize)
+                .ToList();
+
+            if (models.Count == 0)
+                return UnprocessableEntity(new { error = "No active models under a lab-reachable provider." });
+
+            var correlationId = Guid.NewGuid();
+            foreach (var model in models)
+            {
+                var cmd = new GenerateMatchupPreviewsCommand
+                {
+                    ContestId = contestId,
+                    Sport = sport,
+                    Mode = PreviewGenerationMode.Experiment,
+                    PromptId = promptId,
+                    ModelId = model.Id,
+                    CorrelationId = correlationId
+                };
+                _backgroundJobProvider.Enqueue<IGenerateMatchupPreviews>(p => p.Process(cmd));
+            }
+
+            return Accepted(new { correlationId, modelCount = models.Count });
         }
 
         /// <summary>

--- a/src/SportsData.Api/Application/Admin/Models/CreateModelCommand.cs
+++ b/src/SportsData.Api/Application/Admin/Models/CreateModelCommand.cs
@@ -80,16 +80,28 @@ public class CreateModelCommandHandler : ICreateModelCommandHandler
             return new Failure<Guid>(default!, ResultStatus.Validation, validation.Errors);
         }
 
-        var providerExists = await _dataContext.ModelProviders
+        var provider = await _dataContext.ModelProviders
             .AsNoTracking()
-            .AnyAsync(p => p.Id == command.ModelProviderId, cancellationToken);
+            .Where(p => p.Id == command.ModelProviderId)
+            .Select(p => new { p.Kind })
+            .FirstOrDefaultAsync(cancellationToken);
 
-        if (!providerExists)
+        if (provider is null)
         {
             return new Failure<Guid>(
                 default!,
                 ResultStatus.Validation,
                 [new ValidationFailure(nameof(command.ModelProviderId), "Model provider not found — create it first (POST /admin/model-providers)")]);
+        }
+
+        // A GatewayOnly provider has no first-party client by definition —
+        // a direct-routed model under it would be unreachable forever.
+        if (provider.Kind == ModelProviderKind.GatewayOnly && command.Gateway == ModelGateway.None)
+        {
+            return new Failure<Guid>(
+                default!,
+                ResultStatus.Validation,
+                [new ValidationFailure(nameof(command.Gateway), "This provider is gateway-only (no first-party client) — the model must specify a gateway route.")]);
         }
 
         var name = command.Name.Trim();

--- a/src/SportsData.Api/Application/Admin/Models/CreateModelCommand.cs
+++ b/src/SportsData.Api/Application/Admin/Models/CreateModelCommand.cs
@@ -16,8 +16,11 @@ public class CreateModelCommand
     /// <summary>Display name (unique), e.g. "Claude Haiku 4.5".</summary>
     public required string Name { get; set; }
 
-    /// <summary>Exact API identifier, e.g. "claude-haiku-4-5".</summary>
+    /// <summary>Exact API identifier for the chosen route, e.g. "claude-haiku-4-5" direct, "anthropic/claude-sonnet-4.5" via OpenRouter.</summary>
     public required string ApiModelId { get; set; }
+
+    /// <summary>How the model is reached (None = first-party client). Identity, like ApiModelId — a different route is a different evaluand, so it is create-only.</summary>
+    public ModelGateway Gateway { get; set; } = ModelGateway.None;
 
     public DateTime? ReleaseDate { get; set; }
 
@@ -43,6 +46,7 @@ public class CreateModelCommandValidator : AbstractValidator<CreateModelCommand>
         RuleFor(x => x.ModelProviderId).NotEmpty();
         RuleFor(x => x.Name).NotEmpty().MaximumLength(100);
         RuleFor(x => x.ApiModelId).NotEmpty().MaximumLength(100);
+        RuleFor(x => x.Gateway).IsInEnum();
         RuleFor(x => x.CutoffEvidence).MaximumLength(512);
     }
 }
@@ -124,6 +128,7 @@ public class CreateModelCommandHandler : ICreateModelCommandHandler
             ModelProviderId = command.ModelProviderId,
             Name = name,
             ApiModelId = apiModelId,
+            Gateway = command.Gateway,
             ReleaseDate = command.ReleaseDate,
             KnowledgeCutoffUtc = command.KnowledgeCutoffUtc,
             CutoffEvidence = command.CutoffEvidence,

--- a/src/SportsData.Api/Application/Admin/Models/GetModelsQueryHandler.cs
+++ b/src/SportsData.Api/Application/Admin/Models/GetModelsQueryHandler.cs
@@ -16,6 +16,7 @@ public class ModelDto
     public ModelProviderKind ProviderKind { get; set; }
     public string Name { get; set; } = default!;
     public string ApiModelId { get; set; } = default!;
+    public ModelGateway Gateway { get; set; }
     public DateTime? ReleaseDate { get; set; }
     public DateTime? KnowledgeCutoffUtc { get; set; }
     public string? CutoffEvidence { get; set; }
@@ -61,6 +62,7 @@ public class GetModelsQueryHandler : IGetModelsQueryHandler
                 ProviderKind = m.ModelProvider.Kind,
                 Name = m.Name,
                 ApiModelId = m.ApiModelId,
+                Gateway = m.Gateway,
                 ReleaseDate = m.ReleaseDate,
                 KnowledgeCutoffUtc = m.KnowledgeCutoffUtc,
                 CutoffEvidence = m.CutoffEvidence,
@@ -99,6 +101,7 @@ public class GetModelByIdQueryHandler : IGetModelByIdQueryHandler
                 ProviderKind = m.ModelProvider.Kind,
                 Name = m.Name,
                 ApiModelId = m.ApiModelId,
+                Gateway = m.Gateway,
                 ReleaseDate = m.ReleaseDate,
                 KnowledgeCutoffUtc = m.KnowledgeCutoffUtc,
                 CutoffEvidence = m.CutoffEvidence,

--- a/src/SportsData.Api/Application/Admin/Queries/GetMatchupPreviewCaptures/GetMatchupPreviewCapturesQueryHandler.cs
+++ b/src/SportsData.Api/Application/Admin/Queries/GetMatchupPreviewCaptures/GetMatchupPreviewCapturesQueryHandler.cs
@@ -59,6 +59,12 @@ public class GetMatchupPreviewCapturesQueryHandler : IGetMatchupPreviewCapturesQ
                     Model = x.Model,
                     RawResponse = x.RawResponse,
                     ResponseValidationErrors = x.ResponseValidationErrors,
+                    ModelId = x.ModelId,
+                    PredictedStraightUpWinnerId = x.PredictedStraightUpWinnerId,
+                    PredictedSpreadWinnerId = x.PredictedSpreadWinnerId,
+                    PromptTokens = x.PromptTokens,
+                    CompletionTokens = x.CompletionTokens,
+                    LatencyMs = x.LatencyMs,
                     // The instruction text is stored per capture, so this is
                     // the EXACT model input — no blob round-trip, immune to
                     // in-place blob edits after the fact.

--- a/src/SportsData.Api/Application/Admin/Queries/GetMatchupPreviewCaptures/MatchupPreviewCaptureDto.cs
+++ b/src/SportsData.Api/Application/Admin/Queries/GetMatchupPreviewCaptures/MatchupPreviewCaptureDto.cs
@@ -42,5 +42,24 @@ public class MatchupPreviewCaptureDto
     /// <summary>Parse/validation problems recorded on experiment runs; null = clean.</summary>
     public string? ResponseValidationErrors { get; set; }
 
+    // Model Consensus Lab measurements (experiment runs; null elsewhere).
+    // See docs/features/model-consensus-lab.md.
+
+    /// <summary>The Model entity that supplied the evaluation (Model string is the provenance of record).</summary>
+    public Guid? ModelId { get; set; }
+
+    /// <summary>Parsed SU pick (FranchiseSeasonId); null when the response did not parse.</summary>
+    public Guid? PredictedStraightUpWinnerId { get; set; }
+
+    /// <summary>Parsed ATS pick (FranchiseSeasonId); null when absent or unparsed.</summary>
+    public Guid? PredictedSpreadWinnerId { get; set; }
+
+    /// <summary>Actual prompt tokens reported by the transport (EstTokens is the pre-call estimate).</summary>
+    public int? PromptTokens { get; set; }
+
+    public int? CompletionTokens { get; set; }
+
+    public long? LatencyMs { get; set; }
+
     public DateTime CreatedUtc { get; set; }
 }

--- a/src/SportsData.Api/Application/Admin/Queries/GetModelLabMatrix/GetModelLabMatrixQuery.cs
+++ b/src/SportsData.Api/Application/Admin/Queries/GetModelLabMatrix/GetModelLabMatrixQuery.cs
@@ -1,0 +1,28 @@
+using FluentValidation;
+
+using SportsData.Core.Common;
+
+namespace SportsData.Api.Application.Admin.Queries.GetModelLabMatrix;
+
+/// <summary>
+/// One week of the Model Consensus Lab matrix: every contest any pick'em
+/// league carries for (sport, season, week) x every active lab-reachable
+/// model. See docs/features/model-consensus-lab.md.
+/// </summary>
+public class GetModelLabMatrixQuery
+{
+    public Sport Sport { get; set; }
+
+    public int SeasonYear { get; set; }
+
+    public int Week { get; set; }
+}
+
+public class GetModelLabMatrixQueryValidator : AbstractValidator<GetModelLabMatrixQuery>
+{
+    public GetModelLabMatrixQueryValidator()
+    {
+        RuleFor(x => x.SeasonYear).InclusiveBetween(2000, 2100);
+        RuleFor(x => x.Week).InclusiveBetween(1, 30);
+    }
+}

--- a/src/SportsData.Api/Application/Admin/Queries/GetModelLabMatrix/GetModelLabMatrixQueryHandler.cs
+++ b/src/SportsData.Api/Application/Admin/Queries/GetModelLabMatrix/GetModelLabMatrixQueryHandler.cs
@@ -1,0 +1,163 @@
+using FluentValidation.Results;
+
+using Microsoft.EntityFrameworkCore;
+
+using SportsData.Api.Application.Previews;
+using SportsData.Api.Infrastructure.Data;
+using SportsData.Core.Common;
+using SportsData.Core.Infrastructure.Clients.Contest;
+
+namespace SportsData.Api.Application.Admin.Queries.GetModelLabMatrix;
+
+public interface IGetModelLabMatrixQueryHandler
+{
+    Task<Result<ModelLabMatrixDto>> ExecuteAsync(
+        GetModelLabMatrixQuery query,
+        CancellationToken cancellationToken);
+}
+
+public class GetModelLabMatrixQueryHandler : IGetModelLabMatrixQueryHandler
+{
+    private readonly AppDataContext _dataContext;
+    private readonly IContestClientFactory _contestClientFactory;
+    private readonly IAiModelClientResolver _modelClientResolver;
+    private readonly ILogger<GetModelLabMatrixQueryHandler> _logger;
+
+    public GetModelLabMatrixQueryHandler(
+        AppDataContext dataContext,
+        IContestClientFactory contestClientFactory,
+        IAiModelClientResolver modelClientResolver,
+        ILogger<GetModelLabMatrixQueryHandler> logger)
+    {
+        _dataContext = dataContext;
+        _contestClientFactory = contestClientFactory;
+        _modelClientResolver = modelClientResolver;
+        _logger = logger;
+    }
+
+    public async Task<Result<ModelLabMatrixDto>> ExecuteAsync(
+        GetModelLabMatrixQuery query,
+        CancellationToken cancellationToken)
+    {
+        var validation = await new GetModelLabMatrixQueryValidator()
+            .ValidateAsync(query, cancellationToken);
+
+        if (!validation.IsValid)
+        {
+            return new Failure<ModelLabMatrixDto>(default!, ResultStatus.Validation, validation.Errors);
+        }
+
+        // The contest universe is "every game any pick'em league carries"
+        // for the week — PickemGroupMatchup is the synced, API-local record
+        // of exactly that, distinct across leagues.
+        var contestIds = await _dataContext.PickemGroupMatchups
+            .AsNoTracking()
+            .Where(m => m.SeasonYear == query.SeasonYear
+                     && m.SeasonWeek == query.Week
+                     && _dataContext.PickemGroups
+                         .Any(g => g.Id == m.GroupId && g.Sport == query.Sport))
+            .Select(m => m.ContestId)
+            .Distinct()
+            .ToListAsync(cancellationToken);
+
+        var columns = await GetModelColumnsAsync(cancellationToken);
+
+        if (contestIds.Count == 0)
+        {
+            return new Success<ModelLabMatrixDto>(new ModelLabMatrixDto { Models = columns });
+        }
+
+        // Display identity (names + FranchiseSeasonIds for pick mapping)
+        // comes from Producer's existing batch matchup endpoint — the same
+        // source the picks page renders from.
+        var matchupsResult = await _contestClientFactory
+            .Resolve(query.Sport)
+            .GetMatchupsByContestIds(contestIds, MarkDirection.Roundel, cancellationToken);
+
+        if (!matchupsResult.IsSuccess || matchupsResult.Value is null)
+        {
+            _logger.LogError(
+                "Producer GetMatchupsByContestIds failed for model-lab matrix. Sport={Sport}, Year={Year}, Week={Week}, Contests={Count}",
+                query.Sport, query.SeasonYear, query.Week, contestIds.Count);
+            return new Failure<ModelLabMatrixDto>(
+                default!,
+                ResultStatus.Error,
+                [new ValidationFailure("matchups", "Failed to retrieve matchup data from Producer")]);
+        }
+
+        var modelIds = columns.Select(c => c.Id).ToHashSet();
+
+        var captures = await _dataContext.MatchupPreviewPrompts
+            .AsNoTracking()
+            .Where(x => x.Mode == PreviewGenerationMode.Experiment
+                     && x.ModelId != null
+                     && contestIds.Contains(x.ContestId))
+            .Select(x => new
+            {
+                x.ContestId,
+                x.ModelId,
+                x.PredictedStraightUpWinnerId,
+                x.PredictedSpreadWinnerId,
+                x.ResponseValidationErrors,
+                x.CreatedUtc
+            })
+            .ToListAsync(cancellationToken);
+
+        // Latest run wins per (contest, model) — reruns supersede, history
+        // stays on the capture rows for the Preview Lab drill-down.
+        var latestCells = captures
+            .Where(c => modelIds.Contains(c.ModelId!.Value))
+            .GroupBy(c => (c.ContestId, c.ModelId))
+            .Select(g => g.OrderByDescending(c => c.CreatedUtc).First())
+            .ToLookup(c => c.ContestId);
+
+        var contests = matchupsResult.Value
+            .OrderBy(m => m.StartDateUtc).ThenBy(m => m.Away)
+            .Select(m => new ModelLabMatrixDto.MatrixContestDto
+            {
+                ContestId = m.ContestId,
+                StartDateUtc = m.StartDateUtc,
+                Away = m.Away,
+                AwayShort = m.AwayShort,
+                AwayFranchiseSeasonId = m.AwayFranchiseSeasonId,
+                Home = m.Home,
+                HomeShort = m.HomeShort,
+                HomeFranchiseSeasonId = m.HomeFranchiseSeasonId,
+                Cells = latestCells[m.ContestId]
+                    .Select(c => new ModelLabMatrixDto.MatrixCellDto
+                    {
+                        ModelId = c.ModelId!.Value,
+                        PredictedStraightUpWinnerId = c.PredictedStraightUpWinnerId,
+                        PredictedSpreadWinnerId = c.PredictedSpreadWinnerId,
+                        Problems = c.ResponseValidationErrors,
+                        CreatedUtc = c.CreatedUtc
+                    })
+                    .ToList()
+            })
+            .ToList();
+
+        return new Success<ModelLabMatrixDto>(new ModelLabMatrixDto
+        {
+            Models = columns,
+            Contests = contests
+        });
+    }
+
+    private async Task<List<ModelLabMatrixDto.MatrixModelDto>> GetModelColumnsAsync(
+        CancellationToken cancellationToken)
+    {
+        var candidates = await _dataContext.Models
+            .AsNoTracking()
+            .Where(m => m.IsActive && m.ModelProvider!.IsActive)
+            .OrderBy(m => m.Name)
+            .Select(m => new { m.Id, m.Name, m.Gateway, m.ModelProvider!.Kind })
+            .ToListAsync(cancellationToken);
+
+        // The resolver is the single source of truth for lab reachability —
+        // same filter the panel fan-out applies.
+        return candidates
+            .Where(m => _modelClientResolver.CanResolve(m.Gateway, m.Kind))
+            .Select(m => new ModelLabMatrixDto.MatrixModelDto { Id = m.Id, Name = m.Name })
+            .ToList();
+    }
+}

--- a/src/SportsData.Api/Application/Admin/Queries/GetModelLabMatrix/ModelLabMatrixDto.cs
+++ b/src/SportsData.Api/Application/Admin/Queries/GetModelLabMatrix/ModelLabMatrixDto.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Generic;
+
+namespace SportsData.Api.Application.Admin.Queries.GetModelLabMatrix;
+
+/// <summary>
+/// The week matrix: rows = contests (each rendered as an SU line and an
+/// ATS line by the UI), columns = models. A missing cell means that
+/// (contest, model) pair has no experiment yet — the UI offers to
+/// generate it. Consensus is computed client-side from the cells.
+/// </summary>
+public class ModelLabMatrixDto
+{
+    public List<MatrixModelDto> Models { get; set; } = [];
+
+    public List<MatrixContestDto> Contests { get; set; } = [];
+
+    public class MatrixModelDto
+    {
+        public Guid Id { get; set; }
+
+        public string Name { get; set; } = default!;
+    }
+
+    public class MatrixContestDto
+    {
+        public Guid ContestId { get; set; }
+
+        public DateTime StartDateUtc { get; set; }
+
+        public string Away { get; set; } = default!;
+
+        public string AwayShort { get; set; } = default!;
+
+        public Guid AwayFranchiseSeasonId { get; set; }
+
+        public string Home { get; set; } = default!;
+
+        public string HomeShort { get; set; } = default!;
+
+        public Guid HomeFranchiseSeasonId { get; set; }
+
+        /// <summary>Latest experiment per model; a model absent here has no run yet.</summary>
+        public List<MatrixCellDto> Cells { get; set; } = [];
+    }
+
+    public class MatrixCellDto
+    {
+        public Guid ModelId { get; set; }
+
+        /// <summary>Parsed SU pick (FranchiseSeasonId); null = abstained/unparsed.</summary>
+        public Guid? PredictedStraightUpWinnerId { get; set; }
+
+        /// <summary>Parsed ATS pick (FranchiseSeasonId); null = abstained/unparsed.</summary>
+        public Guid? PredictedSpreadWinnerId { get; set; }
+
+        /// <summary>Validation problems recorded on the capture; null = clean.</summary>
+        public string? Problems { get; set; }
+
+        public DateTime CreatedUtc { get; set; }
+    }
+}

--- a/src/SportsData.Api/Application/Previews/AiModelClientResolver.cs
+++ b/src/SportsData.Api/Application/Previews/AiModelClientResolver.cs
@@ -1,0 +1,74 @@
+using Microsoft.Extensions.Logging;
+
+using SportsData.Api.Infrastructure.Data.Entities;
+using SportsData.Core.Infrastructure.Clients.AI;
+
+using System;
+using System.Net.Http;
+
+namespace SportsData.Api.Application.Previews;
+
+/// <summary>
+/// Resolves a <see cref="Model"/> row (with its <see cref="ModelProvider"/>
+/// loaded) to a callable evaluation client: the row's
+/// <see cref="Model.Gateway"/> picks the route, and for direct routes the
+/// provider's <see cref="ModelProvider.Kind"/> picks the first-party
+/// implementation. See docs/features/model-consensus-lab.md.
+/// </summary>
+public interface IAiModelClientResolver
+{
+    /// <summary>True when <see cref="Resolve"/> has a client for this (gateway, kind) pair.</summary>
+    bool CanResolve(ModelGateway gateway, ModelProviderKind kind);
+
+    IProvideModelEvaluation Resolve(Model model);
+}
+
+/// <inheritdoc />
+public sealed class AiModelClientResolver : IAiModelClientResolver
+{
+    /// <summary>Named HttpClient registered in Program.cs (timeout etc.).</summary>
+    public const string OpenRouterHttpClientName = "openrouter";
+
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly OpenRouterClientConfig _openRouterConfig;
+    private readonly ILoggerFactory _loggerFactory;
+
+    public AiModelClientResolver(
+        IHttpClientFactory httpClientFactory,
+        OpenRouterClientConfig openRouterConfig,
+        ILoggerFactory loggerFactory)
+    {
+        _httpClientFactory = httpClientFactory;
+        _openRouterConfig = openRouterConfig;
+        _loggerFactory = loggerFactory;
+    }
+
+    // Direct (Gateway=None) evaluation clients arrive with panel promotion
+    // (phase 3 of the design doc) — a model earns its first-party client
+    // through the OpenRouter audition. Until then only gateway-routed rows
+    // are reachable, whichever provider made them.
+    public bool CanResolve(ModelGateway gateway, ModelProviderKind kind) =>
+        gateway == ModelGateway.OpenRouter;
+
+    public IProvideModelEvaluation Resolve(Model model)
+    {
+        if (model.ModelProvider is null)
+        {
+            throw new InvalidOperationException(
+                $"Model {model.Id} was loaded without its ModelProvider — the resolver needs Kind. Include it in the query.");
+        }
+
+        return model.Gateway switch
+        {
+            ModelGateway.OpenRouter => new OpenRouterClient(
+                _httpClientFactory.CreateClient(OpenRouterHttpClientName),
+                _openRouterConfig,
+                model.ApiModelId,
+                _loggerFactory.CreateLogger<OpenRouterClient>()),
+
+            _ => throw new NotSupportedException(
+                $"No lab evaluation client for gateway {model.Gateway} / provider kind " +
+                $"{model.ModelProvider.Kind} (model {model.Name}). See docs/features/model-consensus-lab.md.")
+        };
+    }
+}

--- a/src/SportsData.Api/Application/Previews/GenerateMatchupPreviewsCommand.cs
+++ b/src/SportsData.Api/Application/Previews/GenerateMatchupPreviewsCommand.cs
@@ -22,6 +22,13 @@ public class GenerateMatchupPreviewsCommand
     public PreviewGenerationMode Mode { get; set; } = PreviewGenerationMode.Generate;
 
     /// <summary>
+    /// Model Consensus Lab: run this experiment against a specific Model
+    /// entity instead of the default production client. Experiment mode only.
+    /// See docs/features/model-consensus-lab.md.
+    /// </summary>
+    public Guid? ModelId { get; set; }
+
+    /// <summary>
     /// Explicit Prompt entity override for Preview Lab runs — honored in
     /// Capture/Experiment modes only; Generate always uses the resolved
     /// default so an experiment override can never leak into production

--- a/src/SportsData.Api/Application/Previews/MatchupPreviewProcessor.cs
+++ b/src/SportsData.Api/Application/Previews/MatchupPreviewProcessor.cs
@@ -417,7 +417,9 @@ namespace SportsData.Api.Application.Previews
             var wiredModelName = _aiCommunication.GetModelName();
             var defaultModel = await _dataContext.Models
                 .AsNoTracking()
-                .FirstOrDefaultAsync(m => m.IsDefault);
+                .Where(m => m.IsDefault)
+                .Select(m => new { m.Id, m.ApiModelId })
+                .FirstOrDefaultAsync();
             if (defaultModel is null)
             {
                 _logger.LogWarning(

--- a/src/SportsData.Api/Application/Previews/MatchupPreviewProcessor.cs
+++ b/src/SportsData.Api/Application/Previews/MatchupPreviewProcessor.cs
@@ -27,6 +27,7 @@ namespace SportsData.Api.Application.Previews
         private readonly IMatchupPreviewPromptProvider _promptProvider;
         private readonly IEventBus _eventBus;
         private readonly IDateTimeProvider _dateTimeProvider;
+        private readonly IAiModelClientResolver _modelClientResolver;
 
         public MatchupPreviewProcessor(
             AppDataContext dataContext,
@@ -36,7 +37,8 @@ namespace SportsData.Api.Application.Previews
             IProvideAiCommunication aiCommunication,
             IMatchupPreviewPromptProvider promptProvider,
             IEventBus eventBus,
-            IDateTimeProvider dateTimeProvider)
+            IDateTimeProvider dateTimeProvider,
+            IAiModelClientResolver modelClientResolver)
         {
             _dataContext = dataContext;
             _logger = logger;
@@ -45,7 +47,8 @@ namespace SportsData.Api.Application.Previews
             _aiCommunication = aiCommunication;
             _promptProvider = promptProvider;
             _eventBus = eventBus;
-            _dateTimeProvider = dateTimeProvider;
+            _dateTimeProvider = dateTimeProvider;            _modelClientResolver = modelClientResolver;
+
         }
 
         /// <summary>
@@ -79,6 +82,38 @@ namespace SportsData.Api.Application.Previews
                     "Preview generation not supported for {Sport} — no prompts exist; skipping. ContestId={ContestId}",
                     command.Sport, command.ContestId);
                 return;
+            }
+
+            // Model Consensus Lab: resolve the Model row FIRST — a missing
+            // or inactive model must cost nothing (no Producer round trip,
+            // no prompt assembly). Inactive means inactive, including for
+            // fan-out jobs enqueued moments before an admin flipped the row.
+            Model? labModel = null;
+            if (command.Mode == PreviewGenerationMode.Experiment && command.ModelId is not null)
+            {
+                labModel = await _dataContext.Models
+                    .AsNoTracking()
+                    .Include(x => x.ModelProvider)
+                    .FirstOrDefaultAsync(x => x.Id == command.ModelId.Value);
+
+                if (labModel is null || !labModel.IsActive || labModel.ModelProvider?.IsActive != true)
+                {
+                    _logger.LogWarning(
+                        "Experiment references missing or inactive model {ModelId}; skipping. ContestId={ContestId}",
+                        command.ModelId, command.ContestId);
+                    return;
+                }
+
+                // A route without a lab client (direct first-party clients
+                // arrive with panel promotion) is a skip, not a crash —
+                // throwing here would put Hangfire into a pointless retry loop.
+                if (!_modelClientResolver.CanResolve(labModel.Gateway, labModel.ModelProvider.Kind))
+                {
+                    _logger.LogWarning(
+                        "No lab evaluation client for gateway {Gateway} / provider kind {Kind} (model {ModelName}); skipping. ContestId={ContestId}",
+                        labModel.Gateway, labModel.ModelProvider.Kind, labModel.Name, command.ContestId);
+                    return;
+                }
             }
 
             var rejectedPreview = await _dataContext.MatchupPreviews
@@ -153,7 +188,37 @@ namespace SportsData.Api.Application.Previews
                 return;
             }
 
-            var aiResponse = await _aiCommunication.GetResponseAsync(assembled.FullPrompt, CancellationToken.None);
+            // Model Consensus Lab: an experiment naming a Model row runs
+            // against THAT model (resolved by provider Kind: OpenRouter
+            // audition, or a direct client once a panel seat is earned) and
+            // records the measurements the lab scores on. Everything else
+            // uses the default production client, unchanged.
+            Result<string> aiResponse;
+            AiEvaluationResult? evaluation = null;
+
+            if (labModel is not null)
+            {
+                var evalClient = _modelClientResolver.Resolve(labModel);
+                var evalResult = await evalClient.EvaluateAsync(assembled.FullPrompt, CancellationToken.None);
+
+                if (evalResult.IsSuccess)
+                {
+                    evaluation = evalResult.Value;
+                    aiResponse = new Success<string>(evaluation.Content);
+                }
+                else
+                {
+                    aiResponse = new Failure<string>(
+                        string.Empty,
+                        evalResult.Status,
+                        ((Failure<AiEvaluationResult>)evalResult).Errors);
+                }
+            }
+            else
+            {
+                aiResponse = await _aiCommunication.GetResponseAsync(assembled.FullPrompt, CancellationToken.None);
+            }
+
             var rawResponse = aiResponse.Value;
 
             if (command.Mode == PreviewGenerationMode.Experiment)
@@ -162,10 +227,25 @@ namespace SportsData.Api.Application.Previews
                 // on the capture row. NEVER writes a MatchupPreview (an
                 // experimental row would shadow a prior season's real preview
                 // on the picks page) and never publishes PreviewGenerated.
-                capture.Model = _aiCommunication.GetModelName();
+                capture.Model = labModel?.ApiModelId ?? _aiCommunication.GetModelName();
+                capture.ModelId = labModel?.Id;
                 capture.RawResponse = string.IsNullOrWhiteSpace(rawResponse) ? null : rawResponse;
+                capture.PromptTokens = evaluation?.PromptTokens;
+                capture.CompletionTokens = evaluation?.CompletionTokens;
+                capture.LatencyMs = evaluation?.LatencyMs;
 
                 var problems = new List<string>();
+
+                // Truncation is a CONFIG problem, not a model problem —
+                // name it so the matrix's error tooltip says what to fix
+                // instead of blaming the parse that inevitably follows.
+                var truncated = string.Equals(
+                    evaluation?.FinishReason, "length", StringComparison.OrdinalIgnoreCase);
+                if (truncated)
+                {
+                    problems.Add(
+                        $"TRUNCATED at the max-tokens ceiling (finish_reason=length, completion={evaluation?.CompletionTokens}) — raise OpenRouterClientConfig MaxTokens; reasoning models spend thinking tokens against the same cap");
+                }
 
                 if (!aiResponse.IsSuccess || string.IsNullOrWhiteSpace(rawResponse))
                 {
@@ -178,10 +258,21 @@ namespace SportsData.Api.Application.Previews
                     var experimentParsed = TryParseResponse(rawResponse);
                     if (experimentParsed is null)
                     {
-                        problems.Add("Response could not be parsed by either deserialization strategy");
+                        // A truncated response's parse failure is already
+                        // explained by the truncation problem above.
+                        if (!truncated)
+                        {
+                            problems.Add("Response could not be parsed by either deserialization strategy");
+                        }
                     }
                     else
                     {
+                        // Persist the parsed picks even when validation
+                        // flags problems — the matrix scores the PICK; the
+                        // problems column records the caveat alongside it.
+                        capture.PredictedStraightUpWinnerId = experimentParsed.PredictedStraightUpWinner;
+                        capture.PredictedSpreadWinnerId = experimentParsed.PredictedSpreadWinner;
+
                         var experimentValidation = MatchupPreviewValidator.Validate(
                             contestId: command.ContestId,
                             homeScore: experimentParsed.HomeScore,
@@ -318,6 +409,32 @@ namespace SportsData.Api.Application.Previews
             // We have a valid response (parsed + valid)
             _logger.LogDebug("AI generated preview. {@Parsed}", parsed);
 
+            // Registry provenance: the IsDefault Model row IS the production
+            // model selection. Stamp its id only when it agrees with the
+            // client actually wired — a mismatch means the flag and the DI
+            // config have drifted, and a null stamp beats a false one.
+            Guid? productionModelId = null;
+            var wiredModelName = _aiCommunication.GetModelName();
+            var defaultModel = await _dataContext.Models
+                .AsNoTracking()
+                .FirstOrDefaultAsync(m => m.IsDefault);
+            if (defaultModel is null)
+            {
+                _logger.LogWarning(
+                    "No IsDefault Model row in the registry — preview {ContestId} gets string-only model provenance ({Model})",
+                    command.ContestId, wiredModelName);
+            }
+            else if (!string.Equals(defaultModel.ApiModelId, wiredModelName, StringComparison.Ordinal))
+            {
+                _logger.LogWarning(
+                    "IsDefault Model row ({DefaultApiModelId}) does not match the wired production client ({Model}) — stamping no ModelId on preview {ContestId}",
+                    defaultModel.ApiModelId, wiredModelName, command.ContestId);
+            }
+            else
+            {
+                productionModelId = defaultModel.Id;
+            }
+
             var preview = new MatchupPreview
             {
                 Id = Guid.NewGuid(),
@@ -332,7 +449,8 @@ namespace SportsData.Api.Application.Previews
                     : OverUnderPrediction.Under,
                 AwayScore = parsed.AwayScore,
                 HomeScore = parsed.HomeScore,
-                Model = _aiCommunication.GetModelName(),
+                Model = wiredModelName,
+                ModelId = productionModelId,
                 ValidationErrors = null,
                 CreatedUtc = _dateTimeProvider.UtcNow(),
                 CreatedBy = command.CorrelationId,
@@ -345,6 +463,7 @@ namespace SportsData.Api.Application.Previews
 
             capture.MatchupPreviewId = preview.Id;
             capture.Model = preview.Model;
+            capture.ModelId = productionModelId;
             capture.RawResponse = rawResponse;
 
             await _eventBus.Publish(new PreviewGenerated(
@@ -544,8 +663,34 @@ namespace SportsData.Api.Application.Previews
             };
         }
 
+        /// <summary>
+        /// Strips a markdown code fence (```json ... ``` or ``` ... ```)
+        /// wrapping the payload. Many models fence JSON out of habit
+        /// (Claude Haiku did on the lab's first multi-model run) — the
+        /// answer inside is valid, and discarding it would be waste, not
+        /// rigor. Anything short of a leading fence is returned untouched.
+        /// </summary>
+        private static string StripCodeFence(string raw)
+        {
+            var trimmed = raw.Trim();
+            if (!trimmed.StartsWith("```", StringComparison.Ordinal))
+                return raw;
+
+            var firstLineBreak = trimmed.IndexOf('\n');
+            if (firstLineBreak < 0)
+                return raw;
+
+            var closingFence = trimmed.LastIndexOf("```", StringComparison.Ordinal);
+            if (closingFence <= firstLineBreak)
+                return raw;
+
+            return trimmed[(firstLineBreak + 1)..closingFence].Trim();
+        }
+
         private MatchupPreviewResponse? TryParseResponse(string rawResponse)
         {
+            rawResponse = StripCodeFence(rawResponse);
+
             try
             {
                 return JsonSerializer.Deserialize<MatchupPreviewResponse>(rawResponse, new JsonSerializerOptions

--- a/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Api/DependencyInjection/ServiceRegistration.cs
@@ -245,6 +245,8 @@ namespace SportsData.Api.DependencyInjection
                 SportsData.Api.Application.Admin.Queries.GetMatchupForContest.GetMatchupForContestQueryHandler>();
             services.AddScoped<SportsData.Api.Application.Admin.Queries.GetLeagueWeekContests.IGetLeagueWeekContestsQueryHandler,
                 SportsData.Api.Application.Admin.Queries.GetLeagueWeekContests.GetLeagueWeekContestsQueryHandler>();
+            services.AddScoped<SportsData.Api.Application.Admin.Queries.GetModelLabMatrix.IGetModelLabMatrixQueryHandler,
+                SportsData.Api.Application.Admin.Queries.GetModelLabMatrix.GetModelLabMatrixQueryHandler>();
 
             // Analytics Queries
             services.AddScoped<IGetFranchiseSeasonMetricsQueryHandler, GetFranchiseSeasonMetricsQueryHandler>();

--- a/src/SportsData.Api/Infrastructure/Data/Entities/MatchupPreview.cs
+++ b/src/SportsData.Api/Infrastructure/Data/Entities/MatchupPreview.cs
@@ -72,7 +72,9 @@ namespace SportsData.Api.Infrastructure.Data.Entities
                 builder.Property(x => x.Analysis).HasMaxLength(1024);
                 builder.Property(x => x.Prediction).HasMaxLength(768);
 
-                builder.Property(x => x.Model).HasMaxLength(50);
+                // 100 matches Model.ApiModelId — gateway-namespaced ids
+                // ("google/gemini-3.1-pro-preview-customtools") outgrow 50.
+                builder.Property(x => x.Model).HasMaxLength(100);
 
                 builder.Property(x => x.ValidationErrors).HasMaxLength(1024);
                 builder.Property(x => x.RejectionNote).HasMaxLength(512);

--- a/src/SportsData.Api/Infrastructure/Data/Entities/MatchupPreview.cs
+++ b/src/SportsData.Api/Infrastructure/Data/Entities/MatchupPreview.cs
@@ -29,6 +29,16 @@ namespace SportsData.Api.Infrastructure.Data.Entities
 
         public string? Model { get; set; }
 
+        /// <summary>
+        /// The registry Model row that generated this preview — stamped
+        /// from the IsDefault row ONLY when its ApiModelId matches the
+        /// wired client's model (a mismatch means the flag and DI config
+        /// drifted; we stamp nothing rather than lie). No FK — the Model
+        /// string above stays the provenance of record (same pattern as
+        /// MatchupPreviewPrompt.ModelId).
+        /// </summary>
+        public Guid? ModelId { get; set; }
+
         public string? ValidationErrors { get; set; }
 
         /// <summary>

--- a/src/SportsData.Api/Infrastructure/Data/Entities/MatchupPreviewPrompt.cs
+++ b/src/SportsData.Api/Infrastructure/Data/Entities/MatchupPreviewPrompt.cs
@@ -74,6 +74,28 @@ namespace SportsData.Api.Infrastructure.Data.Entities
         /// <summary>Parse/validation problems recorded on experiment runs; null = clean.</summary>
         public string? ResponseValidationErrors { get; set; }
 
+        // ── Model Consensus Lab measurements (experiment runs; see
+        //    docs/features/model-consensus-lab.md). The entity's own charter
+        //    ("the backtest corpus: payload x model x prompt vs actual
+        //    outcome") is what the lab scores — these columns make the picks
+        //    queryable instead of buried in RawResponse.
+
+        /// <summary>The Model entity that supplied this evaluation. No FK — the Model string stays the provenance of record (same pattern as PromptId/PromptVersion).</summary>
+        public Guid? ModelId { get; set; }
+
+        /// <summary>Parsed SU pick (FranchiseSeasonId); null when the response did not parse.</summary>
+        public Guid? PredictedStraightUpWinnerId { get; set; }
+
+        /// <summary>Parsed ATS pick (FranchiseSeasonId); null when absent or unparsed.</summary>
+        public Guid? PredictedSpreadWinnerId { get; set; }
+
+        /// <summary>Actual prompt tokens reported by the transport (EstTokens is the pre-call estimate).</summary>
+        public int? PromptTokens { get; set; }
+
+        public int? CompletionTokens { get; set; }
+
+        public long? LatencyMs { get; set; }
+
         public class EntityConfiguration : IEntityTypeConfiguration<MatchupPreviewPrompt>
         {
             public void Configure(EntityTypeBuilder<MatchupPreviewPrompt> builder)

--- a/src/SportsData.Api/Infrastructure/Data/Entities/MatchupPreviewPrompt.cs
+++ b/src/SportsData.Api/Infrastructure/Data/Entities/MatchupPreviewPrompt.cs
@@ -126,7 +126,9 @@ namespace SportsData.Api.Infrastructure.Data.Entities
                     .HasConversion<int>()
                     .IsRequired();
 
-                builder.Property(x => x.Model).HasMaxLength(50);
+                // 100 matches Model.ApiModelId — gateway-namespaced ids
+                // ("google/gemini-3.1-pro-preview-customtools") outgrow 50.
+                builder.Property(x => x.Model).HasMaxLength(100);
 
                 builder.Property(x => x.ResponseValidationErrors).HasMaxLength(1024);
             }

--- a/src/SportsData.Api/Infrastructure/Data/Entities/Model.cs
+++ b/src/SportsData.Api/Infrastructure/Data/Entities/Model.cs
@@ -26,8 +26,27 @@ namespace SportsData.Api.Infrastructure.Data.Entities
         /// <summary>Display name (unique), e.g. "Claude Haiku 4.5".</summary>
         public required string Name { get; set; }
 
-        /// <summary>Exact API identifier sent on the wire, e.g. "claude-haiku-4-5".</summary>
+        /// <summary>
+        /// Exact API identifier sent on the wire FOR THIS ROUTE: the
+        /// provider's native id when <see cref="Gateway"/> is None (e.g.
+        /// "claude-haiku-4-5"), the gateway's namespaced id when routed
+        /// (e.g. OpenRouter's "anthropic/claude-sonnet-4.5"). Exact ids
+        /// only — provider aliases silently swap weights mid-season.
+        /// </summary>
         public required string ApiModelId { get; set; }
+
+        /// <summary>
+        /// How this model is reached. None = first-party client (the
+        /// provider's <see cref="ModelProvider.Kind"/> picks the
+        /// implementation); OpenRouter = via the aggregator gateway
+        /// (admitted 2026-09-03 for the Model Consensus Lab's audition
+        /// breadth). The same weights reached two ways are DIFFERENT
+        /// evaluands (routing/sampling can differ) — model them as two
+        /// rows under the SAME provider; their ApiModelIds differ by
+        /// construction (gateway ids are namespaced), so the
+        /// (ModelProviderId, ApiModelId) unique index keeps them apart.
+        /// </summary>
+        public ModelGateway Gateway { get; set; } = ModelGateway.None;
 
         public DateTime? ReleaseDate { get; set; }
 
@@ -77,6 +96,10 @@ namespace SportsData.Api.Infrastructure.Data.Entities
                 builder.Property(x => x.ApiModelId).HasMaxLength(100).IsRequired();
                 builder.HasIndex(x => new { x.ModelProviderId, x.ApiModelId }).IsUnique();
 
+                builder.Property(x => x.Gateway)
+                    .HasConversion<int>()
+                    .IsRequired();
+
                 builder.Property(x => x.CutoffEvidence).HasMaxLength(512);
 
                 builder.Property(x => x.InputCostPerMTok).HasPrecision(10, 4);
@@ -95,5 +118,18 @@ namespace SportsData.Api.Infrastructure.Data.Entities
                     .HasDatabaseName("IX_Model_SingleDefault");
             }
         }
+    }
+
+    /// <summary>
+    /// How a model is reached — a routing attribute, NOT a provider:
+    /// OpenRouter is a gateway we communicate through; the provider (who
+    /// made the model) stays on <see cref="Model.ModelProviderId"/>.
+    /// </summary>
+    public enum ModelGateway
+    {
+        /// <summary>Direct first-party client, resolved by the provider's Kind.</summary>
+        None = 0,
+
+        OpenRouter = 1
     }
 }

--- a/src/SportsData.Api/Infrastructure/Data/Entities/ModelProvider.cs
+++ b/src/SportsData.Api/Infrastructure/Data/Entities/ModelProvider.cs
@@ -6,13 +6,18 @@ using SportsData.Core.Infrastructure.Data.Entities;
 namespace SportsData.Api.Infrastructure.Data.Entities
 {
     /// <summary>
-    /// An LLM provider fleet (DeepSeek, Anthropic, OpenAI, Google —
-    /// first-party clients only, per the 2026-08-08 decision; OpenRouter
-    /// and Ollama Cloud evaluated and passed, see
-    /// docs/metrics-modeling/matchup-preview-data-inputs.md §6).
-    /// A provider row pairs with a code-side IProvideAiCommunication
-    /// implementation resolved via <see cref="Kind"/> — adding a provider
-    /// means a new client anyway, so the enum being code-bound is honest.
+    /// An LLM provider fleet (DeepSeek, Anthropic, OpenAI, Google, and the
+    /// long tail as it earns its way in). A provider is who MAKES the
+    /// model; HOW a model is reached is <see cref="Model.Gateway"/> — an
+    /// aggregator like OpenRouter is a gateway, not a provider, so a
+    /// routed Claude row still belongs to Anthropic and its cutoff/cost
+    /// metadata stays truthful. (The 2026-08-08 first-party-only decision,
+    /// docs/metrics-modeling/matchup-preview-data-inputs.md §6, was
+    /// amended 2026-09-03 to admit OpenRouter for the Model Consensus
+    /// Lab's many-model audition; see docs/features/model-consensus-lab.md.)
+    /// A provider row pairs with a code-side first-party client resolved
+    /// via <see cref="Kind"/> — adding a provider means a new client anyway,
+    /// so the enum being code-bound is honest.
     /// Credentials live in AppConfig, never here.
     /// </summary>
     public class ModelProvider : CanonicalEntityBase<Guid>
@@ -52,6 +57,15 @@ namespace SportsData.Api.Infrastructure.Data.Entities
         DeepSeek = 0,
         Anthropic = 1,
         OpenAi = 2,
-        Google = 3
+        Google = 3,
+
+        /// <summary>
+        /// A provider with NO first-party client (the long tail: xAI,
+        /// Alibaba, Moonshot, ...): its models are reachable only through
+        /// a gateway row (Model.Gateway != None). Avoids enum churn per
+        /// long-tail maker — if one ever earns a first-party client, it
+        /// gets a real Kind value then.
+        /// </summary>
+        GatewayOnly = 99
     }
 }

--- a/src/SportsData.Api/Migrations/20260903083011_ModelConsensusLab.Designer.cs
+++ b/src/SportsData.Api/Migrations/20260903083011_ModelConsensusLab.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SportsData.Api.Infrastructure.Data;
@@ -11,9 +12,11 @@ using SportsData.Api.Infrastructure.Data;
 namespace SportsData.Api.Migrations
 {
     [DbContext(typeof(AppDataContext))]
-    partial class AppDataContextModelSnapshot : ModelSnapshot
+    [Migration("20260903083011_ModelConsensusLab")]
+    partial class ModelConsensusLab
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -507,9 +510,6 @@ namespace SportsData.Api.Migrations
                     b.Property<string>("Model")
                         .HasMaxLength(50)
                         .HasColumnType("character varying(50)");
-
-                    b.Property<Guid?>("ModelId")
-                        .HasColumnType("uuid");
 
                     b.Property<Guid?>("ModifiedBy")
                         .HasColumnType("uuid");

--- a/src/SportsData.Api/Migrations/20260903083011_ModelConsensusLab.cs
+++ b/src/SportsData.Api/Migrations/20260903083011_ModelConsensusLab.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SportsData.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class ModelConsensusLab : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "Gateway",
+                table: "Model",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "CompletionTokens",
+                table: "MatchupPreviewPrompt",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.AddColumn<long>(
+                name: "LatencyMs",
+                table: "MatchupPreviewPrompt",
+                type: "bigint",
+                nullable: true);
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "ModelId",
+                table: "MatchupPreviewPrompt",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "PredictedSpreadWinnerId",
+                table: "MatchupPreviewPrompt",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "PredictedStraightUpWinnerId",
+                table: "MatchupPreviewPrompt",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "PromptTokens",
+                table: "MatchupPreviewPrompt",
+                type: "integer",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Gateway",
+                table: "Model");
+
+            migrationBuilder.DropColumn(
+                name: "CompletionTokens",
+                table: "MatchupPreviewPrompt");
+
+            migrationBuilder.DropColumn(
+                name: "LatencyMs",
+                table: "MatchupPreviewPrompt");
+
+            migrationBuilder.DropColumn(
+                name: "ModelId",
+                table: "MatchupPreviewPrompt");
+
+            migrationBuilder.DropColumn(
+                name: "PredictedSpreadWinnerId",
+                table: "MatchupPreviewPrompt");
+
+            migrationBuilder.DropColumn(
+                name: "PredictedStraightUpWinnerId",
+                table: "MatchupPreviewPrompt");
+
+            migrationBuilder.DropColumn(
+                name: "PromptTokens",
+                table: "MatchupPreviewPrompt");
+        }
+    }
+}

--- a/src/SportsData.Api/Migrations/20260903100215_MatchupPreviewModelProvenance.Designer.cs
+++ b/src/SportsData.Api/Migrations/20260903100215_MatchupPreviewModelProvenance.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SportsData.Api.Infrastructure.Data;
@@ -11,9 +12,11 @@ using SportsData.Api.Infrastructure.Data;
 namespace SportsData.Api.Migrations
 {
     [DbContext(typeof(AppDataContext))]
-    partial class AppDataContextModelSnapshot : ModelSnapshot
+    [Migration("20260903100215_MatchupPreviewModelProvenance")]
+    partial class MatchupPreviewModelProvenance
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/SportsData.Api/Migrations/20260903100215_MatchupPreviewModelProvenance.cs
+++ b/src/SportsData.Api/Migrations/20260903100215_MatchupPreviewModelProvenance.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SportsData.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class MatchupPreviewModelProvenance : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "ModelId",
+                table: "MatchupPreview",
+                type: "uuid",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ModelId",
+                table: "MatchupPreview");
+        }
+    }
+}

--- a/src/SportsData.Api/Migrations/20260903120448_ModelNameColumnWidth.Designer.cs
+++ b/src/SportsData.Api/Migrations/20260903120448_ModelNameColumnWidth.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SportsData.Api.Infrastructure.Data;
@@ -11,9 +12,11 @@ using SportsData.Api.Infrastructure.Data;
 namespace SportsData.Api.Migrations
 {
     [DbContext(typeof(AppDataContext))]
-    partial class AppDataContextModelSnapshot : ModelSnapshot
+    [Migration("20260903120448_ModelNameColumnWidth")]
+    partial class ModelNameColumnWidth
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/SportsData.Api/Migrations/20260903120448_ModelNameColumnWidth.cs
+++ b/src/SportsData.Api/Migrations/20260903120448_ModelNameColumnWidth.cs
@@ -1,0 +1,62 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SportsData.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class ModelNameColumnWidth : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Model",
+                table: "MatchupPreviewPrompt",
+                type: "character varying(100)",
+                maxLength: 100,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(50)",
+                oldMaxLength: 50,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Model",
+                table: "MatchupPreview",
+                type: "character varying(100)",
+                maxLength: 100,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(50)",
+                oldMaxLength: 50,
+                oldNullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Model",
+                table: "MatchupPreviewPrompt",
+                type: "character varying(50)",
+                maxLength: 50,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(100)",
+                oldMaxLength: 100,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Model",
+                table: "MatchupPreview",
+                type: "character varying(50)",
+                maxLength: 50,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(100)",
+                oldMaxLength: 100,
+                oldNullable: true);
+        }
+    }
+}

--- a/src/SportsData.Api/Program.cs
+++ b/src/SportsData.Api/Program.cs
@@ -1,4 +1,4 @@
-using FirebaseAdmin;
+﻿using FirebaseAdmin;
 
 using Google.Apis.Auth.OAuth2;
 
@@ -236,6 +236,22 @@ namespace SportsData.Api
             });
 
             services.AddScoped<IProvideAiCommunication>(sp => sp.GetRequiredService<DeepSeekClient>());
+
+            // Model Consensus Lab (docs/features/model-consensus-lab.md):
+            // OpenRouter is the audition transport — one OpenAI-compatible
+            // endpoint, per-catalog-row models. The resolver constructs one
+            // client per model; the named HttpClient supplies the timeout.
+            var openRouterConfig = new OpenRouterClientConfig
+            {
+                ApiKey = config["CommonConfig:OpenRouterClientConfig:ApiKey"]!,
+                BaseUrl = config["CommonConfig:OpenRouterClientConfig:BaseUrl"]!
+            };
+            services.AddSingleton(openRouterConfig);
+            services.AddHttpClient(Application.Previews.AiModelClientResolver.OpenRouterHttpClientName, client =>
+            {
+                client.Timeout = TimeSpan.FromMinutes(5);
+            });
+            services.AddScoped<Application.Previews.IAiModelClientResolver, Application.Previews.AiModelClientResolver>();
 
             // MetricBot (internal Python service; deetsMeter predictions).
             // Hangfire owns the weekly schedule + manual triggers; this

--- a/src/SportsData.Core/Infrastructure/Clients/AI/IProvideModelEvaluation.cs
+++ b/src/SportsData.Core/Infrastructure/Clients/AI/IProvideModelEvaluation.cs
@@ -1,0 +1,37 @@
+using SportsData.Core.Common;
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SportsData.Core.Infrastructure.Clients.AI;
+
+/// <summary>
+/// Evaluation-grade AI call: like <see cref="IProvideAiCommunication"/> but
+/// returns the measurement the Model Consensus Lab scores on — token usage
+/// and latency — instead of only logging it. Implemented by clients that
+/// participate in model evaluation (OpenRouter for the audition; direct
+/// provider clients as panel seats are earned).
+/// See docs/features/model-consensus-lab.md.
+/// </summary>
+public interface IProvideModelEvaluation
+{
+    Task<Result<AiEvaluationResult>> EvaluateAsync(
+        string prompt,
+        CancellationToken ct = default);
+
+    string GetModelName();
+}
+
+/// <summary>One model call's outcome, with the measurements the lab persists.</summary>
+/// <param name="FinishReason">
+/// Why generation stopped, as the transport reported it ("stop" = natural
+/// end; "length" = TRUNCATED at the max-tokens ceiling — the content is
+/// partial and any parse failure is a config problem, not a model problem).
+/// Null when the transport did not say.
+/// </param>
+public sealed record AiEvaluationResult(
+    string Content,
+    int? PromptTokens,
+    int? CompletionTokens,
+    long LatencyMs,
+    string? FinishReason = null);

--- a/src/SportsData.Core/Infrastructure/Clients/AI/OpenRouterClient.cs
+++ b/src/SportsData.Core/Infrastructure/Clients/AI/OpenRouterClient.cs
@@ -141,7 +141,13 @@ public class OpenRouterClient : IProvideAiCommunication, IProvideModelEvaluation
                 stopwatch.ElapsedMilliseconds,
                 finishReason));
         }
-        catch (Exception ex) when (ex is HttpRequestException or JsonException or TaskCanceledException)
+        // Caller-requested cancellation propagates (it is not a model
+        // failure); an HttpClient TIMEOUT also surfaces as
+        // TaskCanceledException but with an untripped token — that one IS
+        // an evaluation failure and stays caught.
+        catch (Exception ex) when (
+            ex is HttpRequestException or JsonException
+            || (ex is TaskCanceledException && !ct.IsCancellationRequested))
         {
             stopwatch.Stop();
             _logger.LogError(ex, "OpenRouter call failed for model {Model}", _model);

--- a/src/SportsData.Core/Infrastructure/Clients/AI/OpenRouterClient.cs
+++ b/src/SportsData.Core/Infrastructure/Clients/AI/OpenRouterClient.cs
@@ -1,0 +1,270 @@
+using FluentValidation.Results;
+
+using Microsoft.Extensions.Logging;
+
+using SportsData.Core.Common;
+
+using System;
+using System.Diagnostics;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SportsData.Core.Infrastructure.Clients.AI;
+
+/// <summary>
+/// OpenRouter client — one OpenAI-compatible endpoint that routes to every
+/// provider's models. This is the AUDITION transport for the Model Consensus
+/// Lab: same prompt, many models, one account. Production panel seats use
+/// direct provider clients instead (no shared single point of failure).
+/// See docs/features/model-consensus-lab.md.
+/// </summary>
+/// <remarks>
+/// Unlike <see cref="DeepSeekClient"/>, the MODEL is per-instance (ctor), not
+/// config: the lab's client factory constructs one instance per enabled
+/// model-catalog row. No global throttle here either — the fan-out job owns
+/// concurrency, and serializing all models behind one semaphore would defeat
+/// the point of a parallel audition.
+/// </remarks>
+public class OpenRouterClient : IProvideAiCommunication, IProvideModelEvaluation
+{
+    private readonly HttpClient _httpClient;
+    private readonly OpenRouterClientConfig _config;
+    private readonly string _model;
+    private readonly ILogger _logger;
+
+    public OpenRouterClient(
+        HttpClient httpClient,
+        OpenRouterClientConfig config,
+        string model,
+        ILogger logger)
+    {
+        _httpClient = httpClient;
+        _config = config;
+        _model = model;
+        _logger = logger;
+
+        _httpClient.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue("Bearer", _config.ApiKey);
+        _httpClient.DefaultRequestHeaders.Accept.Add(
+            new MediaTypeWithQualityHeaderValue("application/json"));
+        // OpenRouter attribution headers (their recommended practice; also
+        // how requests show up in their dashboard).
+        _httpClient.DefaultRequestHeaders.TryAddWithoutValidation("HTTP-Referer", "https://www.sportdeets.com");
+        _httpClient.DefaultRequestHeaders.TryAddWithoutValidation("X-Title", "sportDeets Model Lab");
+    }
+
+    public async Task<Result<AiEvaluationResult>> EvaluateAsync(
+        string prompt,
+        CancellationToken ct = default)
+    {
+        var request = new ChatRequest
+        {
+            Model = _model,
+            Messages = [new ChatMessage { Role = "user", Content = prompt }],
+            // Deterministic-as-possible for pick evaluation: the lab compares
+            // MODELS, and sampling noise inside one model muddies that signal.
+            Temperature = _config.Temperature,
+            MaxTokens = _config.MaxTokens,
+            Stream = false
+        };
+
+        var stopwatch = Stopwatch.StartNew();
+
+        try
+        {
+            using var response = await _httpClient.PostAsJsonAsync(
+                _config.BaseUrl,
+                request,
+                new JsonSerializerOptions { DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull },
+                ct);
+
+            stopwatch.Stop();
+
+            if (!response.IsSuccessStatusCode)
+            {
+                var errorContent = await response.Content.ReadAsStringAsync(ct);
+                _logger.LogError(
+                    "OpenRouter returned {StatusCode} for model {Model}: {Error}",
+                    response.StatusCode, _model, errorContent);
+                return new Failure<AiEvaluationResult>(
+                    default!,
+                    ResultStatus.Error,
+                    [new ValidationFailure("AI", $"OpenRouter {response.StatusCode} for {_model}")]);
+            }
+
+            var chatResponse = await response.Content.ReadFromJsonAsync<ChatResponse>(
+                new JsonSerializerOptions { PropertyNameCaseInsensitive = true }, ct);
+
+            var content = chatResponse?.Choices is { Length: > 0 }
+                ? chatResponse.Choices[0].Message?.Content?.Trim()
+                : null;
+
+            if (string.IsNullOrWhiteSpace(content))
+            {
+                _logger.LogError("OpenRouter returned empty content for model {Model}", _model);
+                return new Failure<AiEvaluationResult>(
+                    default!,
+                    ResultStatus.Error,
+                    [new ValidationFailure("AI", $"Empty content from {_model}")]);
+            }
+
+            var finishReason = chatResponse!.Choices![0].FinishReason;
+
+            _logger.LogInformation(
+                "OpenRouter response. Model={Model}, PromptTokens={PromptTokens}, CompletionTokens={CompletionTokens}, LatencyMs={LatencyMs}, FinishReason={FinishReason}",
+                _model,
+                chatResponse.Usage?.PromptTokens,
+                chatResponse.Usage?.CompletionTokens,
+                stopwatch.ElapsedMilliseconds,
+                finishReason);
+
+            if (string.Equals(finishReason, "length", StringComparison.OrdinalIgnoreCase))
+            {
+                // Reasoning models burn thinking tokens against the same
+                // ceiling (Gemini 3.1 spent 4092 of 4096 reasoning and never
+                // finished the answer) — the caller decides what to do, but
+                // this is a config problem, not a model problem.
+                _logger.LogWarning(
+                    "OpenRouter response TRUNCATED at MaxTokens={MaxTokens} for model {Model} — content is partial",
+                    _config.MaxTokens, _model);
+            }
+
+            return new Success<AiEvaluationResult>(new AiEvaluationResult(
+                content,
+                chatResponse.Usage?.PromptTokens,
+                chatResponse.Usage?.CompletionTokens,
+                stopwatch.ElapsedMilliseconds,
+                finishReason));
+        }
+        catch (Exception ex) when (ex is HttpRequestException or JsonException or TaskCanceledException)
+        {
+            stopwatch.Stop();
+            _logger.LogError(ex, "OpenRouter call failed for model {Model}", _model);
+            return new Failure<AiEvaluationResult>(
+                default!,
+                ResultStatus.Error,
+                [new ValidationFailure("AI", $"{ex.GetType().Name} calling {_model}")]);
+        }
+    }
+
+    public async Task<Result<string>> GetResponseAsync(string prompt, CancellationToken ct = default)
+    {
+        var result = await EvaluateAsync(prompt, ct);
+        return result.IsSuccess
+            ? new Success<string>(result.Value.Content)
+            : new Failure<string>(string.Empty, result.Status, ((Failure<AiEvaluationResult>)result).Errors);
+    }
+
+    public async Task<T?> GetTypedResponseAsync<T>(string prompt, CancellationToken ct = default)
+    {
+        var response = await GetResponseAsync(prompt, ct);
+
+        if (!response.IsSuccess || string.IsNullOrWhiteSpace(response.Value))
+            return default;
+
+        try
+        {
+            return JsonSerializer.Deserialize<T>(
+                response.Value,
+                new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        }
+        catch (JsonException ex)
+        {
+            _logger.LogError(ex,
+                "Failed to deserialize OpenRouter response into {Type}. Model: {Model}, Raw: {Response}",
+                typeof(T).Name, _model, response.Value);
+            return default;
+        }
+    }
+
+    public string GetModelName() => _model;
+
+    #region OpenRouter API models (OpenAI-compatible)
+
+    private class ChatRequest
+    {
+        [JsonPropertyName("model")]
+        public required string Model { get; set; }
+
+        [JsonPropertyName("messages")]
+        public required ChatMessage[] Messages { get; set; }
+
+        [JsonPropertyName("temperature")]
+        public double Temperature { get; set; }
+
+        [JsonPropertyName("max_tokens")]
+        public int MaxTokens { get; set; }
+
+        [JsonPropertyName("stream")]
+        public bool Stream { get; set; }
+    }
+
+    private class ChatMessage
+    {
+        [JsonPropertyName("role")]
+        public required string Role { get; set; }
+
+        [JsonPropertyName("content")]
+        public required string Content { get; set; }
+    }
+
+    private class ChatResponse
+    {
+        [JsonPropertyName("choices")]
+        public ChatChoice[]? Choices { get; set; }
+
+        [JsonPropertyName("usage")]
+        public ChatUsage? Usage { get; set; }
+    }
+
+    private class ChatChoice
+    {
+        [JsonPropertyName("message")]
+        public ChatMessage? Message { get; set; }
+
+        [JsonPropertyName("finish_reason")]
+        public string? FinishReason { get; set; }
+    }
+
+    private class ChatUsage
+    {
+        [JsonPropertyName("prompt_tokens")]
+        public int? PromptTokens { get; set; }
+
+        [JsonPropertyName("completion_tokens")]
+        public int? CompletionTokens { get; set; }
+    }
+
+    #endregion
+}
+
+/// <summary>
+/// Config for the OpenRouter transport. MODEL deliberately absent — it is
+/// per-catalog-row, supplied to each client instance by the lab's factory.
+/// AppConfig keys: CommonConfig:OpenRouterClientConfig:{ApiKey,BaseUrl}.
+/// </summary>
+public class OpenRouterClientConfig
+{
+    /// <summary>https://openrouter.ai/api/v1/chat/completions</summary>
+    public required string BaseUrl { get; set; }
+
+    public required string ApiKey { get; set; }
+
+    /// <summary>Low temperature: the lab compares models, and sampling noise inside one model muddies the signal.</summary>
+    public double Temperature { get; set; } = 0.1;
+
+    /// <summary>
+    /// Reasoning models spend their thinking tokens against this same
+    /// ceiling (Gemini 3.1 Pro burned 4092 of a 4096 cap reasoning and
+    /// truncated mid-answer on every run) — so the ceiling is sized for
+    /// thinking + answer, not answer alone. Worst-case cost at 16k on the
+    /// priciest audition model is ~$0.25/run; a truncated run costs nearly
+    /// as much and returns nothing.
+    /// </summary>
+    public int MaxTokens { get; set; } = 16384;
+}

--- a/src/UI/sd-ui/src/MainApp.jsx
+++ b/src/UI/sd-ui/src/MainApp.jsx
@@ -38,6 +38,7 @@ import AdminBaseballPage from "./components/admin/AdminBaseballPage";
 import AdminPreviewLabPage from "./components/admin/AdminPreviewLabPage";
 import AdminPromptsPage from "./components/admin/AdminPromptsPage";
 import AdminModelsPage from "./components/admin/AdminModelsPage";
+import AdminModelLabPage from "./components/admin/AdminModelLabPage";
 import AdminSmackLabPage from "./components/admin/AdminSmackLabPage";
 import AdminRoute from "./routes/AdminRoute";
 import SeasonOverview from "./components/season/SeasonOverview";
@@ -315,6 +316,14 @@ function MainApp() {
               element={
                 <AdminRoute>
                   <AdminModelsPage />
+                </AdminRoute>
+              }
+            />
+            <Route
+              path="/admin/model-lab"
+              element={
+                <AdminRoute>
+                  <AdminModelLabPage />
                 </AdminRoute>
               }
             />

--- a/src/UI/sd-ui/src/api/adminApi.js
+++ b/src/UI/sd-ui/src/api/adminApi.js
@@ -33,14 +33,35 @@ const AdminApi = {
       null,
       { params: { ...(sport ? { sport } : {}), ...(promptId ? { promptId } : {}) } }
     ),
-  runPreviewExperiment: (contestId, sport, promptId) =>
+  // modelId (optional): run against that Model row instead of the
+  // production client — the Model Lab's single-cell fill-in.
+  runPreviewExperiment: (contestId, sport, promptId, modelId) =>
     apiClient.post(
       `/admin/matchup/preview/${encodeURIComponent(contestId)}/experiment`,
       null,
-      { params: { ...(sport ? { sport } : {}), ...(promptId ? { promptId } : {}) } }
+      {
+        params: {
+          ...(sport ? { sport } : {}),
+          ...(promptId ? { promptId } : {}),
+          ...(modelId ? { modelId } : {}),
+        },
+      }
     ),
   getPreviewCaptures: (contestId) =>
     apiClient.get(`/admin/matchup/preview/${encodeURIComponent(contestId)}/captures`),
+  // Model Consensus Lab fan-out: one Experiment per active, lab-reachable
+  // model (same prompt, same contest) — a capture row per model, never a
+  // MatchupPreview. docs/features/model-consensus-lab.md.
+  runPreviewPanel: (contestId, sport, promptId) =>
+    apiClient.post(
+      `/admin/matchup/preview/${encodeURIComponent(contestId)}/experiment/panel`,
+      null,
+      { params: { ...(sport ? { sport } : {}), ...(promptId ? { promptId } : {}) } }
+    ),
+  // Week matrix: contests any pick'em league carries for (sport, year,
+  // week) x active lab-reachable models, latest picks per pair.
+  getModelLabMatrix: (sport, seasonYear, week) =>
+    apiClient.get('/admin/model-lab/matrix', { params: { sport, seasonYear, week } }),
 
   // Prompt management (per-sport-league prompt entities; text lives in
   // the API database). Name and slot (sport, withStats) are immutable —

--- a/src/UI/sd-ui/src/components/admin/AdminModelLabPage.jsx
+++ b/src/UI/sd-ui/src/components/admin/AdminModelLabPage.jsx
@@ -18,6 +18,10 @@ const LEAGUE_OPTIONS = [
 
 const DEFAULT_YEAR = 2026;
 
+// Queued-marker lifecycle (see the reconcile effect below).
+const QUEUED_SKEW_GRACE_MS = 2 * 60 * 1000;
+const QUEUED_EXPIRY_MS = 10 * 60 * 1000;
+
 /**
  * Model Consensus Lab — the week matrix. Rows = contests any pick'em
  * league carries for the selected sport/week (one SU line + one ATS line
@@ -79,15 +83,22 @@ export default function AdminModelLabPage() {
     localStorage.setItem(LEAGUE_STORAGE_KEY, league);
     localStorage.setItem(YEAR_STORAGE_KEY, String(year));
     localStorage.setItem(WEEK_STORAGE_KEY, String(week));
-    loadMatrix(leagueSport, year, week);
+    // Year/week arrive digit by digit — debounce so intermediate values
+    // ("2", "20", "202"...) never fire a request, and skip invalid ones.
+    if (!Number.isInteger(year) || year < 2000 || !Number.isInteger(week) || week < 1) {
+      return undefined;
+    }
+    const timer = setTimeout(() => loadMatrix(leagueSport, year, week), 400);
+    return () => clearTimeout(timer);
   }, [league, leagueSport, year, week, loadMatrix]);
 
-  // A completed run clears its queued marker and quietly refreshes the
-  // matrix so the cell fills in as each model finishes. Read current
-  // selection through refs so the handler identity stays stable (the
-  // SignalR hook keys its connection on it).
+  // Read current selection through refs so the SignalR handler identity
+  // stays stable (the hook keys its connection on it). Assigned in
+  // effects — never during render.
   const selectionRef = useRef({ leagueSport, year, week });
-  selectionRef.current = { leagueSport, year, week };
+  useEffect(() => {
+    selectionRef.current = { leagueSport, year, week };
+  }, [leagueSport, year, week]);
   const contestIdsRef = useRef(new Set());
   useEffect(() => {
     contestIdsRef.current = new Set(
@@ -95,17 +106,47 @@ export default function AdminModelLabPage() {
     );
   }, [matrix]);
 
+  // Queued markers hold their set-time and clear only when the reloaded
+  // matrix shows a cell CREATED AFTER the marker (2-minute clock-skew
+  // grace) — a stale completion event can no longer clear an in-flight
+  // retry, and a panel marker survives until every column has landed.
+  // A 10-minute expiry stops a dead job from pinning "queued…" forever.
+  useEffect(() => {
+    if (!matrix) return;
+    setQueued(q => {
+      const entries = Object.entries(q);
+      if (entries.length === 0) return q;
+      const cellTime = {};
+      const modelIds = (matrix.models ?? []).map(m => String(m.id).toLowerCase());
+      for (const c of matrix.contests ?? []) {
+        for (const cell of c.cells ?? []) {
+          cellTime[`${String(c.contestId).toLowerCase()}|${String(cell.modelId).toLowerCase()}`] =
+            Date.parse(cell.createdUtc) || 0;
+        }
+      }
+      const now = Date.now();
+      const next = {};
+      let changed = false;
+      for (const [key, setAt] of entries) {
+        const [cid, mid] = key.toLowerCase().split('|');
+        const landedAfter = (m) => (cellTime[`${cid}|${m}`] ?? 0) > setAt - QUEUED_SKEW_GRACE_MS;
+        const done = mid === '*'
+          ? modelIds.length > 0 && modelIds.every(landedAfter)
+          : landedAfter(mid);
+        if (done || now - setAt > QUEUED_EXPIRY_MS) {
+          changed = true;
+          continue;
+        }
+        next[key] = setAt;
+      }
+      return changed ? next : q;
+    });
+  }, [matrix]);
+
   const handlePromptCaptured = useCallback(
     (data) => {
       const id = data?.contestId?.toLowerCase();
       if (!id || !contestIdsRef.current.has(id)) return;
-      setQueued(q => {
-        const next = { ...q };
-        for (const key of Object.keys(next)) {
-          if (key.startsWith(`${id}|`) || key.startsWith(`${data.contestId}|`)) delete next[key];
-        }
-        return next;
-      });
       const { leagueSport: s, year: y, week: w } = selectionRef.current;
       loadMatrix(s, y, w, { quiet: true });
     },
@@ -129,7 +170,7 @@ export default function AdminModelLabPage() {
 
   const generateCell = async (contestId, modelId) => {
     const key = `${contestId}|${modelId}`;
-    setQueued(q => ({ ...q, [key]: true }));
+    setQueued(q => ({ ...q, [key]: Date.now() }));
     try {
       await apiWrapper.Admin.runPreviewExperiment(
         contestId, leagueSport, promptId.trim() || undefined, modelId
@@ -146,7 +187,7 @@ export default function AdminModelLabPage() {
 
   const runPanelForContest = async (contestId) => {
     const key = `${contestId}|*`;
-    setQueued(q => ({ ...q, [key]: true }));
+    setQueued(q => ({ ...q, [key]: Date.now() }));
     try {
       const res = await apiWrapper.Admin.runPreviewPanel(
         contestId, leagueSport, promptId.trim() || undefined

--- a/src/UI/sd-ui/src/components/admin/AdminModelLabPage.jsx
+++ b/src/UI/sd-ui/src/components/admin/AdminModelLabPage.jsx
@@ -1,0 +1,427 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import toast from 'react-hot-toast';
+import './AdminPage.css';
+import AdminHeader from './AdminHeader';
+import apiWrapper from '../../api/apiWrapper';
+import useSignalRClient from '../../hooks/useSignalRClient';
+import { useUserDto } from '../../contexts/UserContext';
+
+const LEAGUE_STORAGE_KEY = 'admin.modellab.league';
+const YEAR_STORAGE_KEY = 'admin.modellab.year';
+const WEEK_STORAGE_KEY = 'admin.modellab.week';
+const PROMPT_ID_STORAGE_KEY = 'admin.modellab.promptId';
+
+const LEAGUE_OPTIONS = [
+  { value: 'ncaa', label: 'NCAAFB', sport: 'FootballNcaa' },
+  { value: 'nfl', label: 'NFL', sport: 'FootballNfl' },
+];
+
+const DEFAULT_YEAR = 2026;
+
+/**
+ * Model Consensus Lab — the week matrix. Rows = contests any pick'em
+ * league carries for the selected sport/week (one SU line + one ATS line
+ * each); columns = active lab-reachable models + Consensus. An empty cell
+ * offers a per-(contest, model) generate button; a whole-row Run panel
+ * fills every hole for that contest. Actuals + accuracy columns arrive
+ * with scoring-on-finalization. Design: docs/features/model-consensus-lab.md.
+ */
+export default function AdminModelLabPage() {
+  const { userDto } = useUserDto();
+
+  const [league, setLeague] = useState(() => {
+    const stored = localStorage.getItem(LEAGUE_STORAGE_KEY);
+    return LEAGUE_OPTIONS.some(o => o.value === stored) ? stored : 'ncaa';
+  });
+  const [year, setYear] = useState(() => {
+    const stored = Number(localStorage.getItem(YEAR_STORAGE_KEY));
+    return Number.isInteger(stored) && stored >= 2000 ? stored : DEFAULT_YEAR;
+  });
+  const [week, setWeek] = useState(() => {
+    const stored = Number(localStorage.getItem(WEEK_STORAGE_KEY));
+    return Number.isInteger(stored) && stored >= 1 ? stored : 1;
+  });
+  const [promptId, setPromptId] = useState(
+    () => localStorage.getItem(PROMPT_ID_STORAGE_KEY) ?? ''
+  );
+
+  const [matrix, setMatrix] = useState(null); // { models: [], contests: [] }
+  const [loading, setLoading] = useState(false);
+  // Cells with a generation in flight, keyed `${contestId}|${modelId}`
+  // (or `${contestId}|*` for a whole-row panel run).
+  const [queued, setQueued] = useState({});
+
+  const leagueSport = useMemo(
+    () => LEAGUE_OPTIONS.find(o => o.value === league)?.sport ?? 'FootballNcaa',
+    [league]
+  );
+
+  // Request sequence token: manual loads and per-completion SignalR
+  // refreshes overlap; an out-of-order response must not win.
+  const loadSeqRef = useRef(0);
+
+  const loadMatrix = useCallback(async (sport, y, w, { quiet = false } = {}) => {
+    const seq = ++loadSeqRef.current;
+    if (!quiet) setLoading(true);
+    try {
+      const res = await apiWrapper.Admin.getModelLabMatrix(sport, y, w);
+      if (seq !== loadSeqRef.current) return;
+      setMatrix(res.data ?? { models: [], contests: [] });
+    } catch (err) {
+      if (seq !== loadSeqRef.current) return;
+      toast.error(err?.message ?? 'Failed to load matrix');
+    } finally {
+      if (seq === loadSeqRef.current) setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem(LEAGUE_STORAGE_KEY, league);
+    localStorage.setItem(YEAR_STORAGE_KEY, String(year));
+    localStorage.setItem(WEEK_STORAGE_KEY, String(week));
+    loadMatrix(leagueSport, year, week);
+  }, [league, leagueSport, year, week, loadMatrix]);
+
+  // A completed run clears its queued marker and quietly refreshes the
+  // matrix so the cell fills in as each model finishes. Read current
+  // selection through refs so the handler identity stays stable (the
+  // SignalR hook keys its connection on it).
+  const selectionRef = useRef({ leagueSport, year, week });
+  selectionRef.current = { leagueSport, year, week };
+  const contestIdsRef = useRef(new Set());
+  useEffect(() => {
+    contestIdsRef.current = new Set(
+      (matrix?.contests ?? []).map(c => c.contestId?.toLowerCase())
+    );
+  }, [matrix]);
+
+  const handlePromptCaptured = useCallback(
+    (data) => {
+      const id = data?.contestId?.toLowerCase();
+      if (!id || !contestIdsRef.current.has(id)) return;
+      setQueued(q => {
+        const next = { ...q };
+        for (const key of Object.keys(next)) {
+          if (key.startsWith(`${id}|`) || key.startsWith(`${data.contestId}|`)) delete next[key];
+        }
+        return next;
+      });
+      const { leagueSport: s, year: y, week: w } = selectionRef.current;
+      loadMatrix(s, y, w, { quiet: true });
+    },
+    [loadMatrix]
+  );
+
+  useSignalRClient({
+    userId: userDto?.id,
+    onPreviewPromptCaptured: handlePromptCaptured,
+  });
+
+  const handlePromptIdChange = (e) => {
+    const next = e.target.value;
+    setPromptId(next);
+    if (next.trim()) {
+      localStorage.setItem(PROMPT_ID_STORAGE_KEY, next);
+    } else {
+      localStorage.removeItem(PROMPT_ID_STORAGE_KEY);
+    }
+  };
+
+  const generateCell = async (contestId, modelId) => {
+    const key = `${contestId}|${modelId}`;
+    setQueued(q => ({ ...q, [key]: true }));
+    try {
+      await apiWrapper.Admin.runPreviewExperiment(
+        contestId, leagueSport, promptId.trim() || undefined, modelId
+      );
+    } catch (err) {
+      setQueued(q => {
+        const next = { ...q };
+        delete next[key];
+        return next;
+      });
+      toast.error(err?.message ?? 'Generate failed');
+    }
+  };
+
+  const runPanelForContest = async (contestId) => {
+    const key = `${contestId}|*`;
+    setQueued(q => ({ ...q, [key]: true }));
+    try {
+      const res = await apiWrapper.Admin.runPreviewPanel(
+        contestId, leagueSport, promptId.trim() || undefined
+      );
+      const count = res?.data?.modelCount;
+      toast.success(count ? `Panel queued — ${count} model(s).` : 'Panel queued.');
+    } catch (err) {
+      setQueued(q => {
+        const next = { ...q };
+        delete next[key];
+        return next;
+      });
+      toast.error(
+        err?.response?.data?.error ?? err?.message ?? 'Panel run failed'
+      );
+    }
+  };
+
+  const models = matrix?.models ?? [];
+  const contests = matrix?.contests ?? [];
+
+  return (
+    <div className="admin-page">
+      <AdminHeader />
+      <div style={{ maxWidth: 1400, margin: '0 auto' }}>
+        <h2 style={{ marginBottom: 4 }}>Model Consensus Lab</h2>
+        <p style={{ color: 'var(--text-secondary)', marginTop: 0 }}>
+          Every contest any pick'em league carries for the week, against
+          every active lab-reachable model. Empty cell = no run yet — the
+          button generates just that pair. Experiments never write a
+          MatchupPreview. Models live on /admin/models; consensus is a
+          simple majority of the picks cast.
+        </p>
+
+        <div style={{ display: 'flex', gap: 8, alignItems: 'center', margin: '16px 0', flexWrap: 'wrap' }}>
+          <label htmlFor="modellab-league" style={{ fontWeight: 600 }}>League:</label>
+          <select
+            id="modellab-league"
+            value={league}
+            onChange={(e) => setLeague(e.target.value)}
+            style={{ padding: '6px 8px' }}
+          >
+            {LEAGUE_OPTIONS.map(o => (
+              <option key={o.value} value={o.value}>{o.label}</option>
+            ))}
+          </select>
+          <label htmlFor="modellab-year" style={{ fontWeight: 600 }}>Season:</label>
+          <input
+            id="modellab-year"
+            type="number"
+            min="2000"
+            max="2100"
+            value={year}
+            onChange={(e) => setYear(Number(e.target.value))}
+            style={{ width: 90, padding: '6px 8px' }}
+          />
+          <label htmlFor="modellab-week" style={{ fontWeight: 600 }}>Week:</label>
+          <input
+            id="modellab-week"
+            type="number"
+            min="1"
+            max="30"
+            value={week}
+            onChange={(e) => setWeek(Number(e.target.value))}
+            style={{ width: 70, padding: '6px 8px' }}
+          />
+          <button type="button" onClick={() => loadMatrix(leagueSport, year, week)}>
+            Refresh
+          </button>
+          <label htmlFor="modellab-prompt-id" style={{ fontWeight: 600 }}>Prompt ID:</label>
+          <input
+            id="modellab-prompt-id"
+            type="text"
+            value={promptId}
+            onChange={handlePromptIdChange}
+            placeholder="optional — Prompt GUID override for generated runs"
+            title="Explicit Prompt entity override (Guid) applied to runs started from this page. Blank = the sport/variant default."
+            style={{ flex: 1, padding: '6px 8px', minWidth: 240 }}
+          />
+        </div>
+
+        {loading && <div>Loading matrix…</div>}
+        {!loading && models.length === 0 && (
+          <div style={{ color: 'var(--text-secondary)' }}>
+            No active lab-reachable models — add models (gateway: OpenRouter)
+            on /admin/models first.
+          </div>
+        )}
+        {!loading && models.length > 0 && contests.length === 0 && (
+          <div style={{ color: 'var(--text-secondary)' }}>
+            No pick'em league carries contests for this sport/week.
+          </div>
+        )}
+
+        {models.length > 0 && contests.length > 0 && (
+          <div style={{ overflowX: 'auto' }}>
+            <table style={{ borderCollapse: 'collapse', width: '100%', fontSize: '0.9rem' }}>
+              <thead>
+                <tr>
+                  <th style={headerStyle}>Contest</th>
+                  {models.map(m => (
+                    <th key={m.id} style={headerStyle}>{m.name}</th>
+                  ))}
+                  <th style={headerStyle}>Consensus</th>
+                  <th style={headerStyle} aria-label="Row actions" />
+                </tr>
+              </thead>
+              <tbody>
+                {contests.map((c) => (
+                  <ContestRows
+                    key={c.contestId}
+                    contest={c}
+                    models={models}
+                    queued={queued}
+                    onGenerateCell={generateCell}
+                    onRunPanel={runPanelForContest}
+                  />
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+const headerStyle = {
+  textAlign: 'left',
+  padding: '6px 10px',
+  borderBottom: '2px solid var(--border-primary)',
+  whiteSpace: 'nowrap',
+};
+
+const cellStyle = {
+  padding: '6px 10px',
+  borderBottom: '1px solid var(--border-primary)',
+  whiteSpace: 'nowrap',
+};
+
+/** Majority of the picks cast; needs at least 2 votes and no tie. */
+function consensusOf(picks) {
+  const votes = picks.filter(Boolean);
+  if (votes.length < 2) return null;
+  const counts = {};
+  for (const v of votes) counts[v] = (counts[v] ?? 0) + 1;
+  const ranked = Object.entries(counts).sort((a, b) => b[1] - a[1]);
+  if (ranked.length > 1 && ranked[0][1] === ranked[1][1]) return null; // tie
+  return ranked[0][1] * 2 > votes.length ? ranked[0][0] : null;
+}
+
+function ContestRows({ contest, models, queued, onGenerateCell, onRunPanel }) {
+  const teamById = useMemo(() => ({
+    [String(contest.awayFranchiseSeasonId).toLowerCase()]: contest.awayShort || contest.away,
+    [String(contest.homeFranchiseSeasonId).toLowerCase()]: contest.homeShort || contest.home,
+  }), [contest]);
+
+  const cellByModel = useMemo(() => {
+    const map = {};
+    for (const cell of contest.cells ?? []) map[String(cell.modelId).toLowerCase()] = cell;
+    return map;
+  }, [contest]);
+
+  const teamFor = (fsId) => {
+    if (!fsId) return null;
+    // A pick GUID outside the matchup is itself a finding — show it raw.
+    return teamById[String(fsId).toLowerCase()] ?? `${String(fsId).substring(0, 8)}…?`;
+  };
+
+  const rowPanelQueued = queued[`${contest.contestId}|*`];
+  const label = `${contest.away} @ ${contest.home}`;
+
+  const renderPickCell = (model, pickField) => {
+    const cell = cellByModel[String(model.id).toLowerCase()];
+    const isQueued = rowPanelQueued || queued[`${contest.contestId}|${model.id}`];
+
+    if (!cell) {
+      return (
+        <td key={model.id} style={cellStyle}>
+          {isQueued ? (
+            <span style={{ color: 'var(--text-secondary)' }}>queued…</span>
+          ) : (
+            <button
+              type="button"
+              onClick={() => onGenerateCell(contest.contestId, model.id)}
+              title={`Run ${model.name} on ${label}`}
+              style={{ fontSize: '0.8rem' }}
+            >
+              generate
+            </button>
+          )}
+        </td>
+      );
+    }
+
+    const pick = teamFor(cell[pickField]);
+    if (!pick) {
+      // No pick + recorded problems = the run FAILED (parse error, bad
+      // response); a clean row with no pick = the model genuinely
+      // abstained. Different facts, different cells — and both keep a
+      // retry (a rerun supersedes; the failed capture stays as history).
+      return (
+        <td key={model.id} style={cellStyle}>
+          {cell.problems ? (
+            <span
+              title={cell.problems}
+              style={{ color: 'var(--color-danger, #c0392b)', fontWeight: 700, cursor: 'help' }}
+            >
+              error
+            </span>
+          ) : (
+            <span style={{ color: 'var(--text-secondary)' }}>abstained</span>
+          )}
+          {isQueued ? (
+            <span style={{ color: 'var(--text-secondary)', marginLeft: 6 }}>queued…</span>
+          ) : (
+            <button
+              type="button"
+              onClick={() => onGenerateCell(contest.contestId, model.id)}
+              title={`Retry ${model.name} on ${label}`}
+              style={{ fontSize: '0.75rem', marginLeft: 6 }}
+            >
+              retry
+            </button>
+          )}
+        </td>
+      );
+    }
+    return (
+      <td key={model.id} style={{ ...cellStyle, fontWeight: 600 }}>
+        {pick}
+        {cell.problems && (
+          <span
+            title={cell.problems}
+            style={{ color: 'var(--color-warning, #e67e22)', marginLeft: 4, cursor: 'help' }}
+          >
+            *
+          </span>
+        )}
+      </td>
+    );
+  };
+
+  const suConsensus = consensusOf(models.map(m =>
+    cellByModel[String(m.id).toLowerCase()]?.predictedStraightUpWinnerId ?? null));
+  const atsConsensus = consensusOf(models.map(m =>
+    cellByModel[String(m.id).toLowerCase()]?.predictedSpreadWinnerId ?? null));
+
+  const hasHoles = models.some(m => !cellByModel[String(m.id).toLowerCase()]);
+
+  return (
+    <>
+      <tr>
+        <td style={{ ...cellStyle, fontWeight: 600 }}>{label} — SU</td>
+        {models.map(m => renderPickCell(m, 'predictedStraightUpWinnerId'))}
+        <td style={{ ...cellStyle, fontWeight: 700 }}>{suConsensus ? teamFor(suConsensus) : '—'}</td>
+        <td rowSpan={2} style={{ ...cellStyle, verticalAlign: 'middle' }}>
+          {hasHoles && !rowPanelQueued && (
+            <button
+              type="button"
+              onClick={() => onRunPanel(contest.contestId)}
+              title={`Run every lab model on ${label}`}
+              style={{ fontSize: '0.8rem' }}
+            >
+              run panel
+            </button>
+          )}
+          {rowPanelQueued && <span style={{ color: 'var(--text-secondary)' }}>panel queued…</span>}
+        </td>
+      </tr>
+      <tr>
+        <td style={{ ...cellStyle, color: 'var(--text-secondary)' }}>{label} — ATS</td>
+        {models.map(m => renderPickCell(m, 'predictedSpreadWinnerId'))}
+        <td style={{ ...cellStyle, fontWeight: 700 }}>{atsConsensus ? teamFor(atsConsensus) : '—'}</td>
+      </tr>
+    </>
+  );
+}

--- a/src/UI/sd-ui/src/components/admin/AdminModelsPage.jsx
+++ b/src/UI/sd-ui/src/components/admin/AdminModelsPage.jsx
@@ -9,6 +9,9 @@ const PROVIDER_KINDS = [
   { value: 'Anthropic', label: 'Anthropic' },
   { value: 'OpenAi', label: 'OpenAI' },
   { value: 'Google', label: 'Google' },
+  // Long-tail makers (xAI, Alibaba, Moonshot, ...) with no first-party
+  // client — their models are reachable only via a gateway row.
+  { value: 'GatewayOnly', label: 'Gateway-only (no first-party client)' },
 ];
 
 // 2025 season window for the risk chip (see llm-training-dates.md):
@@ -26,10 +29,18 @@ function riskFor2025(cutoffUtc) {
   return { label: 'HIGHER-RISK (full 2025 season in training)', color: 'var(--color-danger, #c0392b)' };
 }
 
+// How the model is reached — a routing attribute, NOT a provider (the
+// provider stays who MAKES the model). Identity, like apiModelId: create-only.
+const GATEWAY_OPTIONS = [
+  { value: 'None', label: 'Direct (first-party client)' },
+  { value: 'OpenRouter', label: 'via OpenRouter gateway' },
+];
+
 const EMPTY_FORM = {
   modelProviderId: '',
   name: '',
   apiModelId: '',
+  gateway: 'None',
   releaseDate: '',
   knowledgeCutoffUtc: '',
   cutoffEvidence: '',
@@ -96,6 +107,7 @@ export default function AdminModelsPage() {
       modelProviderId: m.modelProviderId,
       name: m.name,
       apiModelId: m.apiModelId,
+      gateway: m.gateway ?? 'None',
       releaseDate: toDateInput(m.releaseDate),
       knowledgeCutoffUtc: toDateInput(m.knowledgeCutoffUtc),
       cutoffEvidence: m.cutoffEvidence ?? '',
@@ -153,6 +165,7 @@ export default function AdminModelsPage() {
           modelProviderId: form.modelProviderId,
           name: form.name.trim(),
           apiModelId: form.apiModelId.trim(),
+          gateway: form.gateway,
           releaseDate: fromDateInput(form.releaseDate),
           knowledgeCutoffUtc: fromDateInput(form.knowledgeCutoffUtc),
           cutoffEvidence: form.cutoffEvidence || null,
@@ -180,6 +193,30 @@ export default function AdminModelsPage() {
       loadAll();
     } catch (err) {
       toast.error(err?.response?.data?.errors?.[0]?.errorMessage ?? err.message ?? 'Set default failed');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  // One-click matrix curation: active models are the Model Lab's columns.
+  // The update endpoint replaces all metadata, so echo the row's own
+  // values back with only IsActive flipped.
+  const handleToggleActive = async (m) => {
+    setSubmitting(true);
+    try {
+      await apiWrapper.Admin.updateModel(m.id, {
+        releaseDate: m.releaseDate,
+        knowledgeCutoffUtc: m.knowledgeCutoffUtc,
+        cutoffEvidence: m.cutoffEvidence,
+        cutoffVerifiedUtc: m.cutoffVerifiedUtc,
+        inputCostPerMTok: m.inputCostPerMTok,
+        outputCostPerMTok: m.outputCostPerMTok,
+        isActive: !m.isActive,
+      });
+      toast.success(m.isActive ? 'Deactivated — dropped from the lab matrix.' : 'Activated — now a lab matrix column.');
+      loadAll();
+    } catch (err) {
+      toast.error(err?.response?.data?.errors?.[0]?.errorMessage ?? err.message ?? 'Toggle failed');
     } finally {
       setSubmitting(false);
     }
@@ -269,6 +306,7 @@ export default function AdminModelsPage() {
                     <div style={{ display: 'flex', gap: 8, alignItems: 'baseline', flexWrap: 'wrap' }}>
                       <strong>{m.name}</strong>
                       <span style={{ color: 'var(--text-secondary)', fontSize: '0.85rem' }}>{m.providerName}</span>
+                      {(m.gateway === 'OpenRouter' || m.gateway === 1) && <span style={{ fontSize: '0.8rem', fontWeight: 700, color: 'var(--color-warning, #e67e22)' }}>via OpenRouter</span>}
                       {m.isDefault && <span style={{ color: 'var(--color-success, #27ae60)', fontSize: '0.8rem', fontWeight: 700 }}>PRODUCTION DEFAULT</span>}
                       {!m.isActive && <span style={{ fontSize: '0.8rem', fontWeight: 700, color: 'var(--text-secondary)' }}>INACTIVE</span>}
                     </div>
@@ -285,6 +323,16 @@ export default function AdminModelsPage() {
                       {!m.isDefault && m.isActive && (
                         <button type="button" disabled={submitting} onClick={() => handleSetDefault(m.id)}>
                           Set default
+                        </button>
+                      )}
+                      {!m.isDefault && (
+                        <button
+                          type="button"
+                          disabled={submitting}
+                          onClick={() => handleToggleActive(m)}
+                          title={m.isActive ? 'Drop from the lab matrix' : 'Add to the lab matrix'}
+                        >
+                          {m.isActive ? 'Deactivate' : 'Activate'}
                         </button>
                       )}
                       <button type="button" onClick={() => handleCopyId(m.id)}>Copy ID</button>
@@ -332,12 +380,25 @@ export default function AdminModelsPage() {
                     placeholder="display name (e.g. Claude Haiku 4.5)"
                     style={{ padding: '6px 8px' }}
                   />
+                  <select
+                    aria-label="Gateway (how the model is reached)"
+                    value={form.gateway}
+                    onChange={(e) => setForm(f => ({ ...f, gateway: e.target.value }))}
+                    title="Routing, not identity of the maker — a gateway row keeps its true provider. Create-only: the same weights reached two ways are different evaluands."
+                    style={{ padding: '6px 8px' }}
+                  >
+                    {GATEWAY_OPTIONS.map(g => (
+                      <option key={g.value} value={g.value}>{g.label}</option>
+                    ))}
+                  </select>
                   <input
                     type="text"
                     aria-label="API model id"
                     value={form.apiModelId}
                     onChange={(e) => setForm(f => ({ ...f, apiModelId: e.target.value }))}
-                    placeholder="exact API id (e.g. claude-haiku-4-5)"
+                    placeholder={form.gateway === 'OpenRouter'
+                      ? "gateway's namespaced id (e.g. anthropic/claude-sonnet-4.5)"
+                      : 'exact API id (e.g. claude-haiku-4-5)'}
                     style={{ padding: '6px 8px', fontFamily: 'monospace' }}
                   />
                 </>

--- a/test/unit/SportsData.Api.Tests.Unit/Application/Previews/MatchupPreviewProcessorTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/Previews/MatchupPreviewProcessorTests.cs
@@ -874,13 +874,16 @@ namespace SportsData.Api.Tests.Unit.Application.Previews
             string apiModelId = "openai/gpt-test",
             bool isDefault = false)
         {
+            // Fixed seed time: the repo rule bans DateTime.UtcNow — and a
+            // deterministic fixture is the point of the rule.
+            var seedTime = new DateTime(2026, 9, 3, 0, 0, 0, DateTimeKind.Utc);
             var provider = new ModelProvider
             {
                 Id = Guid.NewGuid(),
                 Name = $"Provider-{Guid.NewGuid():N}",
                 Kind = ModelProviderKind.OpenAi,
                 IsActive = providerActive,
-                CreatedUtc = DateTime.UtcNow
+                CreatedUtc = seedTime
             };
             var model = new Model
             {
@@ -891,7 +894,7 @@ namespace SportsData.Api.Tests.Unit.Application.Previews
                 Gateway = gateway,
                 IsActive = modelActive,
                 IsDefault = isDefault,
-                CreatedUtc = DateTime.UtcNow
+                CreatedUtc = seedTime
             };
             await DataContext.ModelProviders.AddAsync(provider);
             await DataContext.Models.AddAsync(model);

--- a/test/unit/SportsData.Api.Tests.Unit/Application/Previews/MatchupPreviewProcessorTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/Previews/MatchupPreviewProcessorTests.cs
@@ -1,6 +1,7 @@
 ﻿using Moq;
 
 using SportsData.Api.Application.Previews;
+using SportsData.Api.Infrastructure.Data.Entities;
 using SportsData.Api.Infrastructure.Prompts;
 using SportsData.Core.Common;
 using SportsData.Core.Dtos.Canonical;
@@ -863,6 +864,248 @@ namespace SportsData.Api.Tests.Unit.Application.Previews
         public void BaseballMlb_IsNotSupported()
         {
             Assert.False(MatchupPreviewPolicy.SupportsSport(Sport.BaseballMlb));
+        }
+
+
+        private async Task<Model> SeedLabModelAsync(
+            bool modelActive = true,
+            bool providerActive = true,
+            ModelGateway gateway = ModelGateway.OpenRouter,
+            string apiModelId = "openai/gpt-test",
+            bool isDefault = false)
+        {
+            var provider = new ModelProvider
+            {
+                Id = Guid.NewGuid(),
+                Name = $"Provider-{Guid.NewGuid():N}",
+                Kind = ModelProviderKind.OpenAi,
+                IsActive = providerActive,
+                CreatedUtc = DateTime.UtcNow
+            };
+            var model = new Model
+            {
+                Id = Guid.NewGuid(),
+                ModelProviderId = provider.Id,
+                Name = $"Model-{Guid.NewGuid():N}",
+                ApiModelId = apiModelId,
+                Gateway = gateway,
+                IsActive = modelActive,
+                IsDefault = isDefault,
+                CreatedUtc = DateTime.UtcNow
+            };
+            await DataContext.ModelProviders.AddAsync(provider);
+            await DataContext.Models.AddAsync(model);
+            await DataContext.SaveChangesAsync();
+            return model;
+        }
+
+        [Fact]
+        public async Task Generate_ParsesMarkdownFencedJsonResponse()
+        {
+            // Many models fence JSON out of habit — Claude Haiku did on the
+            // lab's first multi-model run and a valid pick was discarded as
+            // a parse failure. The fence is cosmetic; the answer counts.
+            SetupPipeline(BuildMatchup("STATUS_SCHEDULED"));
+
+            var responseJson = $$"""
+                ```json
+                {
+                  "overview": "o", "analysis": "a", "prediction": "p",
+                  "predictedStraightUpWinner": "{{_homeFranchiseSeasonId}}",
+                  "predictedSpreadWinner": null,
+                  "overUnderPrediction": 2, "awayScore": 17, "homeScore": 27
+                }
+                ```
+                """;
+            Mocker.GetMock<IProvideAiCommunication>()
+                .Setup(x => x.GetResponseAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Success<string>(responseJson));
+            Mocker.GetMock<IProvideAiCommunication>()
+                .Setup(x => x.GetModelName())
+                .Returns("test-model");
+
+            var sut = Mocker.CreateInstance<MatchupPreviewProcessor>();
+            await sut.Process(new GenerateMatchupPreviewsCommand
+            {
+                ContestId = _contestId,
+                Sport = Sport.FootballNfl
+            });
+
+            var preview = Assert.Single(DataContext.MatchupPreviews);
+            Assert.Equal(_homeFranchiseSeasonId, preview.PredictedStraightUpWinner);
+            Assert.Null(preview.ValidationErrors);
+        }
+
+        [Fact]
+        public async Task Generate_StampsModelId_WhenDefaultRowMatchesWiredClient()
+        {
+            SetupPipeline(BuildMatchup("STATUS_SCHEDULED"));
+
+            // The registry's IsDefault row IS the production model selection —
+            // when its ApiModelId matches the wired client, the preview gets
+            // registry provenance alongside the model string.
+            var defaultModel = await SeedLabModelAsync(
+                gateway: ModelGateway.None, apiModelId: "test-model", isDefault: true);
+
+            var responseJson = $$"""
+                {
+                  "overview": "o", "analysis": "a", "prediction": "p",
+                  "predictedStraightUpWinner": "{{_homeFranchiseSeasonId}}",
+                  "predictedSpreadWinner": null,
+                  "overUnderPrediction": 2, "awayScore": 17, "homeScore": 27
+                }
+                """;
+            Mocker.GetMock<IProvideAiCommunication>()
+                .Setup(x => x.GetResponseAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Success<string>(responseJson));
+            Mocker.GetMock<IProvideAiCommunication>()
+                .Setup(x => x.GetModelName())
+                .Returns("test-model");
+
+            var sut = Mocker.CreateInstance<MatchupPreviewProcessor>();
+            await sut.Process(new GenerateMatchupPreviewsCommand
+            {
+                ContestId = _contestId,
+                Sport = Sport.FootballNfl
+            });
+
+            var preview = Assert.Single(DataContext.MatchupPreviews);
+            Assert.Equal(defaultModel.Id, preview.ModelId);
+            Assert.Equal("test-model", preview.Model);
+            var capture = Assert.Single(DataContext.MatchupPreviewPrompts);
+            Assert.Equal(defaultModel.Id, capture.ModelId);
+        }
+
+        [Fact]
+        public async Task Generate_StampsNoModelId_WhenDefaultRowMismatchesWiredClient()
+        {
+            SetupPipeline(BuildMatchup("STATUS_SCHEDULED"));
+
+            // Flag/config drift: a null stamp beats a false one.
+            await SeedLabModelAsync(
+                gateway: ModelGateway.None, apiModelId: "some-other-model", isDefault: true);
+
+            var responseJson = $$"""
+                {
+                  "overview": "o", "analysis": "a", "prediction": "p",
+                  "predictedStraightUpWinner": "{{_homeFranchiseSeasonId}}",
+                  "predictedSpreadWinner": null,
+                  "overUnderPrediction": 2, "awayScore": 17, "homeScore": 27
+                }
+                """;
+            Mocker.GetMock<IProvideAiCommunication>()
+                .Setup(x => x.GetResponseAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Success<string>(responseJson));
+            Mocker.GetMock<IProvideAiCommunication>()
+                .Setup(x => x.GetModelName())
+                .Returns("test-model");
+
+            var sut = Mocker.CreateInstance<MatchupPreviewProcessor>();
+            await sut.Process(new GenerateMatchupPreviewsCommand
+            {
+                ContestId = _contestId,
+                Sport = Sport.FootballNfl
+            });
+
+            var preview = Assert.Single(DataContext.MatchupPreviews);
+            Assert.Null(preview.ModelId);
+            Assert.Equal("test-model", preview.Model);
+        }
+
+        [Fact]
+        public async Task Process_ExperimentWithInactiveModel_Skips()
+        {
+            // A fan-out enqueued before an admin deactivated the row must not
+            // call any model — inactive means inactive, even for in-flight jobs.
+            var model = await SeedLabModelAsync(modelActive: false);
+
+            var command = new GenerateMatchupPreviewsCommand
+            {
+                ContestId = Guid.NewGuid(),
+                Sport = Sport.FootballNfl,
+                Mode = PreviewGenerationMode.Experiment,
+                ModelId = model.Id
+            };
+
+            var sut = Mocker.CreateInstance<MatchupPreviewProcessor>();
+            await sut.Process(command);
+
+            Mocker.GetMock<IAiModelClientResolver>()
+                .Verify(x => x.Resolve(It.IsAny<Model>()), Times.Never);
+            Mocker.GetMock<IProvideAiCommunication>()
+                .Verify(x => x.GetResponseAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task Process_ExperimentWithInactiveProvider_Skips()
+        {
+            // Deactivating a PROVIDER silences its whole fleet at once.
+            var model = await SeedLabModelAsync(providerActive: false);
+
+            var command = new GenerateMatchupPreviewsCommand
+            {
+                ContestId = Guid.NewGuid(),
+                Sport = Sport.FootballNfl,
+                Mode = PreviewGenerationMode.Experiment,
+                ModelId = model.Id
+            };
+
+            var sut = Mocker.CreateInstance<MatchupPreviewProcessor>();
+            await sut.Process(command);
+
+            Mocker.GetMock<IAiModelClientResolver>()
+                .Verify(x => x.Resolve(It.IsAny<Model>()), Times.Never);
+            Mocker.GetMock<IProvideAiCommunication>()
+                .Verify(x => x.GetResponseAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task Process_ExperimentWithMissingModel_Skips()
+        {
+            var command = new GenerateMatchupPreviewsCommand
+            {
+                ContestId = Guid.NewGuid(),
+                Sport = Sport.FootballNcaa,
+                Mode = PreviewGenerationMode.Experiment,
+                ModelId = Guid.NewGuid() // no such Model row
+            };
+
+            var sut = Mocker.CreateInstance<MatchupPreviewProcessor>();
+            await sut.Process(command);
+
+            Mocker.GetMock<IAiModelClientResolver>()
+                .Verify(x => x.Resolve(It.IsAny<Model>()), Times.Never);
+            Mocker.GetMock<IProvideAiCommunication>()
+                .Verify(x => x.GetResponseAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task Process_ExperimentWithUnresolvableRoute_SkipsWithoutThrowing()
+        {
+            // Direct routes have no lab client until panel promotion; that
+            // must be a logged skip, never an exception — a throw here
+            // would put Hangfire into a pointless retry loop.
+            var model = await SeedLabModelAsync(gateway: ModelGateway.None);
+
+            Mocker.GetMock<IAiModelClientResolver>()
+                .Setup(x => x.CanResolve(ModelGateway.None, It.IsAny<ModelProviderKind>()))
+                .Returns(false);
+
+            var command = new GenerateMatchupPreviewsCommand
+            {
+                ContestId = Guid.NewGuid(),
+                Sport = Sport.FootballNfl,
+                Mode = PreviewGenerationMode.Experiment,
+                ModelId = model.Id
+            };
+
+            var sut = Mocker.CreateInstance<MatchupPreviewProcessor>();
+            await sut.Process(command);
+
+            Mocker.GetMock<IAiModelClientResolver>()
+                .Verify(x => x.Resolve(It.IsAny<Model>()), Times.Never);
+            Mocker.GetMock<IProvideAiCommunication>()
+                .Verify(x => x.GetResponseAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
         }
 
     }


### PR DESCRIPTION
## What this is

Phase 1 of the Model Consensus Lab (docs/features/model-consensus-lab.md): run the SAME prompt against every active lab-reachable model and compare picks in a week matrix — groundwork for StatBot's prediction eventually becoming the consensus of a small panel.

**Decision amendment recorded in-tree**: the 2026-08-08 first-party-only strategy (matchup-preview-data-inputs.md §6, AMENDED note) predated the many-model ambition. OpenRouter is admitted **as a gateway, not a provider** — `Model.Gateway (None | OpenRouter)` carries the route; the provider remains who makes the model, so cutoff/cost metadata stays truthful. Built on the EXISTING `Model`/`ModelProvider` registry — no new catalog table.

## Highlights

- **OpenRouterClient** (Core) + `IProvideModelEvaluation` — content, actual tokens, latency, finish_reason. Temp 0.1; MaxTokens 16384 (reasoning models spend thinking tokens against the same ceiling — Gemini 3.1 truncated every run at 4096).
- **Gateway-keyed resolver**; `CanResolve(gateway, kind)` is the single reachability truth. Unreachable routes = logged skips, never Hangfire retry loops. Direct routes arrive with panel promotion (phase 3).
- **Processor**: top-of-Process model gate (inactive model costs zero); experiment measurements persist on the capture row (`MatchupPreviewPrompt` = the backtest corpus by charter) — picks survive validation problems; markdown fences stripped (Haiku fences JSON); truncation is a named problem, not parse noise.
- **Provenance**: `MatchupPreview.ModelId` stamped from the registry `IsDefault` row only when it matches the wired client (drift ⇒ null + warning; a null beats a lie).
- **Week matrix** `GET admin/model-lab/matrix` + `/app/admin/model-lab`: rows = contest × SU/ATS (universe = every game any pick'em league carries), columns = models + consensus (strict majority, ≥2 votes); per-cell generate/retry, per-row panel, cells fill live via SignalR. Error ("problems recorded") vs abstained (clean, no pick) are distinct cells.
- **Model Manager**: Gateway on create (create-only identity — same weights via two routes are two evaluands), one-click Activate/Deactivate = matrix membership; `ModelProviderKind.GatewayOnly` for long-tail makers.

## Deploy checklist (operator)

1. **Rotate `OpenRouterApiKey` in Key Vault BEFORE deploy** (current key was exposed locally during debugging — owner already planned this).
2. AppConfig keys already applied via IaC (provision `6a5b06c`).
3. Two EF migrations: `ModelConsensusLab`, `MatchupPreviewModelProvenance` (all additive/nullable).
4. Run `sql/pgsql/seed_model_lab.sql` against the prod API DB (idempotent) — seeds 5 providers + 7 models incl. the production-direct DeepSeek row (`IsDefault`), which activates preview provenance stamping.
5. Cutoffs in the seed are transcribed from `llm-training-dates.md` and deliberately UNVERIFIED — verify via the Model Manager evidence/verified fields as time allows.

## Note on base

Contains #711's commit (this branch grew on top of it while #711 is in review). Once #711 merges, I'll rebase onto main and this PR reduces to the lab work alone.

Locally validated end-to-end: matrix populates across all six audition models (Haiku fence bug and Gemini truncation found and fixed in the process). 818/818 API unit tests, ESLint clean, CRA build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnJySMvfUPeQSMufNNcKSK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an admin Model Consensus Lab for comparing model predictions by league, season, and week.
  - Generate individual evaluations or queue full multi-model panels with consensus and ATS comparisons.
  - Added support for OpenRouter-routed models alongside direct provider models.
  - Model registry now displays gateway details and supports activation controls.
  - Preview captures include model attribution, predictions, token usage, and latency.
- **Documentation**
  - Added design documentation covering the Model Consensus Lab and evaluation workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->