### PR TITLE
fix(producer): relocate stale home/away occupant on competitor re-designation

### DIFF
--- a/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Common/EventCompetitionCompetitorDocumentProcessorBase.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Common/EventCompetitionCompetitorDocumentProcessorBase.cs
@@ -143,6 +143,49 @@ public abstract class EventCompetitionCompetitorDocumentProcessorBase<TDataConte
                 x.ExternalIds.Any(z => z.SourceUrlHash == command.UrlHash &&
                                        z.Provider == command.SourceDataProvider));
 
+        // ESPN home/away re-designation swaps sides on BOTH competitors, but
+        // documents arrive one at a time — the first writer collides with the
+        // STALE occupant of its new side under the (CompetitionId, HomeAway)
+        // unique index (2026-08-29 Howard @ Alabama A&M: six Hangfire jobs
+        // retrying into the same stale row; the stale side also poisoned
+        // score-side attribution downstream). A competition has exactly two
+        // competitors, so the occupant of our target side belongs on the
+        // other one: relocate it FIRST, in its own SaveChanges, so the slot
+        // is free before our write. Each step is idempotent under Hangfire
+        // retries — a crash at any point converges on reprocessing.
+        var desiredSide = dto.HomeAway?.Trim().ToLowerInvariant();
+        if (desiredSide is "home" or "away")
+        {
+            var occupant = await _dataContext.CompetitionCompetitors
+                .FirstOrDefaultAsync(x =>
+                    x.CompetitionId == competitionId
+                    && x.HomeAway == desiredSide
+                    && x.FranchiseSeasonId != franchiseSeasonId.Value);
+
+            if (occupant is not null)
+            {
+                var otherSide = desiredSide == "home" ? "away" : "home";
+
+                // Full-swap case: OUR row currently holds the other side —
+                // park it out of the way first or the occupant's relocation
+                // collides with it. ProcessUpdate below writes the final side.
+                if (entity is not null
+                    && string.Equals(entity.HomeAway, otherSide, StringComparison.OrdinalIgnoreCase))
+                {
+                    entity.HomeAway = "swap-pending";
+                    await _dataContext.SaveChangesAsync();
+                }
+
+                _logger.LogWarning(
+                    "Home/away re-designation: relocating stale occupant of side '{Side}' to '{OtherSide}'. " +
+                    "CompetitionId={CompetitionId}, OccupantId={OccupantId}, OccupantFranchiseSeasonId={OccupantFranchiseSeasonId}",
+                    desiredSide, otherSide, competitionId, occupant.Id, occupant.FranchiseSeasonId);
+
+                occupant.HomeAway = otherSide;
+                await _dataContext.SaveChangesAsync();
+            }
+        }
+
         if (entity is null)
         {
             _logger.LogInformation("Processing new CompetitionCompetitor entity. Ref={Ref}", dto.Ref);

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Common/EventCompetitionCompetitorDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Common/EventCompetitionCompetitorDocumentProcessorTests.cs
@@ -148,5 +148,226 @@ namespace SportsData.Producer.Tests.Unit.Application.Documents.Processors.Provid
             saved.Order.Should().Be(0);
             saved.Winner.Should().BeFalse();
         }
