### PR TITLE
fix(producer): contest audit catches fresh corruption — newest-first, 6-hourly, re-armed on input change

### DIFF
--- a/src/SportsData.Producer/Application/Contests/ContestEnrichmentAuditJob.cs
+++ b/src/SportsData.Producer/Application/Contests/ContestEnrichmentAuditJob.cs
@@ -73,13 +73,18 @@ public class ContestEnrichmentAuditJob<TDataContext> : IContestEnrichmentAuditJo
             "ContestEnrichmentAuditJob starting. BatchSize={BatchSize}",
             BatchSize);
 
-        // Order by FinalizedUtc so the oldest unverified finalizations are
-        // audited first — keeps the backlog draining predictably during
-        // the post-deploy ramp.
+        // NEWEST first (flipped 2026-09-04): fresh finalizations are what
+        // users see, picks score against, and preview payloads consume — a
+        // corrupted weekend batch must be caught within hours, not after
+        // the sweep finishes chewing the 2008+ backlog (oldest-first left
+        // the 2026-08-30 inverted-winner batch unaudited for days while
+        // auditing historical rows nobody was reading). The backlog still
+        // drains fully — from the other end, whenever a firing has fewer
+        // fresh candidates than the batch cap.
         var contestIds = await _dataContext.Contests
             .AsNoTracking()
             .Where(c => c.FinalizedUtc != null && c.AuditedUtc == null)
-            .OrderBy(c => c.FinalizedUtc)
+            .OrderByDescending(c => c.FinalizedUtc)
             .Take(BatchSize)
             .Select(c => c.Id)
             .ToListAsync();

--- a/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Common/EventCompetitionCompetitorScoreDocumentProcessor.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Common/EventCompetitionCompetitorScoreDocumentProcessor.cs
@@ -11,6 +11,7 @@ using SportsData.Core.Infrastructure.Refs;
 using SportsData.Producer.Application.Documents.Processors.Commands;
 using SportsData.Producer.Exceptions;
 using SportsData.Producer.Infrastructure.Data.Common;
+using SportsData.Producer.Infrastructure.Data.Entities;
 using SportsData.Producer.Infrastructure.Data.Entities.Extensions;
 
 namespace SportsData.Producer.Application.Documents.Processors.Providers.Espn.Common;
@@ -118,7 +119,16 @@ public class EventCompetitionCompetitorScoreDocumentProcessor<TDataContext> : Do
                 competitionCompetitorIdValue,
                 score.Value,
                 dto.Value);
-            
+
+            // A score CORRECTION on a finalized contest means the derived
+            // results (winner / ATS / O-U) may now be stale — the audit is
+            // one-shot and would never look again (the 2026-08-30 batch left
+            // 14 NCAA contests with inverted winners this way). Re-arm it:
+            // the sweep re-verifies against the corrected inputs and
+            // self-heals on mismatch. Live games never hit this (not
+            // finalized); already-unaudited rows are a no-op.
+            await RearmAuditIfFinalizedAsync(competitor, dto.Value);
+
             score.Value = dto.Value;
             score.DisplayValue = dto.DisplayValue;
             score.ModifiedBy = command.CorrelationId;
@@ -150,6 +160,10 @@ public class EventCompetitionCompetitorScoreDocumentProcessor<TDataContext> : Do
         else
         {
             _logger.LogInformation("Creating new CompetitorScore. CompetitorId={CompetitorId}", competitionCompetitorIdValue);
+
+            // Same re-arm as the update branch: a score row ARRIVING after
+            // finalization is also an input change the audit must re-verify.
+            await RearmAuditIfFinalizedAsync(competitor, dto.Value);
 
             var entity = dto.AsEntity(
                 competitionCompetitorIdValue,
@@ -183,8 +197,41 @@ public class EventCompetitionCompetitorScoreDocumentProcessor<TDataContext> : Do
                 dto.Value);
         }
 
-        _logger.LogInformation("CompetitorScore processing completed. CompetitorId={CompetitorId}, Value={Value}", 
-            competitionCompetitorIdValue, 
+        _logger.LogInformation("CompetitorScore processing completed. CompetitorId={CompetitorId}, Value={Value}",
+            competitionCompetitorIdValue,
             dto.Value);
+    }
+
+    /// <summary>
+    /// Re-arms the enrichment audit when a score input lands on a FINALIZED
+    /// contest: the audit is one-shot, so a post-finalization correction
+    /// would otherwise never be re-verified (2026-08-30: 14 NCAA contests
+    /// kept inverted winners this way). The competitor was loaded
+    /// AsNoTracking, so its Contest navigation only GATES the tracked fetch
+    /// — live-game score updates (contest not finalized) cost zero extra
+    /// queries. The tracked write rides the caller's SaveChangesAsync, so
+    /// the re-arm commits atomically with the score change itself.
+    /// </summary>
+    private async Task RearmAuditIfFinalizedAsync(CompetitionCompetitorBase competitor, double newValue)
+    {
+        var contestNav = competitor.Competition?.Contest;
+        if (contestNav?.FinalizedUtc is null || contestNav.AuditedUtc is null)
+        {
+            return;
+        }
+
+        var contest = await _dataContext.Contests
+            .FirstOrDefaultAsync(c => c.Id == contestNav.Id);
+
+        if (contest?.FinalizedUtc is null || contest.AuditedUtc is null)
+        {
+            return;
+        }
+
+        contest.AuditedUtc = null;
+        _logger.LogWarning(
+            "Score input changed on FINALIZED contest — audit re-armed for re-verification. ContestId={ContestId}, NewValue={NewValue}",
+            contest.Id,
+            newValue);
     }
 }

--- a/src/SportsData.Producer/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Producer/DependencyInjection/ServiceRegistration.cs
@@ -448,14 +448,17 @@ namespace SportsData.Producer.DependencyInjection
                     job => job.ExecuteAsync(),
                     Cron.Weekly);
 
-                // Nightly at 06:00 UTC — after all US prime-time games have
-                // ended and any post-game enrichment lag has resolved. Picks
-                // up corruption like the 2026-06-18 Rockies @ Cubs case
-                // (FinalizedUtc + null Winner from a stale-source race).
+                // Every 6 hours (was nightly 06:00): a corrupted weekend
+                // finalization batch (2026-08-30: 14 inverted winners) must
+                // heal within hours — a Thursday-night mistake poisons
+                // Friday's preview payloads. The sweep enqueues cheap
+                // single-row read jobs on the DEFAULT queue, so live-window
+                // work on 00-live always drains first (the #709 priority
+                // split is what makes the in-window firings safe).
                 recurringJobManager.AddOrUpdate<IContestEnrichmentAuditJob>(
                     "ContestEnrichmentAuditJob",
                     job => job.ExecuteAsync(),
-                    "0 6 * * *");
+                    "0 */6 * * *");
             }
 
             if (mode is Sport.FootballNcaa or Sport.FootballNfl or Sport.BaseballMlb)

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Contests/ContestEnrichmentAuditJobTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Contests/ContestEnrichmentAuditJobTests.cs
@@ -21,10 +21,13 @@ public class ContestEnrichmentAuditJobTests : ProducerTestBase<ContestEnrichment
         new(2026, 6, 19, 6, 0, 0, DateTimeKind.Utc);
 
     [Fact]
