### PR TITLE
fix(notification): backfill consumer schedules reminders even when the projection is unchanged

### DIFF
--- a/src/SportsData.Notification/Application/Consumers/PickemGroupMatchupDataPublishedConsumer.cs
+++ b/src/SportsData.Notification/Application/Consumers/PickemGroupMatchupDataPublishedConsumer.cs
@@ -125,7 +125,20 @@ namespace SportsData.Notification.Application.Consumers
 
             if (!changed)
             {
-                _logger.LogDebug("PickemGroupMatchup projection unchanged.");
+                // An unchanged projection is NOT proof that reminder
+                // schedules exist — leagues consumed by the pre-scheduler
+                // image have current projections and zero schedules. This
+                // event is the operator's remediation trigger, so evaluate
+                // unconditionally; both schedulers are idempotent no-ops
+                // when the schedules are already in place.
+                _logger.LogInformation(
+                    "PickemGroupMatchup projection unchanged; evaluating reminder schedules.");
+
+                await _reminderScheduler.EvaluateAndScheduleForLeagueWeekAsync(
+                    msg.PickemGroupId, msg.SeasonWeek, context.CancellationToken);
+
+                await _contestStartScheduler.EvaluateAndScheduleForContestAsync(
+                    msg.ContestId, context.CancellationToken);
                 return;
             }
 
@@ -147,22 +160,19 @@ namespace SportsData.Notification.Application.Consumers
             await _dataContext.SaveChangesAsync(context.CancellationToken);
             _logger.LogInformation("PickemGroupMatchup projection updated.");
 
-            if (startDateChanged || weekChanged)
+            if (weekChanged)
             {
-                if (weekChanged)
-                {
-                    await _reminderScheduler.EvaluateAndScheduleForLeagueWeekAsync(
-                        msg.PickemGroupId, priorSeasonWeek, context.CancellationToken);
-                }
                 await _reminderScheduler.EvaluateAndScheduleForLeagueWeekAsync(
-                    msg.PickemGroupId, msg.SeasonWeek, context.CancellationToken);
+                    msg.PickemGroupId, priorSeasonWeek, context.CancellationToken);
             }
 
-            if (startDateChanged)
-            {
-                await _contestStartScheduler.EvaluateAndScheduleForContestAsync(
-                    msg.ContestId, context.CancellationToken);
-            }
+            // Unconditional for the same reason as the unchanged path:
+            // schedule state is independent of projection state.
+            await _reminderScheduler.EvaluateAndScheduleForLeagueWeekAsync(
+                msg.PickemGroupId, msg.SeasonWeek, context.CancellationToken);
+
+            await _contestStartScheduler.EvaluateAndScheduleForContestAsync(
+                msg.ContestId, context.CancellationToken);
         }
 
         private static bool IsUniqueConstraintViolation(DbUpdateException ex)

--- a/test/unit/SportsData.Notification.Tests.Unit/Application/Consumers/PickemGroupMatchupDataPublishedConsumerTests.cs
+++ b/test/unit/SportsData.Notification.Tests.Unit/Application/Consumers/PickemGroupMatchupDataPublishedConsumerTests.cs
@@ -101,7 +101,9 @@ public class PickemGroupMatchupDataPublishedConsumerTests
 
         var row = await DataContext.PickemGroupMatchups
             .AsNoTracking()
-            .SingleAsync(m => m.PickemGroupId == groupId && m.ContestId == contestId);
+            .Where(m => m.PickemGroupId == groupId && m.ContestId == contestId)
+            .Select(m => new { m.ModifiedUtc })
+            .SingleAsync();
         row.ModifiedUtc.Should().BeNull();
     }
 
@@ -117,7 +119,9 @@ public class PickemGroupMatchupDataPublishedConsumerTests
 
         var row = await DataContext.PickemGroupMatchups
             .AsNoTracking()
-            .SingleAsync(m => m.PickemGroupId == groupId && m.ContestId == contestId);
+            .Where(m => m.PickemGroupId == groupId && m.ContestId == contestId)
+            .Select(m => new { m.StartDateUtc, m.StatusTypeName })
+            .SingleAsync();
         row.StartDateUtc.Should().Be(start);
         row.StatusTypeName.Should().Be("STATUS_SCHEDULED");
 
@@ -152,6 +156,36 @@ public class PickemGroupMatchupDataPublishedConsumerTests
     }
 
     [Fact]
+    public async Task Consume_SeasonYearOnlyChanged_UpdatesProjectionAndSchedules()
+    {
+        // Regression: scheduling was gated on startDateChanged || weekChanged,
+        // so a SeasonYear-only update skipped both schedulers.
+        var groupId = Guid.NewGuid();
+        var contestId = Guid.NewGuid();
+        var start = FixedNow.AddDays(1);
+        await SeedProjectionAsync(groupId, contestId, start, seasonYear: 2025);
+
+        var sut = Mocker.CreateInstance<PickemGroupMatchupDataPublishedConsumer>();
+        await sut.Consume(ContextFor(Msg(groupId, contestId, start, seasonYear: 2026)));
+
+        var row = await DataContext.PickemGroupMatchups
+            .AsNoTracking()
+            .Where(m => m.PickemGroupId == groupId && m.ContestId == contestId)
+            .Select(m => new { m.SeasonYear, m.StartDateUtc, m.SeasonWeek })
+            .SingleAsync();
+        row.SeasonYear.Should().Be(2026);
+        row.StartDateUtc.Should().Be(start);
+        row.SeasonWeek.Should().Be(2);
+
+        _reminderScheduler.Verify(
+            x => x.EvaluateAndScheduleForLeagueWeekAsync(groupId, 2, It.IsAny<CancellationToken>()),
+            Times.Once);
+        _contestStartScheduler.Verify(
+            x => x.EvaluateAndScheduleForContestAsync(contestId, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
     public async Task Consume_StartDateChanged_UpdatesProjectionAndSchedules()
     {
         var groupId = Guid.NewGuid();
@@ -164,7 +198,9 @@ public class PickemGroupMatchupDataPublishedConsumerTests
 
         var row = await DataContext.PickemGroupMatchups
             .AsNoTracking()
-            .SingleAsync(m => m.PickemGroupId == groupId && m.ContestId == contestId);
+            .Where(m => m.PickemGroupId == groupId && m.ContestId == contestId)
+            .Select(m => new { m.StartDateUtc, m.ModifiedUtc })
+            .SingleAsync();
         row.StartDateUtc.Should().Be(newStart);
         row.ModifiedUtc.Should().Be(FixedNow);
 

--- a/test/unit/SportsData.Notification.Tests.Unit/Application/Consumers/PickemGroupMatchupDataPublishedConsumerTests.cs
+++ b/test/unit/SportsData.Notification.Tests.Unit/Application/Consumers/PickemGroupMatchupDataPublishedConsumerTests.cs
@@ -1,0 +1,178 @@
+using FluentAssertions;
+
+using MassTransit;
+
+using Microsoft.EntityFrameworkCore;
+
+using Moq;
+
+using SportsData.Core.Common;
+using SportsData.Core.Eventing.Events.PickemGroups;
+using SportsData.Notification.Application.Consumers;
+using SportsData.Notification.Application.Scheduling;
+using SportsData.Notification.Infrastructure.Data.Entities;
+
+using Xunit;
+
+namespace SportsData.Notification.Tests.Unit.Application.Consumers;
+
+public class PickemGroupMatchupDataPublishedConsumerTests
+    : NotificationTestBase<PickemGroupMatchupDataPublishedConsumer>
+{
+    private static readonly DateTime FixedNow = new(2026, 9, 5, 12, 0, 0, DateTimeKind.Utc);
+
+    private readonly Mock<IPickDeadlineReminderScheduler> _reminderScheduler;
+    private readonly Mock<IContestStartReminderScheduler> _contestStartScheduler;
+
+    public PickemGroupMatchupDataPublishedConsumerTests()
+    {
+        Mocker.GetMock<IDateTimeProvider>()
+            .Setup(x => x.UtcNow())
+            .Returns(FixedNow);
+
+        _reminderScheduler = Mocker.GetMock<IPickDeadlineReminderScheduler>();
+        _contestStartScheduler = Mocker.GetMock<IContestStartReminderScheduler>();
+    }
+
+    private static ConsumeContext<PickemGroupMatchupDataPublished> ContextFor(
+        PickemGroupMatchupDataPublished msg)
+    {
+        var ctx = new Mock<ConsumeContext<PickemGroupMatchupDataPublished>>();
+        ctx.SetupGet(x => x.Message).Returns(msg);
+        ctx.SetupGet(x => x.CancellationToken).Returns(CancellationToken.None);
+        return ctx.Object;
+    }
+
+    private static PickemGroupMatchupDataPublished Msg(
+        Guid groupId, Guid contestId, DateTime startDateUtc, int seasonWeek = 2, int seasonYear = 2026)
+        => new(groupId, contestId, startDateUtc, seasonWeek, Sport.FootballNcaa,
+            seasonYear, Guid.NewGuid(), Guid.NewGuid());
+
+    private async Task SeedProjectionAsync(
+        Guid groupId, Guid contestId, DateTime startDateUtc, int seasonWeek = 2, int seasonYear = 2026)
+    {
+        DataContext.PickemGroupMatchups.Add(new PickemGroupMatchup
+        {
+            PickemGroupId = groupId,
+            ContestId = contestId,
+            StartDateUtc = startDateUtc,
+            StartDateUpdatedAt = FixedNow.AddDays(-10),
+            SeasonYear = seasonYear,
+            SeasonWeek = seasonWeek,
+            StatusTypeName = "STATUS_SCHEDULED",
+            CreatedUtc = FixedNow.AddDays(-10),
+            CreatedBy = Guid.NewGuid()
+        });
+        await DataContext.SaveChangesAsync();
+    }
+
+    [Fact]
+    public async Task Consume_UnchangedProjection_StillEvaluatesSchedulers()
+    {
+        // The backfill exists to heal missing SCHEDULES, not projections.
+        // A projection can be fully current while its reminders were never
+        // scheduled (pre-scheduler image consumed the original events).
+        var groupId = Guid.NewGuid();
+        var contestId = Guid.NewGuid();
+        var start = FixedNow.AddDays(1);
+        await SeedProjectionAsync(groupId, contestId, start);
+
+        var sut = Mocker.CreateInstance<PickemGroupMatchupDataPublishedConsumer>();
+        await sut.Consume(ContextFor(Msg(groupId, contestId, start)));
+
+        _reminderScheduler.Verify(
+            x => x.EvaluateAndScheduleForLeagueWeekAsync(groupId, 2, It.IsAny<CancellationToken>()),
+            Times.Once);
+        _contestStartScheduler.Verify(
+            x => x.EvaluateAndScheduleForContestAsync(contestId, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Consume_UnchangedProjection_DoesNotStampModified()
+    {
+        var groupId = Guid.NewGuid();
+        var contestId = Guid.NewGuid();
+        var start = FixedNow.AddDays(1);
+        await SeedProjectionAsync(groupId, contestId, start);
+
+        var sut = Mocker.CreateInstance<PickemGroupMatchupDataPublishedConsumer>();
+        await sut.Consume(ContextFor(Msg(groupId, contestId, start)));
+
+        var row = await DataContext.PickemGroupMatchups
+            .AsNoTracking()
+            .SingleAsync(m => m.PickemGroupId == groupId && m.ContestId == contestId);
+        row.ModifiedUtc.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Consume_NewProjection_InsertsAndSchedules()
+    {
+        var groupId = Guid.NewGuid();
+        var contestId = Guid.NewGuid();
+        var start = FixedNow.AddDays(1);
+
+        var sut = Mocker.CreateInstance<PickemGroupMatchupDataPublishedConsumer>();
+        await sut.Consume(ContextFor(Msg(groupId, contestId, start)));
+
+        var row = await DataContext.PickemGroupMatchups
+            .AsNoTracking()
+            .SingleAsync(m => m.PickemGroupId == groupId && m.ContestId == contestId);
+        row.StartDateUtc.Should().Be(start);
+        row.StatusTypeName.Should().Be("STATUS_SCHEDULED");
+
+        _reminderScheduler.Verify(
+            x => x.EvaluateAndScheduleForLeagueWeekAsync(groupId, 2, It.IsAny<CancellationToken>()),
+            Times.Once);
+        _contestStartScheduler.Verify(
+            x => x.EvaluateAndScheduleForContestAsync(contestId, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Consume_WeekChanged_ReevaluatesPriorAndCurrentWeek()
+    {
+        var groupId = Guid.NewGuid();
+        var contestId = Guid.NewGuid();
+        var start = FixedNow.AddDays(1);
+        await SeedProjectionAsync(groupId, contestId, start, seasonWeek: 1);
+
+        var sut = Mocker.CreateInstance<PickemGroupMatchupDataPublishedConsumer>();
+        await sut.Consume(ContextFor(Msg(groupId, contestId, start, seasonWeek: 2)));
+
+        _reminderScheduler.Verify(
+            x => x.EvaluateAndScheduleForLeagueWeekAsync(groupId, 1, It.IsAny<CancellationToken>()),
+            Times.Once);
+        _reminderScheduler.Verify(
+            x => x.EvaluateAndScheduleForLeagueWeekAsync(groupId, 2, It.IsAny<CancellationToken>()),
+            Times.Once);
+        _contestStartScheduler.Verify(
+            x => x.EvaluateAndScheduleForContestAsync(contestId, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Consume_StartDateChanged_UpdatesProjectionAndSchedules()
+    {
+        var groupId = Guid.NewGuid();
+        var contestId = Guid.NewGuid();
+        await SeedProjectionAsync(groupId, contestId, FixedNow.AddDays(1));
+
+        var newStart = FixedNow.AddDays(2);
+        var sut = Mocker.CreateInstance<PickemGroupMatchupDataPublishedConsumer>();
+        await sut.Consume(ContextFor(Msg(groupId, contestId, newStart)));
+
+        var row = await DataContext.PickemGroupMatchups
+            .AsNoTracking()
+            .SingleAsync(m => m.PickemGroupId == groupId && m.ContestId == contestId);
+        row.StartDateUtc.Should().Be(newStart);
+        row.ModifiedUtc.Should().Be(FixedNow);
+
+        _reminderScheduler.Verify(
+            x => x.EvaluateAndScheduleForLeagueWeekAsync(groupId, 2, It.IsAny<CancellationToken>()),
+            Times.Once);
+        _contestStartScheduler.Verify(
+            x => x.EvaluateAndScheduleForContestAsync(contestId, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+}


### PR DESCRIPTION
## Why the production backfill was a silent no-op

The post-deploy backfill run (`POST /admin/notifications/matchups/backfill?sport=FootballNcaa`, correlation `5cae6e99-5d34-4ee3-ada0-fa982b68d6c1`) published 52 `PickemGroupMatchupDataPublished` events. RabbitMQ delivery was verified end-to-end (exchange, bindings, queue drained to zero on `rabbitmq-api`) — the events WERE consumed. The consumer then hit its unchanged-projection path: `LogDebug` (below Seq's minimum level, hence total silence) and `return` — **without calling either scheduler**.

The deploy-hold gap was narrower than theorized in the triage: the old image DID insert projections; it just had no scheduler code. So every affected league has a fully current projection and zero reminder schedules — exactly the state the backfill exists to heal, and exactly the state it skipped.

## Fix

Schedule state is independent of projection state, and both schedulers are idempotent (no-op when a `PendingScheduledJob` already covers the fire time), so:

- **Unchanged path**: still short-circuits the projection write, but now evaluates pick-deadline (league-week) and contest-start scheduling unconditionally, and logs at Information so backfill runs are visible in Seq.
- **Update path**: scheduling was gated on `startDateChanged || weekChanged` — now unconditional at the end of the path (a SeasonYear-only change previously skipped it). The prior-week re-evaluation stays gated on `weekChanged`.

## Tests

New `PickemGroupMatchupDataPublishedConsumerTests` (the consumer had none): unchanged-projection still schedules (the regression), unchanged does not stamp `Modified*`, insert path schedules, week change re-evaluates prior + current week, start-date change updates and schedules. 130/130 Notification unit tests pass.

## Post-merge runbook

Re-run the backfill for FootballNcaa and FootballNfl; verify "projection unchanged; evaluating reminder schedules" bursts in Seq followed by scheduler activity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnJySMvfUPeQSMufNNcKSK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Reminder scheduling now runs reliably even when matchup projections remain unchanged.
  - League-week reminders are reevaluated when a matchup moves between weeks.
  - Current league-week and contest-start schedules are consistently reevaluated after matchup updates.
  - Matchup updates now preserve modification timestamps when no projection changes occur.
  - Scheduling is also refreshed when matchup start dates or season information changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->