### PR TITLE
feat(api,web): model-lab matrix grades picks against actuals

### DIFF
--- a/src/SportsData.Api/Application/Admin/Queries/GetModelLabMatrix/GetModelLabMatrixQueryHandler.cs
+++ b/src/SportsData.Api/Application/Admin/Queries/GetModelLabMatrix/GetModelLabMatrixQueryHandler.cs
@@ -124,6 +124,9 @@ public class GetModelLabMatrixQueryHandler : IGetModelLabMatrixQueryHandler
                 HomeShort = m.HomeShort,
                 HomeFranchiseSeasonId = m.HomeFranchiseSeasonId,
                 Spread = m.SpreadCurrent,
+                IsFinal = ContestStatusValues.IsCompleted(m.Status),
+                ActualWinnerId = m.WinnerFranchiseSeasonId,
+                ActualSpreadWinnerId = m.SpreadWinnerFranchiseSeasonId,
                 Cells = latestCells[m.ContestId]
                     .Select(c => new ModelLabMatrixDto.MatrixCellDto
                     {

--- a/src/SportsData.Api/Application/Admin/Queries/GetModelLabMatrix/ModelLabMatrixDto.cs
+++ b/src/SportsData.Api/Application/Admin/Queries/GetModelLabMatrix/ModelLabMatrixDto.cs
@@ -43,6 +43,15 @@ public class ModelLabMatrixDto
         /// <summary>Current line, HOME-relative (negative = home favored, e.g. -22.5); null when no odds. The team name would be redundant — the spread is always the home team's.</summary>
         public double? Spread { get; set; }
 
+        /// <summary>True once the contest is completed — the gate for grading picks. Unfinalized games render ungraded.</summary>
+        public bool IsFinal { get; set; }
+
+        /// <summary>Actual straight-up winner (FranchiseSeasonId); null until final (or on a tie).</summary>
+        public Guid? ActualWinnerId { get; set; }
+
+        /// <summary>Actual ATS winner (FranchiseSeasonId); null until final — and null on a PUSH, which grades nobody.</summary>
+        public Guid? ActualSpreadWinnerId { get; set; }
+
         /// <summary>Latest experiment per model; a model absent here has no run yet.</summary>
         public List<MatrixCellDto> Cells { get; set; } = [];
     }

--- a/src/UI/sd-ui/src/components/admin/AdminModelLabPage.jsx
+++ b/src/UI/sd-ui/src/components/admin/AdminModelLabPage.jsx
@@ -206,8 +206,39 @@ export default function AdminModelLabPage() {
     }
   };
 
-  const models = matrix?.models ?? [];
-  const contests = matrix?.contests ?? [];
+  const models = useMemo(() => matrix?.models ?? [], [matrix]);
+  const contests = useMemo(() => matrix?.contests ?? [], [matrix]);
+
+  // Season-to-date records for the footer: per model and for the
+  // consensus column, X/Y = correct picks / graded picks. A pick is
+  // GRADED only when the game is final, the model actually picked, and
+  // an actual exists (ATS pushes grade nobody). Abstentions and
+  // not-yet-run cells never count against a model here — cost of
+  // abstaining is a Phase-4 scoring question, not a display one.
+  const records = useMemo(() => {
+    const perModel = {};
+    const consensus = { su: [0, 0], ats: [0, 0] };
+    const tally = (pair, grade) => {
+      if (!grade) return;
+      pair[1] += 1;
+      if (grade === 'correct') pair[0] += 1;
+    };
+    for (const c of contests) {
+      const cellBy = {};
+      for (const cell of c.cells ?? []) cellBy[String(cell.modelId).toLowerCase()] = cell;
+      for (const m of models) {
+        const cell = cellBy[String(m.id).toLowerCase()];
+        const rec = (perModel[m.id] ??= { su: [0, 0], ats: [0, 0] });
+        tally(rec.su, gradePick(cell?.predictedStraightUpWinnerId, c.actualWinnerId, c.isFinal));
+        tally(rec.ats, gradePick(cell?.predictedSpreadWinnerId, c.actualSpreadWinnerId, c.isFinal));
+      }
+      const suC = consensusOf(models.map(m => cellBy[String(m.id).toLowerCase()]?.predictedStraightUpWinnerId ?? null));
+      const atsC = consensusOf(models.map(m => cellBy[String(m.id).toLowerCase()]?.predictedSpreadWinnerId ?? null));
+      tally(consensus.su, gradePick(suC, c.actualWinnerId, c.isFinal));
+      tally(consensus.ats, gradePick(atsC, c.actualSpreadWinnerId, c.isFinal));
+    }
+    return { perModel, consensus };
+  }, [contests, models]);
 
   return (
     <div className="admin-page">
@@ -307,6 +338,24 @@ export default function AdminModelLabPage() {
                   />
                 ))}
               </tbody>