+
+        [Fact]
+        public async Task WhenNewCompetitorClaimsOccupiedSide_ShouldRelocateStaleOccupant()
+        {
+            // The 2026-08-29 Howard @ Alabama A&M jam: ESPN re-designated
+            // home/away, our DB held the OLD home occupant, and the new
+            // competitor's insert collided with the (CompetitionId, HomeAway)
+            // unique index forever. The occupant must be relocated to the
+            // vacant opposite side before the insert.
+
+            var generator = new ExternalRefIdentityGenerator();
+            Mocker.Use<IGenerateExternalRefIdentities>(generator);
+            var sut = Mocker.CreateInstance<FootballEventCompetitionCompetitorDocumentProcessor<FootballDataContext>>();
+
+            var json = await LoadJsonTestData("EspnFootballNcaa/EspnFootballNcaaEventCompetitionCompetitor.json");
+            var dto = json.FromJson<EspnEventCompetitionCompetitorDto>();
+
+            var competitorIdentity = generator.Generate(dto!.Ref);
+            var teamIdentity = generator.Generate(dto.Team.Ref);
+
+            var competitionId = Guid.NewGuid();
+            await FootballDataContext.Competitions.AddAsync(new FootballCompetition
+            {
+                Id = competitionId,
+                ContestId = Guid.NewGuid(),
+                Date = FixedTestNow,
+                CreatedUtc = FixedTestNow,
+                CreatedBy = Guid.NewGuid()
+            });
+
+            var franchiseSeasonId = Guid.NewGuid();
+            await FootballDataContext.FranchiseSeasons.AddAsync(new FranchiseSeason
+            {
+                Id = franchiseSeasonId,
+                Abbreviation = "TST",
+                DisplayName = "Test FS",
+                DisplayNameShort = "TFS",
+                Slug = teamIdentity.CanonicalId.ToString(),
+                Location = "Test Location",
+                Name = "Test Franchise Season",
+                ColorCodeHex = "#FFFFFF",
+                ColorCodeAltHex = "#000000",
+                IsActive = true,
+                SeasonYear = 2024,
+                FranchiseId = Guid.NewGuid(),
+                CreatedUtc = FixedTestNow,
+                CreatedBy = Guid.NewGuid(),
+                ExternalIds =
+                [
+                    new FranchiseSeasonExternalId
+                    {
+                        Id = Guid.NewGuid(),
+                        Provider = SourceDataProvider.Espn,
+                        SourceUrl = teamIdentity.CleanUrl,
+                        SourceUrlHash = teamIdentity.UrlHash,
+                        Value = teamIdentity.UrlHash
+                    }
+                ]
+            });
+
+            // The STALE occupant: a different franchise's row holding the
+            // side the document claims (fixture: home). No row exists for
+            // the document's own competitor.
+            var occupantId = Guid.NewGuid();
+            await FootballDataContext.CompetitionCompetitors.AddAsync(new FootballCompetitionCompetitor
+            {
+                Id = occupantId,
+                CompetitionId = competitionId,
+                FranchiseSeasonId = Guid.NewGuid(),
+                HomeAway = "home",
+                Order = 0,
+                Winner = false,
+                CreatedUtc = FixedTestNow,
+                CreatedBy = Guid.NewGuid()
+            });
+            await FootballDataContext.SaveChangesAsync();
+
+            var command = Fixture.Build<ProcessDocumentCommand>()
+                .With(x => x.Document, json)
+                .With(x => x.DocumentType, DocumentType.EventCompetitionCompetitor)
+                .With(x => x.SeasonYear, 2024)
+                .With(x => x.SourceDataProvider, SourceDataProvider.Espn)
+                .With(x => x.Sport, Sport.FootballNcaa)
+                .With(x => x.ParentId, competitionId.ToString())
+                .With(x => x.UrlHash, competitorIdentity.UrlHash)
+                .OmitAutoProperties()
+                .Create();
+
+            await sut.ProcessAsync(command);
+
+            var occupant = await FootballDataContext.CompetitionCompetitors
+                .AsNoTracking()
+                .FirstAsync(x => x.Id == occupantId);
+            occupant.HomeAway.Should().Be("away", "the stale occupant belongs on the vacated side");
+
+            var created = await FootballDataContext.CompetitionCompetitors
+                .AsNoTracking()
+                .FirstAsync(x => x.Id == competitorIdentity.CanonicalId);
+            created.HomeAway.Should().Be("home");
+        }
+
+        [Fact]
+        public async Task WhenBothCompetitorsSwapSides_ShouldSwapWithoutCollision()
+        {
+            // Full re-designation: OUR row holds away, the other franchise's
+            // row holds home, and the document says we are now home. Both
+            // rows must end swapped — the parking step keeps the relocation
+            // from colliding with our own row.
+
+            var generator = new ExternalRefIdentityGenerator();
+            Mocker.Use<IGenerateExternalRefIdentities>(generator);
+            var sut = Mocker.CreateInstance<FootballEventCompetitionCompetitorDocumentProcessor<FootballDataContext>>();
+
+            var json = await LoadJsonTestData("EspnFootballNcaa/EspnFootballNcaaEventCompetitionCompetitor.json");
+            var dto = json.FromJson<EspnEventCompetitionCompetitorDto>();
+
+            var competitorIdentity = generator.Generate(dto!.Ref);
+            var teamIdentity = generator.Generate(dto.Team.Ref);
+
+            var competitionId = Guid.NewGuid();
+            await FootballDataContext.Competitions.AddAsync(new FootballCompetition
+            {
+                Id = competitionId,
+                ContestId = Guid.NewGuid(),
+                Date = FixedTestNow,
+                CreatedUtc = FixedTestNow,
+                CreatedBy = Guid.NewGuid()
+            });
+
+            var franchiseSeasonId = Guid.NewGuid();
+            await FootballDataContext.FranchiseSeasons.AddAsync(new FranchiseSeason
+            {
+                Id = franchiseSeasonId,
+                Abbreviation = "TST",
+                DisplayName = "Test FS",
+                DisplayNameShort = "TFS",
+                Slug = teamIdentity.CanonicalId.ToString(),
+                Location = "Test Location",
+                Name = "Test Franchise Season",
+                ColorCodeHex = "#FFFFFF",
+                ColorCodeAltHex = "#000000",
+                IsActive = true,
+                SeasonYear = 2024,
+                FranchiseId = Guid.NewGuid(),
+                CreatedUtc = FixedTestNow,
+                CreatedBy = Guid.NewGuid(),
+                ExternalIds =
+                [
+                    new FranchiseSeasonExternalId
+                    {
+                        Id = Guid.NewGuid(),
+                        Provider = SourceDataProvider.Espn,
+                        SourceUrl = teamIdentity.CleanUrl,
+                        SourceUrlHash = teamIdentity.UrlHash,
+                        Value = teamIdentity.UrlHash
+                    }
+                ]
+            });
+
+            // OUR row, keyed by the document's UrlHash, currently away.
+            await FootballDataContext.CompetitionCompetitors.AddAsync(new FootballCompetitionCompetitor
+            {
+                Id = competitorIdentity.CanonicalId,
+                CompetitionId = competitionId,
+                FranchiseSeasonId = franchiseSeasonId,
+                HomeAway = "away",
+                Order = 0,
+                Winner = false,
+                CreatedUtc = FixedTestNow,
+                CreatedBy = Guid.NewGuid(),
+                ExternalIds =
+                [
+                    new CompetitionCompetitorExternalId
+                    {
+                        Id = Guid.NewGuid(),
+                        Provider = SourceDataProvider.Espn,
+                        SourceUrl = competitorIdentity.CleanUrl,
+                        SourceUrlHash = competitorIdentity.UrlHash,
+                        Value = competitorIdentity.UrlHash
+                    }
+                ]
+            });
+
+            // The other franchise's row, currently home.
+            var occupantId = Guid.NewGuid();
+            await FootballDataContext.CompetitionCompetitors.AddAsync(new FootballCompetitionCompetitor
+            {
+                Id = occupantId,
+                CompetitionId = competitionId,
+                FranchiseSeasonId = Guid.NewGuid(),
+                HomeAway = "home",
+                Order = 1,
+                Winner = false,
+                CreatedUtc = FixedTestNow,
+                CreatedBy = Guid.NewGuid()
+            });
+            await FootballDataContext.SaveChangesAsync();
+
+            var command = Fixture.Build<ProcessDocumentCommand>()
+                .With(x => x.Document, json)
+                .With(x => x.DocumentType, DocumentType.EventCompetitionCompetitor)
+                .With(x => x.SeasonYear, 2024)
+                .With(x => x.SourceDataProvider, SourceDataProvider.Espn)
+                .With(x => x.Sport, Sport.FootballNcaa)
+                .With(x => x.ParentId, competitionId.ToString())
+                .With(x => x.UrlHash, competitorIdentity.UrlHash)
+                .OmitAutoProperties()
+                .Create();
+
+            await sut.ProcessAsync(command);
+
+            var ours = await FootballDataContext.CompetitionCompetitors
+                .AsNoTracking()
+                .FirstAsync(x => x.Id == competitorIdentity.CanonicalId);
+            ours.HomeAway.Should().Be("home");
+
+            var occupant = await FootballDataContext.CompetitionCompetitors
+                .AsNoTracking()
+                .FirstAsync(x => x.Id == occupantId);
+            occupant.HomeAway.Should().Be("away");
+        }
     }
 }