-    public async Task Execute_EnqueuesOnePerCandidate_OldestFinalizedFirst()
+    public async Task Execute_EnqueuesOnePerCandidate_NewestFinalizedFirst()
     {
         // Three legitimate candidates: FinalizedUtc set, AuditedUtc null.
-        // Seed in non-chronological order to verify ordering is by FinalizedUtc asc.
+        // Seed in non-chronological order to verify ordering is by
+        // FinalizedUtc DESC — fresh finalizations are the user-facing ones
+        // (flipped 2026-09-04 after the 2026-08-30 inverted-winner batch sat
+        // behind the historical backlog).
         var middleId = await SeedContestAsync(finalizedUtc: FixedNow.AddDays(-5));
         var oldestId = await SeedContestAsync(finalizedUtc: FixedNow.AddDays(-30));
         var newestId = await SeedContestAsync(finalizedUtc: FixedNow.AddDays(-1));
@@ -39,7 +42,7 @@ public class ContestEnrichmentAuditJobTests : ProducerTestBase<ContestEnrichment
 
         await sut.ExecuteAsync();
 
-        enqueued.Should().Equal(oldestId, middleId, newestId);
+        enqueued.Should().Equal(newestId, middleId, oldestId);
     }
 
     [Fact]
@@ -85,13 +88,13 @@ public class ContestEnrichmentAuditJobTests : ProducerTestBase<ContestEnrichment
     }
 
     [Fact]
-    public async Task Execute_RespectsBatchSizeCap_EnqueuesOldestFiveHundredOnly()
+    public async Task Execute_RespectsBatchSizeCap_EnqueuesNewestFiveHundredOnly()
     {
         // Regression lock on the BatchSize cap (500) — prevents the first-run
         // historical backlog from enqueuing tens of thousands of Hangfire jobs
         // at once. Seed 600 candidates with monotonically-increasing
-        // FinalizedUtc so the expected enqueue set is the oldest 500, and the
-        // 100 newest get deferred to the next firing.
+        // FinalizedUtc so the expected enqueue set is the NEWEST 500 (fresh
+        // corruption heals first), and the 100 oldest defer to a later firing.
         const int totalCandidates = 600;
         const int expectedBatchSize = 500;
 
@@ -101,7 +104,7 @@ public class ContestEnrichmentAuditJobTests : ProducerTestBase<ContestEnrichment
             var id = await SeedContestAsync(finalizedUtc: FixedNow.AddDays(-totalCandidates + i));
             seededIds.Add(id);
         }
-        var expectedOldest = seededIds.Take(expectedBatchSize).ToList();
+        var expectedNewest = Enumerable.Reverse(seededIds).Take(expectedBatchSize).ToList();
 
         var enqueued = new List<Guid>();
         Mocker.GetMock<IProvideBackgroundJobs>()
@@ -114,7 +117,7 @@ public class ContestEnrichmentAuditJobTests : ProducerTestBase<ContestEnrichment
         await sut.ExecuteAsync();
 
         enqueued.Should().HaveCount(expectedBatchSize);
-        enqueued.Should().Equal(expectedOldest);
+        enqueued.Should().Equal(expectedNewest);
     }
 
     [Fact]

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/EventCompetitionCompetitorScoreDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/EventCompetitionCompetitorScoreDocumentProcessorTests.cs
@@ -24,6 +24,11 @@ namespace SportsData.Producer.Tests.Unit.Application.Documents.Processors.Provid
 [Collection("Sequential")]
 public class EventCompetitionCompetitorScoreDocumentProcessorTests : ProducerTestBase<FootballDataContext>
 {
+    // Fixed seed time: the repo rule bans DateTime.UtcNow, and deterministic
+    // fixtures are the point of the rule.
+    private static readonly DateTime SeedTime =
+        new(2026, 9, 4, 0, 0, 0, DateTimeKind.Utc);
+
     private const string ScoreUrl = "http://sports.core.api.espn.com/v2/sports/football/leagues/college-football/events/401628334/competitions/401628334/competitors/1/score";
 
     private ProcessDocumentCommand CreateCommand(string jsonFile, string? parentId = null)
@@ -140,11 +145,11 @@ public class EventCompetitionCompetitorScoreDocumentProcessorTests : ProducerTes
             SeasonWeekId = Guid.NewGuid(),
             HomeTeamFranchiseSeasonId = Guid.NewGuid(),
             AwayTeamFranchiseSeasonId = Guid.NewGuid(),
-            StartDateUtc = DateTime.UtcNow,
-            FinalizedUtc = DateTime.UtcNow.AddDays(-2),
-            AuditedUtc = DateTime.UtcNow.AddDays(-1),
+            StartDateUtc = SeedTime,
+            FinalizedUtc = SeedTime.AddDays(-2),
+            AuditedUtc = SeedTime.AddDays(-1),
             CreatedBy = Guid.NewGuid(),
-            CreatedUtc = DateTime.UtcNow
+            CreatedUtc = SeedTime
         };
         await FootballDataContext.Contests.AddAsync(contest);
 