+              <tfoot>
+                <tr>
+                  <td style={footerStyle}>Record - SU</td>
+                  {models.map(m => (
+                    <td key={m.id} style={footerStyle}>{formatRecord(records.perModel[m.id]?.su)}</td>
+                  ))}
+                  <td style={footerStyle}>{formatRecord(records.consensus.su)}</td>
+                  <td style={footerStyle} />
+                </tr>
+                <tr>
+                  <td style={footerStyle}>Record - ATS</td>
+                  {models.map(m => (
+                    <td key={m.id} style={footerStyle}>{formatRecord(records.perModel[m.id]?.ats)}</td>
+                  ))}
+                  <td style={footerStyle}>{formatRecord(records.consensus.ats)}</td>
+                  <td style={footerStyle} />
+                </tr>
+              </tfoot>
             </table>
           </div>
         )}
@@ -328,6 +377,13 @@ const cellStyle = {
   whiteSpace: 'nowrap',
 };
 
+const footerStyle = {
+  padding: '8px 10px',
+  borderTop: '2px solid var(--border-primary)',
+  whiteSpace: 'nowrap',
+  fontWeight: 700,
+};
+
 /** Majority of the picks cast; needs at least 2 votes and no tie. */
 /**
  * Home-relative line as " (-22.5)" / " (+3.5)" / " (PK)" — no team name,
@@ -337,6 +393,34 @@ function formatSpread(spread) {
   if (spread == null) return '';
   if (spread === 0) return ' (PK)';
   return ` (${spread > 0 ? '+' : ''}${spread})`;
+}
+
+/**
+ * 'correct' | 'incorrect' | null. Null = ungraded: game not final, no
+ * pick, or no actual to grade against (an ATS PUSH leaves
+ * actualSpreadWinnerId null on a finalized game — a push grades nobody).
+ */
+function gradePick(pickId, actualId, isFinal) {
+  if (!isFinal || !pickId || !actualId) return null;
+  return String(pickId).toLowerCase() === String(actualId).toLowerCase()
+    ? 'correct'
+    : 'incorrect';
+}
+
+const GRADE_STYLES = {
+  correct: {
+    backgroundColor: 'rgba(39, 174, 96, 0.18)',
+    color: 'var(--color-success, #27ae60)',
+  },
+  incorrect: {
+    backgroundColor: 'rgba(192, 57, 43, 0.18)',
+    color: 'var(--color-danger, #c0392b)',
+  },
+};
+
+function formatRecord(pair) {
+  if (!pair || pair[1] === 0) return '—';
+  return `${pair[0]}/${pair[1]}`;
 }
 
 function consensusOf(picks) {
@@ -393,6 +477,11 @@ function ContestRows({ contest, models, queued, onGenerateCell, onRunPanel }) {
       );
     }
 
