### PR TITLE
feat(api,web): model-lab ATS rows show the line; admin-idiom buttons

### DIFF
--- a/src/SportsData.Api/Application/Admin/Queries/GetModelLabMatrix/GetModelLabMatrixQueryHandler.cs
+++ b/src/SportsData.Api/Application/Admin/Queries/GetModelLabMatrix/GetModelLabMatrixQueryHandler.cs
@@ -123,6 +123,7 @@ public class GetModelLabMatrixQueryHandler : IGetModelLabMatrixQueryHandler
                 Home = m.Home,
                 HomeShort = m.HomeShort,
                 HomeFranchiseSeasonId = m.HomeFranchiseSeasonId,
+                Spread = m.SpreadCurrent,
                 Cells = latestCells[m.ContestId]
                     .Select(c => new ModelLabMatrixDto.MatrixCellDto
                     {

--- a/src/SportsData.Api/Application/Admin/Queries/GetModelLabMatrix/ModelLabMatrixDto.cs
+++ b/src/SportsData.Api/Application/Admin/Queries/GetModelLabMatrix/ModelLabMatrixDto.cs
@@ -40,6 +40,9 @@ public class ModelLabMatrixDto
 
         public Guid HomeFranchiseSeasonId { get; set; }
 
+        /// <summary>Current line, HOME-relative (negative = home favored, e.g. -22.5); null when no odds. The team name would be redundant — the spread is always the home team's.</summary>
+        public double? Spread { get; set; }
+
         /// <summary>Latest experiment per model; a model absent here has no run yet.</summary>
         public List<MatrixCellDto> Cells { get; set; } = [];
     }

--- a/src/UI/sd-ui/src/components/admin/AdminModelLabPage.jsx
+++ b/src/UI/sd-ui/src/components/admin/AdminModelLabPage.jsx
@@ -193,7 +193,7 @@ export default function AdminModelLabPage() {
         contestId, leagueSport, promptId.trim() || undefined
       );
       const count = res?.data?.modelCount;
-      toast.success(count ? `Panel queued — ${count} model(s).` : 'Panel queued.');
+      toast.success(count ? `Panel queued - ${count} model(s).` : 'Panel queued.');
     } catch (err) {
       setQueued(q => {
         const next = { ...q };
@@ -216,7 +216,7 @@ export default function AdminModelLabPage() {
         <h2 style={{ marginBottom: 4 }}>Model Consensus Lab</h2>
         <p style={{ color: 'var(--text-secondary)', marginTop: 0 }}>
           Every contest any pick'em league carries for the week, against
-          every active lab-reachable model. Empty cell = no run yet — the
+          every active lab-reachable model. Empty cell = no run yet - the
           button generates just that pair. Experiments never write a
           MatchupPreview. Models live on /admin/models; consensus is a
           simple majority of the picks cast.
@@ -254,7 +254,7 @@ export default function AdminModelLabPage() {
             onChange={(e) => setWeek(Number(e.target.value))}
             style={{ width: 70, padding: '6px 8px' }}
           />
-          <button type="button" onClick={() => loadMatrix(leagueSport, year, week)}>
+          <button type="button" className="model-lab-btn" onClick={() => loadMatrix(leagueSport, year, week)}>
             Refresh
           </button>
           <label htmlFor="modellab-prompt-id" style={{ fontWeight: 600 }}>Prompt ID:</label>
@@ -263,7 +263,7 @@ export default function AdminModelLabPage() {
             type="text"
             value={promptId}
             onChange={handlePromptIdChange}
-            placeholder="optional — Prompt GUID override for generated runs"
+            placeholder="optional - Prompt GUID override for generated runs"
             title="Explicit Prompt entity override (Guid) applied to runs started from this page. Blank = the sport/variant default."
             style={{ flex: 1, padding: '6px 8px', minWidth: 240 }}
           />
@@ -272,7 +272,7 @@ export default function AdminModelLabPage() {
         {loading && <div>Loading matrix…</div>}
         {!loading && models.length === 0 && (
           <div style={{ color: 'var(--text-secondary)' }}>
-            No active lab-reachable models — add models (gateway: OpenRouter)
+            No active lab-reachable models - add models (gateway: OpenRouter)
             on /admin/models first.
           </div>
         )}
@@ -329,6 +329,16 @@ const cellStyle = {
 };
 
 /** Majority of the picks cast; needs at least 2 votes and no tie. */
+/**
+ * Home-relative line as " (-22.5)" / " (+3.5)" / " (PK)" — no team name,
+ * the spread is always the home team's. Empty string when no odds.
+ */
+function formatSpread(spread) {
+  if (spread == null) return '';
+  if (spread === 0) return ' (PK)';
+  return ` (${spread > 0 ? '+' : ''}${spread})`;
+}
+
 function consensusOf(picks) {
   const votes = picks.filter(Boolean);
   if (votes.length < 2) return null;
@@ -353,7 +363,7 @@ function ContestRows({ contest, models, queued, onGenerateCell, onRunPanel }) {
 
   const teamFor = (fsId) => {
     if (!fsId) return null;
-    // A pick GUID outside the matchup is itself a finding — show it raw.
+    // A pick GUID outside the matchup is itself a finding - show it raw.
     return teamById[String(fsId).toLowerCase()] ?? `${String(fsId).substring(0, 8)}…?`;
   };
 
@@ -372,9 +382,9 @@ function ContestRows({ contest, models, queued, onGenerateCell, onRunPanel }) {
           ) : (
             <button
               type="button"
+              className="model-lab-btn model-lab-btn--small"
               onClick={() => onGenerateCell(contest.contestId, model.id)}
               title={`Run ${model.name} on ${label}`}
-              style={{ fontSize: '0.8rem' }}
             >
               generate
             </button>
@@ -387,7 +397,7 @@ function ContestRows({ contest, models, queued, onGenerateCell, onRunPanel }) {
     if (!pick) {
       // No pick + recorded problems = the run FAILED (parse error, bad
       // response); a clean row with no pick = the model genuinely
-      // abstained. Different facts, different cells — and both keep a
+      // abstained. Different facts, different cells - and both keep a
       // retry (a rerun supersedes; the failed capture stays as history).
       return (
         <td key={model.id} style={cellStyle}>
@@ -406,9 +416,10 @@ function ContestRows({ contest, models, queued, onGenerateCell, onRunPanel }) {
           ) : (
             <button
               type="button"
+              className="model-lab-btn model-lab-btn--small"
               onClick={() => onGenerateCell(contest.contestId, model.id)}
               title={`Retry ${model.name} on ${label}`}
-              style={{ fontSize: '0.75rem', marginLeft: 6 }}
+              style={{ marginLeft: 6 }}
             >
               retry
             </button>
@@ -441,16 +452,16 @@ function ContestRows({ contest, models, queued, onGenerateCell, onRunPanel }) {
   return (
     <>
       <tr>
-        <td style={{ ...cellStyle, fontWeight: 600 }}>{label} — SU</td>
+        <td style={{ ...cellStyle, fontWeight: 600 }}>{label} - SU</td>
         {models.map(m => renderPickCell(m, 'predictedStraightUpWinnerId'))}
-        <td style={{ ...cellStyle, fontWeight: 700 }}>{suConsensus ? teamFor(suConsensus) : '—'}</td>
+        <td style={{ ...cellStyle, fontWeight: 700 }}>{suConsensus ? teamFor(suConsensus) : '-'}</td>
         <td rowSpan={2} style={{ ...cellStyle, verticalAlign: 'middle' }}>
           {hasHoles && !rowPanelQueued && (
             <button
               type="button"
+              className="model-lab-btn model-lab-btn--small"
               onClick={() => onRunPanel(contest.contestId)}
               title={`Run every lab model on ${label}`}
-              style={{ fontSize: '0.8rem' }}
             >
               run panel
             </button>
@@ -459,7 +470,9 @@ function ContestRows({ contest, models, queued, onGenerateCell, onRunPanel }) {
         </td>
       </tr>
       <tr>
-        <td style={{ ...cellStyle, color: 'var(--text-secondary)' }}>{label} — ATS</td>
+        <td style={{ ...cellStyle, color: 'var(--text-secondary)' }}>
+          {label} - ATS{formatSpread(contest.spread)}
+        </td>
         {models.map(m => renderPickCell(m, 'predictedSpreadWinnerId'))}
         <td style={{ ...cellStyle, fontWeight: 700 }}>{atsConsensus ? teamFor(atsConsensus) : '—'}</td>
       </tr>

--- a/src/UI/sd-ui/src/components/admin/AdminPage.css
+++ b/src/UI/sd-ui/src/components/admin/AdminPage.css
@@ -142,3 +142,35 @@
   color: var(--accent);
   text-decoration: none;
 }
+
+/* Model Lab buttons: same surface idiom as the admin nav links
+   (bg-input, 8px radius, accent on hover). */
+.model-lab-btn {
+  padding: 6px 14px;
+  background: var(--bg-input);
+  color: var(--text-primary);
+  border: 1px solid var(--border-primary);
+  border-radius: 8px;
+  font-weight: 600;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: border-color 0.15s ease, color 0.15s ease;
+}
+
+.model-lab-btn:hover:not(:disabled),
+.model-lab-btn:focus-visible {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.model-lab-btn:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+/* Cell-sized variant for generate/retry inside the matrix. */
+.model-lab-btn--small {
+  padding: 2px 10px;
+  font-size: 0.75rem;
+  border-radius: 6px;
+}


### PR DESCRIPTION
Two operator-visibility improvements to the Model Consensus Lab matrix (follow-up to #712, now live in prod):

- **ATS rows show the line**: the matrix DTO gains `Spread` — the numeric, HOME-relative current line (`SpreadCurrent` from the Producer batch call the matrix already makes; zero new queries). Rendered as `Away @ Home - ATS (-22.5)`, `(+3.5)` for a home dog, `(PK)` for a pick'em, omitted when no odds are posted. No team abbreviation — the spread is always the home team's, so naming it is redundant.
- **Buttons**: Refresh / generate / retry / run panel now use `.model-lab-btn` classes that borrow the established admin nav-link idiom in `AdminPage.css` (bg-input surface, 8px radius, accent on hover, dimmed disabled state) instead of bare browser buttons.

Note: the parenthetical is the line at matrix-load time; each capture row's payload preserves the as-generated line, so any mid-week line movement remains auditable per cell.

818/818 API unit tests, ESLint clean, CRA build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnJySMvfUPeQSMufNNcKSK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Model Lab contest matrices now display current point spreads, including pick’em notation where applicable.
  - Spreads are shown relative to the home team and omitted when odds data is unavailable.

- **UI Improvements**
  - Updated Model Lab action buttons with consistent sizing and interaction states.
  - Improved placeholders and separators for clearer matrix presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->