### PR TITLE
fix(mobile): enable R8 obfuscation + resource shrinking for Android release builds

### DIFF
--- a/src/UI/sd-mobile/app.json
+++ b/src/UI/sd-mobile/app.json
@@ -63,6 +63,10 @@
       [
         "expo-build-properties",
         {
+          "android": {
+            "enableProguardInReleaseBuilds": true,
+            "enableShrinkResourcesInReleaseBuilds": true
+          },
           "ios": {
             "extraPods": [
               {

--- a/src/UI/sd-mobile/app.json
+++ b/src/UI/sd-mobile/app.json
@@ -64,7 +64,7 @@
         "expo-build-properties",
         {
           "android": {
-            "enableProguardInReleaseBuilds": true,
+            "enableMinifyInReleaseBuilds": true,
             "enableShrinkResourcesInReleaseBuilds": true
           },
           "ios": {


### PR DESCRIPTION
Root cause of the 2026-09-04 Play search disappearance: Google Play's app-optimization program scores the app at **1% obfuscation vs the 25% threshold**, and per the Console warning this "may impact your visibility" — the discovery demotion is active now (the Feb 2027 date is only when publishing penalties begin). The store listing itself remained live and directly linkable throughout.

Release builds never ran R8/ProGuard: `expo-build-properties` carried only an `ios` block. This adds:

```json
"android": {
  "enableProguardInReleaseBuilds": true,
  "enableShrinkResourcesInReleaseBuilds": true
}
```

**Rollout plan (operator)**: next Android EAS build → **internal track first** — R8 plus Firebase auth/push/SignalR carries reflection risk, so exercise sign-in, notification receipt, and live updates before promoting. Runtime breaks get targeted keep-rules via `extraProguardRules`. Search visibility recovers over days-to-weeks as the new build's metrics land. Independent of the in-flight Apple submission (different platform/binary).

The Console's companion "deprecated edge-to-edge APIs" recommendation is React Native core internals (`com.facebook.react.modules`) — no app-side action; resolves with future RN/Expo upgrades.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnJySMvfUPeQSMufNNcKSK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Android release builds now enable code minification and resource shrinking. These optimizations may reduce the application download size and improve runtime efficiency while preserving the app’s existing functionality. Users may notice a smaller release package and more streamlined production builds, with no changes to the app’s available features or user-facing workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->