@@ -153,7 +158,7 @@ public class EventCompetitionCompetitorScoreDocumentProcessorTests : ProducerTes
             Id = competitionId,
             ContestId = contestId,
             CreatedBy = Guid.NewGuid(),
-            CreatedUtc = DateTime.UtcNow
+            CreatedUtc = SeedTime
         };
         await FootballDataContext.Competitions.AddAsync(competition);
 
@@ -166,7 +171,7 @@ public class EventCompetitionCompetitorScoreDocumentProcessorTests : ProducerTes
             HomeAway = "home",
             Winner = false,
             CreatedBy = Guid.NewGuid(),
-            CreatedUtc = DateTime.UtcNow
+            CreatedUtc = SeedTime
         };
         await FootballDataContext.CompetitionCompetitors.AddAsync(competitor);
         await FootballDataContext.SaveChangesAsync();
@@ -204,9 +209,9 @@ public class EventCompetitionCompetitorScoreDocumentProcessorTests : ProducerTes
             SeasonWeekId = Guid.NewGuid(),
             HomeTeamFranchiseSeasonId = Guid.NewGuid(),
             AwayTeamFranchiseSeasonId = Guid.NewGuid(),
-            StartDateUtc = DateTime.UtcNow,
+            StartDateUtc = SeedTime,
             CreatedBy = Guid.NewGuid(),
-            CreatedUtc = DateTime.UtcNow
+            CreatedUtc = SeedTime
         };
         await FootballDataContext.Contests.AddAsync(contest);
 
@@ -215,7 +220,7 @@ public class EventCompetitionCompetitorScoreDocumentProcessorTests : ProducerTes
             Id = competitionId,
             ContestId = contestId,
             CreatedBy = Guid.NewGuid(),
-            CreatedUtc = DateTime.UtcNow
+            CreatedUtc = SeedTime
         };
         await FootballDataContext.Competitions.AddAsync(competition);
 
@@ -228,7 +233,7 @@ public class EventCompetitionCompetitorScoreDocumentProcessorTests : ProducerTes
             HomeAway = "home",
             Winner = false,
             CreatedBy = Guid.NewGuid(),
-            CreatedUtc = DateTime.UtcNow
+            CreatedUtc = SeedTime
         };
         await FootballDataContext.CompetitionCompetitors.AddAsync(competitor);
         await FootballDataContext.SaveChangesAsync();

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/EventCompetitionCompetitorScoreDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/EventCompetitionCompetitorScoreDocumentProcessorTests.cs
@@ -117,6 +117,134 @@ public class EventCompetitionCompetitorScoreDocumentProcessorTests : ProducerTes
     }
 
     [Fact]