### PR DESCRIPTION
Root-cause fix for the six jammed Hangfire retry jobs (and the deeper layer of the 2026-08-30 winner-corruption incident).

**The jam**: ESPN re-designated home/away on Howard @ Alabama A&M (event 401867935 — verified against ESPN's live API: competitor 2010/Alabama A&M is now `home`). Our `CompetitionCompetitor` table still held the original occupant on that side, so the incoming competitor document's write violated `IX_CompetitionCompetitor_CompetitionId_HomeAway` on every attempt. The processor's existing duplicate-insert recovery correctly refused to swallow it (the attempted row genuinely isn't in the DB) — but nothing could ever resolve it, because a two-row side swap can't happen one document at a time under a unique index.

**The fix**: pre-flight occupant relocation. A competition has exactly two competitors, so whoever holds the document's claimed side belongs on the other one — relocate it first in its own `SaveChanges`, with a parking step for the full-swap case (our own row holds the counterpart side and would collide with the relocation). Each step is idempotent under Hangfire retries: a crash at any point converges on reprocessing. Hot path cost: one indexed point-lookup per document; extra writes only on actual conflicts.

**Why this matters beyond the jam**: competitor `HomeAway` is what score-side attribution hangs off. The stale sides are exactly why two of the fourteen 2026 probe rows had CCS scores swapped relative to Contest columns — this fixes that class at the root. Scores stay attached to their franchise's row through a relocation, which is the correct semantics.

**Operator follow-up after deploy**: the six retry jobs should succeed on their next attempt (or requeue them); then reenrich the Howard @ Alabama A&M and Alabama State @ Southern contests once their competitor docs have reprocessed — this morning's reenrich of those two derived from the stale sides.

Tests: stale-occupant insert case and full-swap update case, plus the whole Producer suite 646/646 (18 pre-existing skips).

Related: #717 (audit hardening — same incident, the detection layer; this PR is the prevention layer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnJySMvfUPeQSMufNNcKSK