### PR TITLE
feat(api): admin trigger for the notification matchup backfill

### DIFF
--- a/src/SportsData.Api/Application/Admin/AdminController.cs
+++ b/src/SportsData.Api/Application/Admin/AdminController.cs
@@ -219,11 +219,18 @@ namespace SportsData.Api.Application.Admin
         {
             var correlationId = Guid.NewGuid();
 
-            await _eventBus.Publish(new PickemGroupMatchupsRequested(
-                sport,
-                seasonYear,
-                correlationId,
-                CausationId.Api.AdminNotificationBackfill), cancellationToken);
+            // No DbContext write on this path — publish straight to the
+            // broker. UseBusOutbox would otherwise buffer the event waiting
+            // for a SaveChangesAsync that never comes, and the backfill
+            // would 202 while silently doing nothing.
+            using (_deliveryScope.Use(DeliveryMode.Direct))
+            {
+                await _eventBus.Publish(new PickemGroupMatchupsRequested(
+                    sport,
+                    seasonYear,
+                    correlationId,
+                    CausationId.Api.AdminNotificationBackfill), cancellationToken);
+            }
 
             return Accepted(new { correlationId });
         }

--- a/src/SportsData.Api/Application/Admin/AdminController.cs
+++ b/src/SportsData.Api/Application/Admin/AdminController.cs
@@ -26,6 +26,7 @@ using SportsData.Api.Application.UI.Contest.Commands.SubmitContestPredictions;
 using SportsData.Api.Application.UI.Contest.Dtos;
 using SportsData.Api.Application.UI.Leagues.Dtos;
 using SportsData.Core.Common;
+using SportsData.Core.Eventing.Events.PickemGroups;
 using SportsData.Core.Common.Hashing;
 using SportsData.Core.Common.Mapping;
 using SportsData.Core.Dtos.Canonical;
@@ -195,6 +196,36 @@ namespace SportsData.Api.Application.Admin
             };
             _backgroundJobProvider.Enqueue<IGenerateMatchupPreviews>(p => p.Process(cmd));
             return Accepted(new { cmd.CorrelationId });
+        }
+
+        /// <summary>
+        /// Notification reminder backfill: publishes the (until now
+        /// trigger-less) PickemGroupMatchupsRequested event. The API's own
+        /// consumer re-publishes PickemGroupMatchupDataPublished for every
+        /// FUTURE matchup of the sport; the Notification service upserts its
+        /// projection and (re)schedules pick-deadline and contest-start
+        /// reminders. Built 2026-09-04: leagues created during the
+        /// Notification deploy hold (image pinned at 5371 until mid-Aug)
+        /// never had reminders scheduled, and the designed backfill event
+        /// had no publisher anywhere. Idempotent — the schedulers no-op on
+        /// unchanged fire times.
+        /// </summary>
+        [HttpPost]
+        [Route("notifications/matchups/backfill")]
+        public async Task<IActionResult> BackfillNotificationMatchups(
+            [FromQuery] Sport sport = Sport.FootballNcaa,
+            [FromQuery] int? seasonYear = null,
+            CancellationToken cancellationToken = default)
+        {
+            var correlationId = Guid.NewGuid();
+
+            await _eventBus.Publish(new PickemGroupMatchupsRequested(
+                sport,
+                seasonYear,
+                correlationId,
+                CausationId.Api.AdminNotificationBackfill), cancellationToken);
+
+            return Accepted(new { correlationId });
         }
 
         /// <summary>

--- a/src/SportsData.Core/Common/CausationId.cs
+++ b/src/SportsData.Core/Common/CausationId.cs
@@ -10,6 +10,7 @@ namespace SportsData.Core.Common
             public static Guid PickScoringAuditProcessor = new Guid("10000000-2000-0000-0000-000000000002");
             public static Guid MatchupPreviewProcessor = new Guid("10000000-3000-0000-0000-000000000001");
             public static readonly Guid SignalRDebugBroadcaster = new Guid("10000000-4000-0000-0000-000000000001");
+            public static readonly Guid AdminNotificationBackfill = new Guid("10000000-5000-0000-0000-000000000001");
         }
 
         public static class Producer


### PR DESCRIPTION
Root cause of "no pick reminders": the reminder pipeline (#470, June) schedules exclusively from live `PickemGroupMatchupCreated` events. Leagues created during the Notification deploy hold (image pinned at 5371 until mid-August) had those events consumed by the pre-reminder image — nothing scheduled, and no catch-up exists. Verified in Seq: the pipeline works for post-deploy leagues (the Sep-2 MLB league scheduled and correctly skipped its already-past deadline); zero football league-weeks have ever been evaluated.

The designed remediation already existed end-to-end — `PickemGroupMatchupsRequested` → API consumer pages future matchups → `PickemGroupMatchupDataPublished` per matchup → Notification upserts its projection and (re)schedules both reminder kinds — **except nothing anywhere published the request event** (the whole operator-trigger event family is publisher-less).

This adds `POST admin/notifications/matchups/backfill?sport=&seasonYear=` publishing it, with a dedicated causation id. Direct publish (no DbContext write ⇒ no outbox needed, per repo rule). Idempotent by construction: publisher filters to future matchups; schedulers no-op on unchanged fire times.

**Operator runbook after deploy**: hit the endpoint once per sport (`FootballNcaa`, `FootballNfl`) — reminders schedule for all future matchups, including per-contest start reminders for upcoming games. Safe to re-run any time.

818/818 API unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnJySMvfUPeQSMufNNcKSK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an administrative endpoint to initiate notification matchup backfills.
  - Administrators can select a sport and optionally specify a season year.
  - Requests are processed asynchronously and return a correlation ID with an HTTP 202 response for tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->