### PR TITLE
fix(jobsdashboard): reference SportsData.Notification so its Hangfire jobs render

### DIFF
--- a/src/SportsData.JobsDashboard/SportsData.JobsDashboard.csproj
+++ b/src/SportsData.JobsDashboard/SportsData.JobsDashboard.csproj
@@ -30,6 +30,7 @@
          into a thin SportsData.Jobs.Contracts assembly to avoid pulling in transitive
          dependencies (EF, SignalR, messaging, etc.) from each worker project. -->
     <ProjectReference Include="..\SportsData.Api\SportsData.Api.csproj" />
+    <ProjectReference Include="..\SportsData.Notification\SportsData.Notification.csproj" />
     <ProjectReference Include="..\SportsData.Producer\SportsData.Producer.csproj" />
     <ProjectReference Include="..\SportsData.Provider\SportsData.Provider.csproj" />
   </ItemGroup>


### PR DESCRIPTION
@coderabbitai ignore

One-line fix: JobsDashboard referenced Api/Producer/Provider but not Notification, so every Notification Hangfire job rendered as "Can not find the target method" — the dashboard deserializes job types in-process and could never load that assembly. Display-only (execution runs on Notification's own Hangfire servers); surfaced today by the pick-deadline v2 job volume (351 scheduled jobs, all unrenderable).

Builds clean. The csproj's existing TODO about a thin Jobs.Contracts assembly still stands as the eventual right answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnJySMvfUPeQSMufNNcKSK