### PR TITLE
fix(notification): suppress line-move pushes once the contest has started

### DIFF
--- a/src/SportsData.Notification/Application/Consumers/ContestOddsUpdatedConsumer.cs
+++ b/src/SportsData.Notification/Application/Consumers/ContestOddsUpdatedConsumer.cs
@@ -103,24 +103,29 @@ namespace SportsData.Notification.Application.Consumers
                 return;
             }
 
-            // Started-contest gate (2026-09-04): odds updates are ROUTINE
-            // after kickoff and even after finalization (odds-late
-            // finalization rewrites lines on final games) — and a line move
-            // on a game the user can no longer pick is pure noise. The
-            // operator received "line changed" pushes for games that had
+            // Started-contest gate (2026-09-04), FAIL-CLOSED: odds updates
+            // are ROUTINE after kickoff and even after finalization
+            // (odds-late finalization rewrites lines on final games) — and a
+            // line move on a game the user can no longer pick is pure noise.
+            // The operator received "line changed" pushes for games that had
             // gone final. The local projection's StartDateUtc is the same
-            // clock picks lock on; an absent projection row falls through
-            // (the qualifying-picks join yields nobody in that case anyway).
+            // clock picks lock on. A MISSING projection row also suppresses:
+            // the qualifying-picks join below does NOT touch this table, so
+            // falling through would send ungated — and an unprojected
+            // matchup is either a past game nothing will ever backfill
+            // (exactly the reported bug) or a transient gap for a future
+            // game that the matchup events / admin backfill heal. Worst
+            // case there is one missed nice-to-have push.
             var startDateUtc = await _dataContext.PickemGroupMatchups
                 .AsNoTracking()
                 .Where(m => m.ContestId == msg.ContestId)
                 .Select(m => (DateTime?)m.StartDateUtc)
                 .FirstOrDefaultAsync(context.CancellationToken);
 
-            if (startDateUtc is not null && startDateUtc <= _dateTimeProvider.UtcNow())
+            if (startDateUtc is null || startDateUtc <= _dateTimeProvider.UtcNow())
             {
                 _logger.LogInformation(
-                    "Contest already started ({StartDateUtc}); suppressing line-move notification.",
+                    "Contest start unknown or already past (StartDateUtc={StartDateUtc}); suppressing line-move notification.",
                     startDateUtc);
                 return;
             }

--- a/src/SportsData.Notification/Application/Consumers/ContestOddsUpdatedConsumer.cs
+++ b/src/SportsData.Notification/Application/Consumers/ContestOddsUpdatedConsumer.cs
@@ -103,6 +103,28 @@ namespace SportsData.Notification.Application.Consumers
                 return;
             }
 
+            // Started-contest gate (2026-09-04): odds updates are ROUTINE
+            // after kickoff and even after finalization (odds-late
+            // finalization rewrites lines on final games) — and a line move
+            // on a game the user can no longer pick is pure noise. The
+            // operator received "line changed" pushes for games that had
+            // gone final. The local projection's StartDateUtc is the same
+            // clock picks lock on; an absent projection row falls through
+            // (the qualifying-picks join yields nobody in that case anyway).
+            var startDateUtc = await _dataContext.PickemGroupMatchups
+                .AsNoTracking()
+                .Where(m => m.ContestId == msg.ContestId)
+                .Select(m => (DateTime?)m.StartDateUtc)
+                .FirstOrDefaultAsync(context.CancellationToken);
+
+            if (startDateUtc is not null && startDateUtc <= _dateTimeProvider.UtcNow())
+            {
+                _logger.LogInformation(
+                    "Contest already started ({StartDateUtc}); suppressing line-move notification.",
+                    startDateUtc);
+                return;
+            }
+
             // Pickers in leagues whose scoring depends on the moved dimension.
             // The join to PickemGroups applies the PickType filter (ATS↔spread,
             // OverUnder↔total, StraightUp never) and drops picks whose league

--- a/test/unit/SportsData.Notification.Tests.Unit/Application/Consumers/ContestOddsUpdatedConsumerTests.cs
+++ b/test/unit/SportsData.Notification.Tests.Unit/Application/Consumers/ContestOddsUpdatedConsumerTests.cs
@@ -126,6 +126,55 @@ public class ContestOddsUpdatedConsumerTests : NotificationTestBase<ContestOddsU
         VerifySendCount(Times.Never());
     }
 
