### PR TITLE
feat(web): model-lab PDF export with anonymized model columns

### DIFF
--- a/src/UI/sd-ui/src/components/admin/AdminModelLabPage.jsx
+++ b/src/UI/sd-ui/src/components/admin/AdminModelLabPage.jsx
@@ -70,16 +70,31 @@ export default function AdminModelLabPage() {
   // model lineup and prompts stay internal; the export is shareable.
   const [printMode, setPrintMode] = useState(false);
   useEffect(() => {
+    // Belt-and-braces reset; the deterministic path is the post-print()
+    // reset below (afterprint doesn't fire in every browser/webview,
+    // and a stuck printMode would leave the screen anonymized and the
+    // export button inert).
     const onAfterPrint = () => setPrintMode(false);
     window.addEventListener('afterprint', onAfterPrint);
     return () => window.removeEventListener('afterprint', onAfterPrint);
   }, []);
   useEffect(() => {
-    if (!printMode) return;
-    // Two frames so the anonymized headers are painted before the
-    // print snapshot is taken.
-    const raf = requestAnimationFrame(() => requestAnimationFrame(() => window.print()));
-    return () => cancelAnimationFrame(raf);
+    if (!printMode) return undefined;
+    // Two frames so the anonymized headers are painted before the print
+    // snapshot is taken. The browser captures the snapshot when print()
+    // is invoked, so resetting immediately after it returns is safe for
+    // the produced PDF even where print() doesn't block on the dialog.
+    let innerRaf = null;
+    const outerRaf = requestAnimationFrame(() => {
+      innerRaf = requestAnimationFrame(() => {
+        window.print();
+        setPrintMode(false);
+      });
+    });
+    return () => {
+      cancelAnimationFrame(outerRaf);
+      if (innerRaf != null) cancelAnimationFrame(innerRaf);
+    };
   }, [printMode]);
 
   const loadMatrix = useCallback(async (sport, y, w, pId, { quiet = false } = {}) => {
@@ -440,7 +455,7 @@ export default function AdminModelLabPage() {
                   {models.map((m, i) => (
                     <th key={m.id} className="model-lab-model-col" style={headerStyle}>
                       {printMode
-                        ? <>Model<br />{String.fromCharCode(65 + i)}</>
+                        ? <>Model<br />{modelLetter(i)}</>
                         : m.name}
                     </th>
                   ))}
@@ -500,6 +515,21 @@ export default function AdminModelLabPage() {
       </div>
     </div>
   );
+}
+
+/**
+ * Base-26 column label: A..Z, then AA, AB, ... — the anonymized export
+ * header must stay a letter no matter how many models the lab carries
+ * (charCode arithmetic alone prints punctuation past the 26th).
+ */
+function modelLetter(index) {
+  let n = index;
+  let label = '';
+  do {
+    label = String.fromCharCode(65 + (n % 26)) + label;
+    n = Math.floor(n / 26) - 1;
+  } while (n >= 0);
+  return label;
 }
 
 const headerStyle = {

--- a/src/UI/sd-ui/src/components/admin/AdminModelLabPage.jsx
+++ b/src/UI/sd-ui/src/components/admin/AdminModelLabPage.jsx
@@ -64,6 +64,24 @@ export default function AdminModelLabPage() {
   // refreshes overlap; an out-of-order response must not win.
   const loadSeqRef = useRef(0);
 
+  // PDF export = the browser's own print-to-PDF over a print stylesheet.
+  // While printMode is on, model columns render as anonymous letters
+  // ("Model A"...) and the print header omits the prompt name — the
+  // model lineup and prompts stay internal; the export is shareable.
+  const [printMode, setPrintMode] = useState(false);
+  useEffect(() => {
+    const onAfterPrint = () => setPrintMode(false);
+    window.addEventListener('afterprint', onAfterPrint);
+    return () => window.removeEventListener('afterprint', onAfterPrint);
+  }, []);
+  useEffect(() => {
+    if (!printMode) return;
+    // Two frames so the anonymized headers are painted before the
+    // print snapshot is taken.
+    const raf = requestAnimationFrame(() => requestAnimationFrame(() => window.print()));
+    return () => cancelAnimationFrame(raf);
+  }, [printMode]);
+
   const loadMatrix = useCallback(async (sport, y, w, pId, { quiet = false } = {}) => {
     const seq = ++loadSeqRef.current;
     if (!quiet) setLoading(true);
@@ -318,8 +336,8 @@ export default function AdminModelLabPage() {
           matrix deserve every pixel; the table's own overflow-x scroll
           still guards narrow viewports. */}
       <div>
-        <h2 style={{ marginBottom: 4 }}>Model Consensus Lab</h2>
-        <p style={{ color: 'var(--text-secondary)', marginTop: 0 }}>
+        <h2 className="model-lab-no-print" style={{ marginBottom: 4 }}>Model Consensus Lab</h2>
+        <p className="model-lab-no-print" style={{ color: 'var(--text-secondary)', marginTop: 0 }}>
           Every contest any pick'em league carries for the week, against
           every active lab-reachable model. Empty cell = no run yet - the
           button generates just that pair. Experiments never write a
@@ -327,7 +345,16 @@ export default function AdminModelLabPage() {
           simple majority of the picks cast.
         </p>
 
-        <div style={{ display: 'flex', gap: 8, alignItems: 'center', margin: '16px 0', flexWrap: 'wrap' }}>
+        <div className="model-lab-print-header">
+          <h2 style={{ margin: 0 }}>sportDeets Model Matrix</h2>
+          <div>
+            {LEAGUE_OPTIONS.find(o => o.value === league)?.label ?? league}
+            {' · '}Season {year} · Week {week}
+            {' · '}generated {new Date().toLocaleDateString()}
+          </div>
+        </div>
+
+        <div className="model-lab-no-print" style={{ display: 'flex', gap: 8, alignItems: 'center', margin: '16px 0', flexWrap: 'wrap' }}>
           <label htmlFor="modellab-league" style={{ fontWeight: 600 }}>League:</label>
           <select
             id="modellab-league"
@@ -361,6 +388,15 @@ export default function AdminModelLabPage() {
           />
           <button type="button" className="model-lab-btn" onClick={() => loadMatrix(leagueSport, year, week, promptId)}>
             Refresh
+          </button>
+          <button
+            type="button"
+            className="model-lab-btn"
+            onClick={() => setPrintMode(true)}
+            disabled={loading || models.length === 0 || contests.length === 0}
+            title="Print-to-PDF with model names anonymized (Model A, B, ...) — safe to share outside admin."
+          >
+            Export PDF
           </button>
           <label htmlFor="modellab-prompt-id" style={{ fontWeight: 600 }}>Prompt:</label>
           <select
@@ -401,8 +437,12 @@ export default function AdminModelLabPage() {
               <thead>
                 <tr>
                   <th style={headerStyle}>Contest</th>
-                  {models.map(m => (
-                    <th key={m.id} style={headerStyle}>{m.name}</th>
+                  {models.map((m, i) => (
+                    <th key={m.id} className="model-lab-model-col" style={headerStyle}>
+                      {printMode
+                        ? <>Model<br />{String.fromCharCode(65 + i)}</>
+                        : m.name}
+                    </th>
                   ))}
                   <th style={headerStyle}>Consensus</th>
                   <th
@@ -417,7 +457,7 @@ export default function AdminModelLabPage() {
                   >
                     Home
                   </th>
-                  <th style={headerStyle} aria-label="Row actions" />
+                  <th className="model-lab-actions" style={headerStyle} aria-label="Row actions" />
                 </tr>
               </thead>
               <tbody>
@@ -441,7 +481,7 @@ export default function AdminModelLabPage() {
                   <td style={footerStyle}>{formatRecord(records.consensus.su)}</td>
                   <td style={{ ...footerStyle, fontStyle: 'italic' }}>{formatRecord(records.favorites.su)}</td>
                   <td style={{ ...footerStyle, fontStyle: 'italic' }}>{formatRecord(records.home.su)}</td>
-                  <td style={footerStyle} />
+                  <td className="model-lab-actions" style={footerStyle} />
                 </tr>
                 <tr>
                   <td style={footerStyle}>Week Record - ATS</td>
@@ -451,7 +491,7 @@ export default function AdminModelLabPage() {
                   <td style={footerStyle}>{formatRecord(records.consensus.ats)}</td>
                   <td style={{ ...footerStyle, fontStyle: 'italic' }}>{formatRecord(records.favorites.ats)}</td>
                   <td style={{ ...footerStyle, fontStyle: 'italic' }}>{formatRecord(records.home.ats)}</td>
-                  <td style={footerStyle} />
+                  <td className="model-lab-actions" style={footerStyle} />
                 </tr>
               </tfoot>
             </table>
@@ -683,7 +723,7 @@ function ContestRows({ contest, models, queued, onGenerateCell, onRunPanel }) {
         </td>
         {renderBaselineCell(favoritePick, contest.actualWinnerId, 'fav-su')}
         {renderBaselineCell(homePick, contest.actualWinnerId, 'home-su')}
-        <td rowSpan={2} style={{ ...cellStyle, verticalAlign: 'middle' }}>
+        <td rowSpan={2} className="model-lab-actions" style={{ ...cellStyle, verticalAlign: 'middle' }}>
           {hasHoles && !rowPanelQueued && (
             <button
               type="button"

--- a/src/UI/sd-ui/src/components/admin/AdminPage.css
+++ b/src/UI/sd-ui/src/components/admin/AdminPage.css
@@ -205,13 +205,17 @@
   }
 
   /* Paper is white regardless of app theme — pin readable ink colors
-     over the dark theme's light-on-dark variables. */
+     over the dark theme's light-on-dark variables, including the grade
+     and problem-marker colors the matrix cells resolve through vars. */
   .admin-page {
     background: #fff !important;
     color: #000 !important;
     --text-primary: #000;
     --text-secondary: #555;
     --border-primary: #999;
+    --color-success: #1e8449;
+    --color-danger: #c0392b;
+    --color-warning: #b9770e;
   }
 
   .admin-page table th,

--- a/src/UI/sd-ui/src/components/admin/AdminPage.css
+++ b/src/UI/sd-ui/src/components/admin/AdminPage.css
@@ -174,3 +174,67 @@
   font-size: 0.75rem;
   border-radius: 6px;
 }
+
+/* --- Model Lab PDF export (browser print-to-PDF) ---------------------
+   The screen page prints as a shareable matrix: admin chrome, controls,
+   and action buttons drop out; a title block drops in; grade tints are
+   forced through (browsers strip backgrounds by default). Model-name
+   anonymization is component state, not CSS — the header cells render
+   "Model A/B/..." while printMode is on. */
+.model-lab-print-header {
+  display: none;
+}
+
+@media print {
+  @page {
+    size: landscape;
+    margin: 10mm;
+  }
+
+  .admin-header,
+  .model-lab-no-print,
+  .model-lab-actions,
+  .model-lab-btn {
+    display: none !important;
+  }
+
+  .model-lab-print-header {
+    display: block;
+    margin-bottom: 12px;
+    color: #000;
+  }
+
+  /* Paper is white regardless of app theme — pin readable ink colors
+     over the dark theme's light-on-dark variables. */
+  .admin-page {
+    background: #fff !important;
+    color: #000 !important;
+    --text-primary: #000;
+    --text-secondary: #555;
+    --border-primary: #999;
+  }
+
+  .admin-page table th,
+  .admin-page table td {
+    print-color-adjust: exact;
+    -webkit-print-color-adjust: exact;
+  }
+}
+
+/* Print density: 12 columns must fit one landscape page. Inline styles
+   set the screen sizing, so the print overrides need !important. Model
+   headers render as stacked "Model / A" (component state) and center. */
+@media print {
+  .admin-page table {
+    font-size: 0.72rem !important;
+  }
+
+  .admin-page table th,
+  .admin-page table td {
+    padding: 3px 5px !important;
+  }
+
+  .model-lab-model-col {
+    text-align: center !important;
+  }
+}


### PR DESCRIPTION
Operator-requested: share the week's model matrix with league friends without granting admin access and without revealing the model lineup.

**Approach**: zero backend, zero auth surface - an Export PDF button drives the browser's print-to-PDF over a print stylesheet. While printing, model columns render as stacked anonymous letters (Model A/B/...); the print header carries league/season/week/date and deliberately omits the prompt name. Admin chrome, controls, and every action button drop out; grade tints are forced through print-color-adjust; density overrides fit all 12 columns on one landscape page. Screen rendering is untouched, and real names return on afterprint.

Known caveat (accepted): raw Ctrl+P prints real model names - anonymization is component state entered only via the button.

Validated locally by the operator against live week-1 data ("it fits now. ship it."). ESLint clean; web suite 83/83.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnJySMvfUPeQSMufNNcKSK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added browser print-to-PDF export for the Model Lab matrix.
  * PDF exports use anonymized model-column headers, including labels for more than 26 models, and include a print-only report header.
  * Export is unavailable when matrix data is missing, waits for headers to render, and automatically exits print mode afterward.

* **Style**
  * Added print-optimized formatting, including landscape layout, white paper styling, hidden administrative controls, and improved table sizing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->