+    public async Task WhenScoreArrivesOnFinalizedAuditedContest_ShouldRearmAudit()
+    {
+        // A score landing AFTER finalization is an input change the one-shot
+        // audit would never re-verify (the 2026-08-30 inverted-winner batch).
+        // The processor must clear AuditedUtc so the sweep re-checks the
+        // derived winner/ATS/O-U against the corrected inputs.
+        var generator = new ExternalRefIdentityGenerator();
+        Mocker.Use<IGenerateExternalRefIdentities>(generator);
+
+        var competitorId = Guid.NewGuid();
+        var competitionId = Guid.NewGuid();
+        var contestId = Guid.NewGuid();
+
+        var contest = new FootballContest
+        {
+            Id = contestId,
+            Name = "Test Contest",
+            ShortName = "Test",
+            Sport = Sport.FootballNcaa,
+            SeasonYear = 2024,
+            SeasonWeekId = Guid.NewGuid(),
+            HomeTeamFranchiseSeasonId = Guid.NewGuid(),
+            AwayTeamFranchiseSeasonId = Guid.NewGuid(),
+            StartDateUtc = DateTime.UtcNow,
+            FinalizedUtc = DateTime.UtcNow.AddDays(-2),
+            AuditedUtc = DateTime.UtcNow.AddDays(-1),
+            CreatedBy = Guid.NewGuid(),
+            CreatedUtc = DateTime.UtcNow
+        };
+        await FootballDataContext.Contests.AddAsync(contest);
+
+        var competition = new FootballCompetition
+        {
+            Id = competitionId,
+            ContestId = contestId,
+            CreatedBy = Guid.NewGuid(),
+            CreatedUtc = DateTime.UtcNow
+        };
+        await FootballDataContext.Competitions.AddAsync(competition);
+
+        var competitor = new FootballCompetitionCompetitor
+        {
+            Id = competitorId,
+            CompetitionId = competitionId,
+            FranchiseSeasonId = Guid.NewGuid(),
+            Order = 1,
+            HomeAway = "home",
+            Winner = false,
+            CreatedBy = Guid.NewGuid(),
+            CreatedUtc = DateTime.UtcNow
+        };
+        await FootballDataContext.CompetitionCompetitors.AddAsync(competitor);
+        await FootballDataContext.SaveChangesAsync();
+
+        var sut = Mocker.CreateInstance<EventCompetitionCompetitorScoreDocumentProcessor<FootballDataContext>>();
+        var json = await LoadJsonTestData("EspnFootballNcaa/EspnFootballNcaaEventCompetitionCompetitorScore.json");
+        var command = CreateCommand(json, competitorId.ToString());
+
+        await sut.ProcessAsync(command);
+
+        var reloaded = await FootballDataContext.Contests.FirstAsync(x => x.Id == contestId);
+        reloaded.AuditedUtc.Should().BeNull("a post-finalization score change must re-arm the audit");
+        reloaded.FinalizedUtc.Should().NotBeNull("re-arming must not unfinalize — the audit decides that on mismatch");
+    }
+
+    [Fact]
+    public async Task WhenScoreArrivesOnUnfinalizedContest_ShouldNotTouchAuditFields()
+    {
+        // Live games stream score updates constantly — the re-arm must only
+        // fire on finalized contests.
+        var generator = new ExternalRefIdentityGenerator();
+        Mocker.Use<IGenerateExternalRefIdentities>(generator);
+
+        var competitorId = Guid.NewGuid();
+        var competitionId = Guid.NewGuid();
+        var contestId = Guid.NewGuid();
+
+        var contest = new FootballContest
+        {
+            Id = contestId,
+            Name = "Test Contest",
+            ShortName = "Test",
+            Sport = Sport.FootballNcaa,
+            SeasonYear = 2024,
+            SeasonWeekId = Guid.NewGuid(),
+            HomeTeamFranchiseSeasonId = Guid.NewGuid(),
+            AwayTeamFranchiseSeasonId = Guid.NewGuid(),
+            StartDateUtc = DateTime.UtcNow,
+            CreatedBy = Guid.NewGuid(),
+            CreatedUtc = DateTime.UtcNow
+        };
+        await FootballDataContext.Contests.AddAsync(contest);
+
+        var competition = new FootballCompetition
+        {
+            Id = competitionId,
+            ContestId = contestId,
+            CreatedBy = Guid.NewGuid(),
+            CreatedUtc = DateTime.UtcNow
+        };
+        await FootballDataContext.Competitions.AddAsync(competition);
+
+        var competitor = new FootballCompetitionCompetitor
+        {
+            Id = competitorId,
+            CompetitionId = competitionId,
+            FranchiseSeasonId = Guid.NewGuid(),
+            Order = 1,
+            HomeAway = "home",
+            Winner = false,
+            CreatedBy = Guid.NewGuid(),
+            CreatedUtc = DateTime.UtcNow
+        };
+        await FootballDataContext.CompetitionCompetitors.AddAsync(competitor);
+        await FootballDataContext.SaveChangesAsync();
+
+        var sut = Mocker.CreateInstance<EventCompetitionCompetitorScoreDocumentProcessor<FootballDataContext>>();
+        var json = await LoadJsonTestData("EspnFootballNcaa/EspnFootballNcaaEventCompetitionCompetitorScore.json");
+        var command = CreateCommand(json, competitorId.ToString());
+
+        await sut.ProcessAsync(command);
+
+        var reloaded = await FootballDataContext.Contests.FirstAsync(x => x.Id == contestId);
+        reloaded.FinalizedUtc.Should().BeNull();
+        reloaded.AuditedUtc.Should().BeNull();
+    }
+
+    [Fact]
     public async Task WhenParentIdIsInvalid_ShouldLogErrorAndReturn()
     {
         // Arrange


### PR DESCRIPTION
Hardens the contest-enrichment audit after the 2026-08-30 incident: a weekend finalization batch left **14 NCAA contests with inverted winners** (scores attributed to swapped sides at derivation; later re-sourcing corrected the scores, but winner/ATS/O-U are only derived at finalization and were never revisited). The Idaho @ Cal Poly case surfaced it via a `W | 34-38` mini-schedule row and a corrupted Idaho @ Utah preview payload. The audit machinery would have caught and healed every one of these — it just couldn't get there. Three changes close the loop:

1. **Newest-first sweep** — the candidate scan ordered `FinalizedUtc ASC` and was still draining the 2008+ historical backlog at 500/night; fresh corruption (the user-facing kind) sat at the back of a weeks-long line. Now `DESC`: the previous night's games are audited in the next firing; the backlog still drains fully from the other end.
2. **6-hourly cadence** (was nightly 06:00) — a Thursday-night mistake must not survive into Friday's preview generation. Audit fan-out jobs ride the default Hangfire queue, so the #709 `00-live` priority split keeps in-window firings harmless to live processing.
3. **Audit re-arm on input change** — the audit is one-shot (`AuditedUtc` stamp) and a score correction arriving after a passed audit was invisible forever. The score document processor now clears `AuditedUtc` when a score changes or newly lands on a **finalized** contest. The competitor is loaded `AsNoTracking`, so the untracked navigation only gates a tracked fetch: live-game score updates (contest not finalized) cost zero additional queries, and the re-arm commits atomically with the score write.

Resulting self-heal chain, no operator involved: input correction → re-arm → sweep (≤6h) → mismatch → clear `FinalizedUtc` → re-enrich → `ContestFinalized` republished → picks re-scored.

The 14 damaged rows are being healed manually via the existing reenrich endpoint (they predate the re-arm); the 2014–2019 `null-winner` backfill rows are already in the audit's candidate set and will drain with the sweep.

Tests: sweep ordering/batch-cap tests updated to the new semantics; two new processor tests (re-arm on finalized+audited contest; untouched on unfinalized). Producer suite 644 passed / 18 skipped (pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnJySMvfUPeQSMufNNcKSK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Audit processing now prioritizes the most recently finalized contests.
  * Finalized contests are rechecked when updated competitor scores arrive.
  * Audit processing runs every six hours for faster verification updates.

* **Tests**
  * Added coverage for prioritization, batch limits, and score updates affecting finalized and unfinalized contests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->