+    const actualId = pickField === 'predictedStraightUpWinnerId'
+      ? contest.actualWinnerId
+      : contest.actualSpreadWinnerId;
+    const grade = gradePick(cell[pickField], actualId, contest.isFinal);
+
     const pick = teamFor(cell[pickField]);
     if (!pick) {
       // No pick + recorded problems = the run FAILED (parse error, bad
@@ -428,7 +517,7 @@ function ContestRows({ contest, models, queued, onGenerateCell, onRunPanel }) {
       );
     }
     return (
-      <td key={model.id} style={{ ...cellStyle, fontWeight: 600 }}>
+      <td key={model.id} style={{ ...cellStyle, fontWeight: 600, ...(grade ? GRADE_STYLES[grade] : null) }}>
         {pick}
         {cell.problems && (
           <span
@@ -447,6 +536,9 @@ function ContestRows({ contest, models, queued, onGenerateCell, onRunPanel }) {
   const atsConsensus = consensusOf(models.map(m =>
     cellByModel[String(m.id).toLowerCase()]?.predictedSpreadWinnerId ?? null));
 
+  const suGrade = gradePick(suConsensus, contest.actualWinnerId, contest.isFinal);
+  const atsGrade = gradePick(atsConsensus, contest.actualSpreadWinnerId, contest.isFinal);
+
   const hasHoles = models.some(m => !cellByModel[String(m.id).toLowerCase()]);
 
   return (
@@ -454,7 +546,9 @@ function ContestRows({ contest, models, queued, onGenerateCell, onRunPanel }) {
       <tr>
         <td style={{ ...cellStyle, fontWeight: 600 }}>{label} - SU</td>
         {models.map(m => renderPickCell(m, 'predictedStraightUpWinnerId'))}
-        <td style={{ ...cellStyle, fontWeight: 700 }}>{suConsensus ? teamFor(suConsensus) : '-'}</td>
+        <td style={{ ...cellStyle, fontWeight: 700, ...(suGrade ? GRADE_STYLES[suGrade] : null) }}>
+          {suConsensus ? teamFor(suConsensus) : '-'}
+        </td>
         <td rowSpan={2} style={{ ...cellStyle, verticalAlign: 'middle' }}>
           {hasHoles && !rowPanelQueued && (
             <button
@@ -474,7 +568,9 @@ function ContestRows({ contest, models, queued, onGenerateCell, onRunPanel }) {
           {label} - ATS{formatSpread(contest.spread)}
         </td>
         {models.map(m => renderPickCell(m, 'predictedSpreadWinnerId'))}
-        <td style={{ ...cellStyle, fontWeight: 700 }}>{atsConsensus ? teamFor(atsConsensus) : '—'}</td>
+        <td style={{ ...cellStyle, fontWeight: 700, ...(atsGrade ? GRADE_STYLES[atsGrade] : null) }}>
+          {atsConsensus ? teamFor(atsConsensus) : '—'}
+        </td>
       </tr>
     </>
   );

--- a/src/UI/sd-ui/src/components/admin/AdminModelLabPage.jsx
+++ b/src/UI/sd-ui/src/components/admin/AdminModelLabPage.jsx
@@ -209,8 +209,10 @@ export default function AdminModelLabPage() {
   const models = useMemo(() => matrix?.models ?? [], [matrix]);
   const contests = useMemo(() => matrix?.contests ?? [], [matrix]);
 
-  // Season-to-date records for the footer: per model and for the
-  // consensus column, X/Y = correct picks / graded picks. A pick is
+  // WEEK records for the footer (scope = the displayed matrix: the
+  // selected week's contests only — season-to-date needs a cross-week
+  // aggregate and is future work): per model and for the consensus
+  // column, X/Y = correct picks / graded picks. A pick is
   // GRADED only when the game is final, the model actually picked, and
   // an actual exists (ATS pushes grade nobody). Abstentions and
   // not-yet-run cells never count against a model here — cost of
@@ -340,7 +342,7 @@ export default function AdminModelLabPage() {
               </tbody>
               <tfoot>
                 <tr>
-                  <td style={footerStyle}>Record - SU</td>
+                  <td style={footerStyle}>Week Record - SU</td>
                   {models.map(m => (
                     <td key={m.id} style={footerStyle}>{formatRecord(records.perModel[m.id]?.su)}</td>
                   ))}
@@ -348,7 +350,7 @@ export default function AdminModelLabPage() {
                   <td style={footerStyle} />
                 </tr>
                 <tr>
-                  <td style={footerStyle}>Record - ATS</td>
+                  <td style={footerStyle}>Week Record - ATS</td>
                   {models.map(m => (
                     <td key={m.id} style={footerStyle}>{formatRecord(records.perModel[m.id]?.ats)}</td>
                   ))}


### PR DESCRIPTION
Phase 2 scoring visuals for the Model Consensus Lab, validated locally against last night's finalized games.

- **DTO**: `IsFinal`, `ActualWinnerId`, `ActualSpreadWinnerId` join the matrix payload from the Producer batch call already in use — zero new queries. Post-#717/#718, these actuals are audited data.
- **Cells**: on finalized games, correct picks tint green / incorrect red — model cells and the Consensus column alike. Deliberately ungraded (white): unplayed games, abstentions, error cells, and ATS pushes (`ActualSpreadWinnerId` null on a finalized game = push, grades nobody).
- **Footer**: `Record - SU` / `Record - ATS` rows showing `X/Y` (correct/graded) per model, plus the **Consensus column's record** — the panel-vs-individual-models comparison the Phase 4 consensus decision hangs on. Denominators count only graded real picks; the cost of abstention is an explicitly deferred Phase-4 scoring-rule question.

First graded night already earns its keep: the USC ATS row shows five of seven models laying -35.5 and losing while two dissenters cashed — the design doc's chalk-bias caution, visible in production data on day one.

818/818 API unit tests, ESLint clean (`--max-warnings=0`), CRA build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnJySMvfUPeQSMufNNcKSK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Model Lab matchup matrices now show whether contests are final, along with actual winners and spread outcomes.
  * Added weekly straight-up and against-the-spread records for each model and Consensus.
  * Finalized picks are visually marked as correct or incorrect in the matchup matrix.
* **Bug Fixes**
  * Ungraded picks, abstentions, unavailable results, and against-the-spread pushes are excluded from record calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->