### PR TITLE
fix(producer): swap parking value must fit HomeAway varchar(10)

### DIFF
--- a/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Common/EventCompetitionCompetitorDocumentProcessorBase.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Common/EventCompetitionCompetitorDocumentProcessorBase.cs
@@ -24,6 +24,14 @@ namespace SportsData.Producer.Application.Documents.Processors.Providers.Espn.Co
 public abstract class EventCompetitionCompetitorDocumentProcessorBase<TDataContext> : DocumentProcessorBase<TDataContext>
     where TDataContext : TeamSportDataContext
 {
+    /// <summary>
+    /// Transient HomeAway value parking OUR row during a full home/away
+    /// swap (see the re-designation block in ProcessInternal). MUST fit
+    /// the column's varchar(10) — the PostgresException the length test
+    /// pins is exactly what a longer value did in production.
+    /// </summary>
+    public const string SwapParkingValue = "swap";
+
     protected EventCompetitionCompetitorDocumentProcessorBase(
         ILogger logger,
         TDataContext dataContext,
@@ -169,10 +177,14 @@ public abstract class EventCompetitionCompetitorDocumentProcessorBase<TDataConte
                 // Full-swap case: OUR row currently holds the other side —
                 // park it out of the way first or the occupant's relocation
                 // collides with it. ProcessUpdate below writes the final side.
+                // Parking value MUST fit HomeAway's varchar(10) — the first
+                // deploy used "swap-pending" (12 chars) and every full-swap
+                // doc failed with 22001; InMemory tests can't catch length
+                // violations, so the length is asserted in the test suite.
                 if (entity is not null
                     && string.Equals(entity.HomeAway, otherSide, StringComparison.OrdinalIgnoreCase))
                 {
-                    entity.HomeAway = "swap-pending";
+                    entity.HomeAway = SwapParkingValue;
                     await _dataContext.SaveChangesAsync();
                 }
 

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Common/EventCompetitionCompetitorDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Common/EventCompetitionCompetitorDocumentProcessorTests.cs
@@ -9,6 +9,7 @@ using SportsData.Core.Common.Hashing;
 using SportsData.Core.Extensions;
 using SportsData.Core.Infrastructure.DataSources.Espn.Dtos.Common;
 using SportsData.Producer.Application.Documents.Processors.Commands;
+using SportsData.Producer.Application.Documents.Processors.Providers.Espn.Common;
 using SportsData.Producer.Application.Documents.Processors.Providers.Espn.Football;
 using SportsData.Producer.Infrastructure.Data.Entities;
 using SportsData.Producer.Infrastructure.Data.Football;
@@ -147,6 +148,17 @@ namespace SportsData.Producer.Tests.Unit.Application.Documents.Processors.Provid
             saved.HomeAway.Should().Be("home");
             saved.Order.Should().Be(0);
             saved.Winner.Should().BeFalse();
+        }
+
+        [Fact]
+        public void SwapParkingValue_FitsHomeAwayColumn()
+        {
+            // HomeAway is varchar(10) and the InMemory provider does NOT
+            // enforce column lengths — the first deploy shipped a 12-char
+            // parking value and every full-swap document failed with
+            // Postgres 22001. This pins the length where the provider can't.
+            EventCompetitionCompetitorDocumentProcessorBase<FootballDataContext>
+                .SwapParkingValue.Length.Should().BeLessThanOrEqualTo(10);
         }
 
         [Fact]


### PR DESCRIPTION
Hotfix for the post-#718 production error: the full-swap parking step wrote `"swap-pending"` (12 chars) into `HomeAway varchar(10)` — Postgres `22001: value too long` on every full-swap document (the exact Howard-class docs the fix exists for). My defect: the InMemory test provider does not enforce column lengths, so both new tests passed over it.

- Parking value is now `SwapParkingValue = "swap"` (public const).
- New test pins `SwapParkingValue.Length <= 10` — asserting in code what the provider can't enforce, with the incident documented at both sites.

Affected Hangfire jobs will succeed on retry once deployed; no data was corrupted (the write failed atomically).

13/13 competitor-processor tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnJySMvfUPeQSMufNNcKSK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed full home/away swaps that could fail when temporarily storing an entity due to an oversized parking value.
  - Swaps now complete successfully using a database-compatible temporary value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->