+    private async Task SeedMatchupProjectionAsync(Guid contestId, DateTime startDateUtc)
+    {
+        DataContext.PickemGroupMatchups.Add(new PickemGroupMatchup
+        {
+            Id = Guid.NewGuid(),
+            PickemGroupId = Guid.NewGuid(),
+            ContestId = contestId,
+            StartDateUtc = startDateUtc,
+            StatusTypeName = "STATUS_SCHEDULED",
+            SeasonYear = 2026,
+            CreatedUtc = FixedNow.AddDays(-1),
+            CreatedBy = Guid.NewGuid()
+        });
+        await DataContext.SaveChangesAsync();
+    }
+
+    [Fact]
+    public async Task Consume_ContestAlreadyStarted_DoesNotNotify()
+    {
+        // Odds updates are routine after kickoff and even after finalization
+        // (odds-late finalization rewrites lines on FINAL games) — a line
+        // move on a game the user can no longer pick must not push.
+        var userId = Guid.NewGuid();
+        var contestId = Guid.NewGuid();
+        await SeedPickAsync(userId, contestId, Guid.NewGuid(), LeaguePickType.AgainstTheSpread);
+        await SeedDeviceAsync(userId);
+        await SeedMatchupProjectionAsync(contestId, FixedNow.AddHours(-4));
+
+        var sut = Mocker.CreateInstance<ContestOddsUpdatedConsumer>();
+        await sut.Consume(ContextFor(Msg(contestId, oldSpread: -3m, newSpread: -6m)));
+
+        VerifySendCount(Times.Never());
+    }
+
+    [Fact]
+    public async Task Consume_ContestNotStarted_StillNotifies()
+    {
+        var userId = Guid.NewGuid();
+        var contestId = Guid.NewGuid();
+        await SeedPickAsync(userId, contestId, Guid.NewGuid(), LeaguePickType.AgainstTheSpread);
+        await SeedDeviceAsync(userId);
+        await SeedMatchupProjectionAsync(contestId, FixedNow.AddHours(4));
+
+        var sut = Mocker.CreateInstance<ContestOddsUpdatedConsumer>();
+        await sut.Consume(ContextFor(Msg(contestId, oldSpread: -3m, newSpread: -6m)));
+
+        VerifySendCount(Times.Once());
+    }
+
     [Fact]
     public async Task Consume_AtsLeague_SpreadMoved_Notifies()
     {

--- a/test/unit/SportsData.Notification.Tests.Unit/Application/Consumers/ContestOddsUpdatedConsumerTests.cs
+++ b/test/unit/SportsData.Notification.Tests.Unit/Application/Consumers/ContestOddsUpdatedConsumerTests.cs
@@ -161,6 +161,25 @@ public class ContestOddsUpdatedConsumerTests : NotificationTestBase<ContestOddsU
     }
 
     [Fact]
+    public async Task Consume_MissingMatchupProjection_DoesNotNotify()
+    {
+        // FAIL-CLOSED: the qualifying-picks join never touches the matchup
+        // projection, so without this gate an unprojected (typically past,
+        // never-to-be-backfilled) contest would send ungated — the exact
+        // reported bug.
+        var userId = Guid.NewGuid();
+        var contestId = Guid.NewGuid();
+        await SeedPickAsync(userId, contestId, Guid.NewGuid(), LeaguePickType.AgainstTheSpread);
+        await SeedDeviceAsync(userId);
+        // no SeedMatchupProjectionAsync on purpose
+
+        var sut = Mocker.CreateInstance<ContestOddsUpdatedConsumer>();
+        await sut.Consume(ContextFor(Msg(contestId, oldSpread: -3m, newSpread: -6m)));
+
+        VerifySendCount(Times.Never());
+    }
+
+    [Fact]
     public async Task Consume_ContestNotStarted_StillNotifies()
     {
         var userId = Guid.NewGuid();
@@ -183,6 +202,7 @@ public class ContestOddsUpdatedConsumerTests : NotificationTestBase<ContestOddsU
         await SeedPickAsync(userId, contestId, Guid.NewGuid(), LeaguePickType.AgainstTheSpread);
         await SeedDeviceAsync(userId);
 
+        await SeedMatchupProjectionAsync(contestId, FixedNow.AddHours(4));
         var sut = Mocker.CreateInstance<ContestOddsUpdatedConsumer>();
         await sut.Consume(ContextFor(Msg(contestId, oldSpread: -3m, newSpread: -6m)));
 
@@ -211,6 +231,7 @@ public class ContestOddsUpdatedConsumerTests : NotificationTestBase<ContestOddsU
         await SeedPickAsync(userId, contestId, Guid.NewGuid(), LeaguePickType.OverUnder);
         await SeedDeviceAsync(userId);
 
+        await SeedMatchupProjectionAsync(contestId, FixedNow.AddHours(4));
         var sut = Mocker.CreateInstance<ContestOddsUpdatedConsumer>();
         await sut.Consume(ContextFor(Msg(contestId, oldTotal: 50m, newTotal: 54m)));
 
@@ -226,6 +247,7 @@ public class ContestOddsUpdatedConsumerTests : NotificationTestBase<ContestOddsU
         await SeedPickAsync(userId, contestId, Guid.NewGuid(), LeaguePickType.AgainstTheSpread);
         await SeedDeviceAsync(userId);
 
+        await SeedMatchupProjectionAsync(contestId, FixedNow.AddHours(4));
         var sut = Mocker.CreateInstance<ContestOddsUpdatedConsumer>();
         await sut.Consume(ContextFor(Msg(contestId, oldSpread: -3m, newSpread: -6m)));
 
@@ -250,6 +272,7 @@ public class ContestOddsUpdatedConsumerTests : NotificationTestBase<ContestOddsU
         });
         await DataContext.SaveChangesAsync();
 
