### PR TITLE
fix(web,mobile): no Game Preview link on scheduled games

### DIFF
--- a/src/UI/sd-mobile/src/components/features/games/GameStatus.tsx
+++ b/src/UI/sd-mobile/src/components/features/games/GameStatus.tsx
@@ -117,7 +117,11 @@ export function GameStatus({ matchup, leagueSport, onPressGameDetail, pickType }
             {cityState}
           </Text>
         ) : null}
-        <OverviewLink label="Game Preview" onPress={onPressGameDetail} theme={theme} />
+        {/* No Contest Overview link on scheduled games (removed 2026-09-04,
+            owner call, in step with web): pre-kickoff the overview is
+            essentially empty, so "Game Preview" led nowhere useful. The
+            live/final branches keep their Box Score links — that's when
+            the overview has content. */}
       </View>
     );
   }
@@ -249,9 +253,10 @@ export function GameStatus({ matchup, leagueSport, onPressGameDetail, pickType }
 // TouchableOpacity (which gave no visual hint that it was tappable).
 //
 // Per-state labels live at the call sites:
-//   Scheduled  → "Game Preview"
 //   InProgress → "Live Box Score"
 //   Final      → "Box Score"
+// (Scheduled games render no link since 2026-09-04 — the overview is
+// essentially empty pre-kickoff.)
 
 export function OverviewLink({
   label,

--- a/src/UI/sd-ui/src/components/matchups/GameStatus.jsx
+++ b/src/UI/sd-ui/src/components/matchups/GameStatus.jsx
@@ -246,28 +246,11 @@ function GameStatus({
         {broadcasts && <div>{formatBroadcasts(broadcasts)}</div>}
         <div>{venue} | {location}</div>
       </div>
-      {/* Bottom-of-status affordance for "open the Contest Overview" —
-          mirrors mobile's OverviewLink ("Game Preview ›" on scheduled
-          games). Replaces the old webcam icon + "View" block, which was
-          an internal marker for stream-scheduled games but read to users
-          like a watch-the-game link. Renders for every scheduled game
-          with a contestId, matching mobile. The explicit STATUS_SCHEDULED
-          check keeps the link out of this branch's other role as the
-          defensive fallback for unrecognized status strings (mobile
-          renders those as a bare label with no link). */}
-      {contestId && status === 'STATUS_SCHEDULED' && (
-        <div className="game-preview-link-row">
-          <Link
-            to={contestLink(contestId, sport, league)}
-            className="game-preview-link"
-            target="_blank"
-            rel="noopener noreferrer"
-            aria-label={`Game preview: ${awayShort ?? 'Away'} at ${homeShort ?? 'Home'}${gameTime ? `, ${gameTime}` : ''}`}
-          >
-            Game Preview ›
-          </Link>
-        </div>
-      )}
+      {/* No Contest Overview link on scheduled games (removed 2026-09-04,
+          owner call): pre-kickoff the overview is essentially empty, so
+          the "Game Preview ›" affordance led nowhere useful. The gamecast
+          link in the in-progress block above is the overview's real entry
+          point once there is something to see. */}
     </>
   );
 }

--- a/src/UI/sd-ui/src/components/matchups/MatchupCard.css
+++ b/src/UI/sd-ui/src/components/matchups/MatchupCard.css
@@ -314,33 +314,6 @@
   color: var(--accent);
 }
 
-/* "Game Preview ›" link below the scheduled-game time/venue block.
-   Mirrors mobile's OverviewLink affordance (small accent-colored text
-   link). Replaced the old webcam-icon "View" block, which implied a
-   watchable stream. */
-.game-preview-link-row {
-  text-align: center;
-  margin-top: 4px;
-}
-
-.game-preview-link {
-  font-size: 0.75rem;
-  font-weight: 600;
-  color: var(--accent);
-  text-decoration: none;
-  transition: opacity 0.2s ease;
-}
-
-.game-preview-link:hover {
-  opacity: 0.8;
-  text-decoration: underline;
-}
-
-.game-preview-link:focus-visible {
-  outline: 2px solid currentcolor;
-  outline-offset: 2px;
-}
-
 .result-label {
   font-size: 0.75rem;
   font-weight: 600;


### PR DESCRIPTION
Operator request: the "Game Preview ›" link on scheduled games (web `GameStatus.jsx` in MatchupCard; mobile `GameStatus.tsx`'s scheduled-branch `OverviewLink`) opened a Contest Overview that is essentially empty before kickoff. Removed on both surfaces.

- The link only ever rendered for `STATUS_SCHEDULED`, so removal is the condition — live/final branches keep their gamecast / Box Score links, which is when the overview has content.
- Web: orphaned `.game-preview-link*` CSS removed; `Link`/`contestLink` imports remain (used by the in-progress gamecast link).
- Mobile: `OverviewLink` component untouched (live/final call sites remain); its doc comment updated. Mobile change rides the next EAS/OTA per the batching convention.

ESLint clean, CRA build clean, mobile typecheck clean. No existing test coverage on either component.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnJySMvfUPeQSMufNNcKSK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Changes**
  * Scheduled games no longer display the “Game Preview” overview link.
  * Overview-link documentation now clarifies that links are available only for live and final games.
  * Removed styling associated with the scheduled-game preview link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->