+        await SeedMatchupProjectionAsync(contestId, FixedNow.AddHours(4));
         var sut = Mocker.CreateInstance<ContestOddsUpdatedConsumer>();
         await sut.Consume(ContextFor(Msg(contestId, oldSpread: -3m, newSpread: -6m)));
 
@@ -264,6 +287,7 @@ public class ContestOddsUpdatedConsumerTests : NotificationTestBase<ContestOddsU
         await SeedPickAsync(userId, contestId, Guid.NewGuid(), LeaguePickType.AgainstTheSpread);
         await SeedDeviceAsync(userId, enabled: false);
 
+        await SeedMatchupProjectionAsync(contestId, FixedNow.AddHours(4));
         var sut = Mocker.CreateInstance<ContestOddsUpdatedConsumer>();
         await sut.Consume(ContextFor(Msg(contestId, oldSpread: -3m, newSpread: -6m)));
 
@@ -364,6 +388,7 @@ public class ContestOddsUpdatedConsumerTests : NotificationTestBase<ContestOddsU
             Week = 3
         });
 
+        await SeedMatchupProjectionAsync(contestId, FixedNow.AddHours(4));
         var sut = Mocker.CreateInstance<ContestOddsUpdatedConsumer>();
         await sut.Consume(ContextFor(Msg(contestId, oldSpread: -3m, newSpread: -1.5m)));
 
@@ -392,6 +417,7 @@ public class ContestOddsUpdatedConsumerTests : NotificationTestBase<ContestOddsU
 
         StubContestThrows();
 
+        await SeedMatchupProjectionAsync(contestId, FixedNow.AddHours(4));
         var sut = Mocker.CreateInstance<ContestOddsUpdatedConsumer>();
         await sut.Consume(ContextFor(Msg(contestId, oldSpread: -3m, newSpread: -1.5m)));
 
@@ -453,6 +479,7 @@ public class ContestOddsUpdatedConsumerTests : NotificationTestBase<ContestOddsU
 
         StubContest(new SeasonContestDto { Id = contestId, Name = FullName, ShortName = ShortName });
 
+        await SeedMatchupProjectionAsync(contestId, FixedNow.AddHours(4));
         var sut = Mocker.CreateInstance<ContestOddsUpdatedConsumer>();
         await sut.Consume(ContextFor(Msg(contestId, oldSpread: -3m, newSpread: -1.5m)));
 


### PR DESCRIPTION
Second of the two notification findings from tonight's dig (first was #724):

**Post-final line-change pushes**: `ContestOddsUpdatedConsumer` had no contest-state gate, and odds updates are *routine* after kickoff — this week's enrichment work showed odds-late finalization rewriting lines on final games, which is exactly when the operator received "line changed" notifications. A line move on a game the user can no longer pick is noise. The consumer now checks the local `PickemGroupMatchups` projection's `StartDateUtc` (the same clock picks lock on) and suppresses once the game has started. An absent projection row falls through unchanged — the qualifying-picks join yields nobody in that case anyway. Two new tests: started → never sends; not-started → still sends.

**The third finding investigated and closed without a code change**: zero `NotificationLog` rows for pick results is *correct* — pick-result sends are claim-logged and deduped in the typed `NotificationUserPick` table; `NotificationLog` is the legacy audit table the table-per-type refactor superseded (only the line-move path still writes it). Audit queries belong against the typed tables.

Notification consumer suite 14/14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnJySMvfUPeQSMufNNcKSK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented odds movement notifications from being sent for contests that have already started or finished.
  * Continued sending notifications for upcoming contests.
  * Preserved existing notification behavior when matchup details are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->