### PR TITLE
fix(producer): ordered odds-provider preference; live odds never finalize a contest

### DIFF
--- a/src/SportsData.Producer/Application/Contests/BaseballContestEnrichmentProcessor.cs
+++ b/src/SportsData.Producer/Application/Contests/BaseballContestEnrichmentProcessor.cs
@@ -124,12 +124,10 @@ namespace SportsData.Producer.Application.Contests
                     contest.AwayScore.Value,
                     contest.HomeScore.Value);
 
-                // Refresh Contest-level denorm if a higher-priority provider
-                // just landed (e.g. EspnBet missing before, now present —
-                // promote it).
-                var primaryOddsLate = competition.Odds!
-                    .FirstOrDefault(o => o.FinalizedUtc.HasValue && o.ProviderId == SportsBook.EspnBet.ToProviderId())
-                    ?? competition.Odds!.FirstOrDefault(o => o.FinalizedUtc.HasValue);
+                // Refresh Contest-level denorm if a higher-preference
+                // provider just landed — ordered preference, live odds
+                // never eligible (see OddsProviderPreference).
+                var primaryOddsLate = OddsProviderPreference.SelectPrimary(competition.Odds);
 
                 if (primaryOddsLate != null)
                 {
@@ -270,9 +268,9 @@ namespace SportsData.Producer.Application.Contests
                     contest.AwayScore!.Value,
                     contest.HomeScore!.Value);
 
-                var primaryOdds = competition.Odds
-                    .FirstOrDefault(o => o.FinalizedUtc.HasValue && o.ProviderId == SportsBook.EspnBet.ToProviderId())
-                    ?? competition.Odds.FirstOrDefault(o => o.FinalizedUtc.HasValue);
+                // Ordered preference, live odds never eligible
+                // (see OddsProviderPreference).
+                var primaryOdds = OddsProviderPreference.SelectPrimary(competition.Odds);
 
                 if (primaryOdds != null)
                 {

--- a/src/SportsData.Producer/Application/Contests/FootballContestEnrichmentProcessor.cs
+++ b/src/SportsData.Producer/Application/Contests/FootballContestEnrichmentProcessor.cs
@@ -111,12 +111,10 @@ namespace SportsData.Producer.Application.Contests
                         contest.AwayScore.Value,
                         contest.HomeScore.Value);
 
-                    // Refresh Contest-level denorm if a higher-priority provider
-                    // just landed (e.g. EspnBet missing before, now present —
-                    // promote it).
-                    var primaryOddsLate = competition.Odds!
-                        .FirstOrDefault(o => o.FinalizedUtc.HasValue && o.ProviderId == SportsBook.EspnBet.ToProviderId())
-                        ?? competition.Odds!.FirstOrDefault(o => o.FinalizedUtc.HasValue);
+                    // Refresh Contest-level denorm if a higher-preference
+                    // provider just landed — ordered preference, live odds
+                    // never eligible (see OddsProviderPreference).
+                    var primaryOddsLate = OddsProviderPreference.SelectPrimary(competition.Odds);
 
                     if (primaryOddsLate != null)
                     {
@@ -263,10 +261,10 @@ namespace SportsData.Producer.Application.Contests
                         contest.AwayScore!.Value,
                         contest.HomeScore!.Value);
 
-                    // Maintain Contest-level denormalized fields from the primary provider
-                    var primaryOdds = competition.Odds
-                        .FirstOrDefault(o => o.FinalizedUtc.HasValue && o.ProviderId == SportsBook.EspnBet.ToProviderId())
-                        ?? competition.Odds.FirstOrDefault(o => o.FinalizedUtc.HasValue);
+                    // Maintain Contest-level denormalized fields from the
+                    // primary provider — ordered preference, live odds never
+                    // eligible (see OddsProviderPreference; Kent-SC 09-05).
+                    var primaryOdds = OddsProviderPreference.SelectPrimary(competition.Odds);
 
                     if (primaryOdds != null)
                     {

--- a/src/SportsData.Producer/Application/Contests/OddsProviderPreference.cs
+++ b/src/SportsData.Producer/Application/Contests/OddsProviderPreference.cs
@@ -55,11 +55,19 @@ namespace SportsData.Producer.Application.Contests
         {
             if (allOdds is null) return null;
 
-            var candidates = allOdds
-                .Where(o => o.FinalizedUtc.HasValue && !LiveOddsProviderIds.Contains(o.ProviderId))
+            // Live exclusion is the only pre-resolution filter. Finalized
+            // eligibility is checked AFTER provider resolution, mirroring
+            // the SQL laterals (which have no finalized filter): if the row
+            // the read-stack resolves to has no results yet, the denorm
+            // ABSTAINS rather than falling through to a row the product
+            // doesn't read. Unobservable at current call sites (enrichment
+            // finalizes every row before selection) but keeps the contract
+            // pure for any future caller (CodeRabbit, PR #732).
+            var nonLive = allOdds
+                .Where(o => !LiveOddsProviderIds.Contains(o.ProviderId))
                 .ToList();
 
-            var displayed = candidates
+            var displayed = nonLive
                 .Where(o => DisplayedProviderIds.Contains(o.ProviderId))
                 .ToList();
 
@@ -78,13 +86,17 @@ namespace SportsData.Producer.Application.Contests
                 foreach (var id in DisplayedProviderIds)
                 {
                     var match = displayed.FirstOrDefault(o => o.ProviderId == id);
-                    if (match != null) return match;
+                    if (match != null)
+                    {
+                        return match.FinalizedUtc.HasValue ? match : null;
+                    }
                 }
             }
 
             // Historical era: no displayed-set rows at all.
-            return candidates.FirstOrDefault(o => o.Spread.HasValue)
-                   ?? candidates.FirstOrDefault();
+            var finalized = nonLive.Where(o => o.FinalizedUtc.HasValue).ToList();
+            return finalized.FirstOrDefault(o => o.Spread.HasValue)
+                   ?? finalized.FirstOrDefault();
         }
     }
 }

--- a/src/SportsData.Producer/Application/Contests/OddsProviderPreference.cs
+++ b/src/SportsData.Producer/Application/Contests/OddsProviderPreference.cs
@@ -16,12 +16,13 @@ namespace SportsData.Producer.Application.Contests
     ///  2. When ANY row from the DISPLAYED set exists (the providers the
     ///     matchup cards and the API's pick-scoring snapshot read —
     ///     compile-time bound to <see cref="MatchupSqlBuilder"/>), selection
-    ///     resolves STRICTLY within that set, spread-carrying first. A
-    ///     spreadless displayed row beating a spread-carrying foreign book
-    ///     is deliberate: the product showed no line, picks were scored
-    ///     straight-up (PickScoringService's null-spread fallback), and the
-    ///     contest denorm must agree with what users experienced — an ATS
-    ///     winner from a book nobody saw would contradict the pick grades.
+    ///     MIRRORS the read-stack's exact resolution: provider order,
+    ///     first-existing wins, spread not considered — because that is
+    ///     precisely what the SQL laterals do (ORDER BY 58-first LIMIT 1).
+    ///     The denorm row is therefore the literal row users saw and picks
+    ///     were graded against; when that row is spreadless, ATS stays null
+    ///     (PickScoringService scored those picks straight-up) rather than
+    ///     asserting a winner from a line nobody was shown.
     ///  3. Only when NO displayed-set row exists (the historical corpus —
     ///     10,588 contests carry spreads exclusively from era books like
     ///     Westgate/SugarHouse/consensus, measured 2026-09-06) fall back to
@@ -64,16 +65,20 @@ namespace SportsData.Producer.Application.Contests
 
             if (displayed.Count > 0)
             {
-                // Modern era: resolve strictly within what the product reads.
+                // Modern era: mirror the read-stack's EXACT resolution — the
+                // SQL laterals are provider-order LIMIT 1 with spread never
+                // considered (ORDER BY 58-first). The denorm row must be the
+                // literal row display/scoring reads, so a spreadless 58
+                // shadowing a spread-carrying 100 leaves ATS null BY DESIGN:
+                // the product showed no line and picks scored straight-up
+                // (Vortex round 3, PR #732). Preferring spread within this
+                // set is a real product improvement, but it starts with the
+                // SQL laterals (Producer GetMatchup*.sql + the API's copies)
+                // and this method flips in the SAME change.
                 foreach (var id in DisplayedProviderIds)
                 {
-                    var withSpread = displayed.FirstOrDefault(o => o.ProviderId == id && o.Spread.HasValue);
-                    if (withSpread != null) return withSpread;
-                }
-                foreach (var id in DisplayedProviderIds)
-                {
-                    var any = displayed.FirstOrDefault(o => o.ProviderId == id);
-                    if (any != null) return any;
+                    var match = displayed.FirstOrDefault(o => o.ProviderId == id);
+                    if (match != null) return match;
                 }
             }
 

--- a/src/SportsData.Producer/Application/Contests/OddsProviderPreference.cs
+++ b/src/SportsData.Producer/Application/Contests/OddsProviderPreference.cs
@@ -39,12 +39,18 @@ namespace SportsData.Producer.Application.Contests
         };
 
         /// <summary>
-        /// The finalized, non-live row to denormalize from: first match in
-        /// preference order; for unknown books, one carrying a spread beats
-        /// one without. Null when nothing qualifies — callers then leave the
-        /// Contest-level ATS/O-U fields alone rather than denormalizing
-        /// garbage (a null here on a finalized contest reads as "no line",
-        /// not "push").
+        /// The finalized, non-live row to denormalize from. Spread presence
+        /// outranks book preference: a spread-carrying row from ANY book
+        /// beats a spreadless row from a preferred one — EnrichOddsResults
+        /// finalizes spreadless (moneyline/O-U-only) rows too, and choosing
+        /// one while a real pregame line exists elsewhere recreates the
+        /// null-ATS "push" this policy exists to kill (Vortex, PR #732).
+        /// Selection: (1) preference order among spread-carrying rows;
+        /// (2) any spread-carrying row; (3) no spread anywhere — preference
+        /// order among the rest, so O-U still denormalizes from the best
+        /// book while ATS stays legitimately null ("no line", not "push");
+        /// (4) null when nothing qualifies — callers leave the
+        /// Contest-level fields alone.
         /// </summary>
         public static CompetitionOdds? SelectPrimary(IEnumerable<CompetitionOdds>? allOdds)
         {
@@ -56,12 +62,20 @@ namespace SportsData.Producer.Application.Contests
 
             foreach (var id in PreferredProviderIds)
             {
+                var match = candidates.FirstOrDefault(o => o.ProviderId == id && o.Spread.HasValue);
+                if (match != null) return match;
+            }
+
+            var anyWithSpread = candidates.FirstOrDefault(o => o.Spread.HasValue);
+            if (anyWithSpread != null) return anyWithSpread;
+
+            foreach (var id in PreferredProviderIds)
+            {
                 var match = candidates.FirstOrDefault(o => o.ProviderId == id);
                 if (match != null) return match;
             }
 
-            return candidates.FirstOrDefault(o => o.Spread.HasValue)
-                   ?? candidates.FirstOrDefault();
+            return candidates.FirstOrDefault();
         }
     }
 }

--- a/src/SportsData.Producer/Application/Contests/OddsProviderPreference.cs
+++ b/src/SportsData.Producer/Application/Contests/OddsProviderPreference.cs
@@ -1,0 +1,67 @@
+using SportsData.Producer.Enums;
+using SportsData.Producer.Extensions;
+using SportsData.Producer.Infrastructure.Data.Entities;
+
+namespace SportsData.Producer.Application.Contests
+{
+    /// <summary>
+    /// Which <see cref="CompetitionOdds"/> row is the PRIMARY for
+    /// Contest-level denorm (SpreadWinnerFranchiseSeasonId / OverUnder)
+    /// and odds reconciliation.
+    ///
+    /// Two rules, born of Kent State @ South Carolina 2026-09-05 (0-57
+    /// against SC -35.5, graded a PUSH because the old
+    /// "EspnBet-or-arbitrary-FirstOrDefault" fallback picked the
+    /// "DraftKings - Live Odds" row, whose null spread yields a null ATS
+    /// winner):
+    ///  1. LIVE odds rows are NEVER primary. They are in-game snapshots
+    ///     (ESPN deletes them post-game); the pregame closing line is the
+    ///     record a pick was made against.
+    ///  2. Preference is an ORDERED LIST, not a single id with an
+    ///     arbitrary fallback. ESPN's featured book changed from ESPN Bet
+    ///     to DraftKings for 2026; either (or both) can appear.
+    /// <see cref="Queries.Matchups.MatchupSqlBuilder"/> encodes the same
+    /// order for display SQL — keep them aligned.
+    /// </summary>
+    public static class OddsProviderPreference
+    {
+        public static readonly string[] PreferredProviderIds =
+        {
+            SportsBook.EspnBet.ToProviderId(),          // 58
+            SportsBook.DraftKings100.ToProviderId(),    // 100
+            SportsBook.DraftKings.ToProviderId(),       // 40
+        };
+
+        public static readonly string[] LiveOddsProviderIds =
+        {
+            SportsBook.EspnBetLiveOdds.ToProviderId(),     // 59
+            SportsBook.DraftKingsLiveOdds.ToProviderId(),  // 200
+        };
+
+        /// <summary>
+        /// The finalized, non-live row to denormalize from: first match in
+        /// preference order; for unknown books, one carrying a spread beats
+        /// one without. Null when nothing qualifies — callers then leave the
+        /// Contest-level ATS/O-U fields alone rather than denormalizing
+        /// garbage (a null here on a finalized contest reads as "no line",
+        /// not "push").
+        /// </summary>
+        public static CompetitionOdds? SelectPrimary(IEnumerable<CompetitionOdds>? allOdds)
+        {
+            if (allOdds is null) return null;
+
+            var candidates = allOdds
+                .Where(o => o.FinalizedUtc.HasValue && !LiveOddsProviderIds.Contains(o.ProviderId))
+                .ToList();
+
+            foreach (var id in PreferredProviderIds)
+            {
+                var match = candidates.FirstOrDefault(o => o.ProviderId == id);
+                if (match != null) return match;
+            }
+
+            return candidates.FirstOrDefault(o => o.Spread.HasValue)
+                   ?? candidates.FirstOrDefault();
+        }
+    }
+}

--- a/src/SportsData.Producer/Application/Contests/OddsProviderPreference.cs
+++ b/src/SportsData.Producer/Application/Contests/OddsProviderPreference.cs
@@ -1,3 +1,4 @@
+using SportsData.Producer.Application.Contests.Queries.Matchups;
 using SportsData.Producer.Enums;
 using SportsData.Producer.Extensions;
 using SportsData.Producer.Infrastructure.Data.Entities;
@@ -6,30 +7,41 @@ namespace SportsData.Producer.Application.Contests
 {
     /// <summary>
     /// Which <see cref="CompetitionOdds"/> row is the PRIMARY for
-    /// Contest-level denorm (SpreadWinnerFranchiseSeasonId / OverUnder)
-    /// and odds reconciliation.
+    /// Contest-level denorm (SpreadWinnerFranchiseSeasonId / OverUnder).
     ///
-    /// Two rules, born of Kent State @ South Carolina 2026-09-05 (0-57
-    /// against SC -35.5, graded a PUSH because the old
-    /// "EspnBet-or-arbitrary-FirstOrDefault" fallback picked the
-    /// "DraftKings - Live Odds" row, whose null spread yields a null ATS
-    /// winner):
-    ///  1. LIVE odds rows are NEVER primary. They are in-game snapshots
-    ///     (ESPN deletes them post-game); the pregame closing line is the
-    ///     record a pick was made against.
-    ///  2. Preference is an ORDERED LIST, not a single id with an
-    ///     arbitrary fallback. ESPN's featured book changed from ESPN Bet
-    ///     to DraftKings for 2026; either (or both) can appear.
-    /// <see cref="Queries.Matchups.MatchupSqlBuilder"/> encodes the same
-    /// order for display SQL — keep them aligned.
+    /// Contract (Kent State @ South Carolina 2026-09-05 + Vortex rounds on
+    /// PR #732):
+    ///  1. LIVE odds rows are NEVER primary — in-game snapshots, deleted by
+    ///     ESPN post-game; the pregame line is the record.
+    ///  2. When ANY row from the DISPLAYED set exists (the providers the
+    ///     matchup cards and the API's pick-scoring snapshot read —
+    ///     compile-time bound to <see cref="MatchupSqlBuilder"/>), selection
+    ///     resolves STRICTLY within that set, spread-carrying first. A
+    ///     spreadless displayed row beating a spread-carrying foreign book
+    ///     is deliberate: the product showed no line, picks were scored
+    ///     straight-up (PickScoringService's null-spread fallback), and the
+    ///     contest denorm must agree with what users experienced — an ATS
+    ///     winner from a book nobody saw would contradict the pick grades.
+    ///  3. Only when NO displayed-set row exists (the historical corpus —
+    ///     10,588 contests carry spreads exclusively from era books like
+    ///     Westgate/SugarHouse/consensus, measured 2026-09-06) fall back to
+    ///     any other non-live book, spread-carrying first, so historical
+    ///     re-finalization preserves the corpus ATS record.
+    ///  4. Null when nothing qualifies — callers leave the Contest-level
+    ///     fields alone ("no line", never "push").
     /// </summary>
     public static class OddsProviderPreference
     {
-        public static readonly string[] PreferredProviderIds =
+        /// <summary>
+        /// The set the display/scoring read-stack queries (see
+        /// MatchupSqlBuilder + GetMatchup*.sql lateral joins). Order is the
+        /// preference order. Widening this set REQUIRES widening the SQL on
+        /// both the Producer and API sides in the same change.
+        /// </summary>
+        public static readonly string[] DisplayedProviderIds =
         {
-            SportsBook.EspnBet.ToProviderId(),          // 58
-            SportsBook.DraftKings100.ToProviderId(),    // 100
-            SportsBook.DraftKings.ToProviderId(),       // 40
+            MatchupSqlBuilder.PreferredOddsProviderId.ToString(),   // 58 EspnBet
+            MatchupSqlBuilder.FallbackOddsProviderId.ToString(),    // 100 DraftKings (2026 featured)
         };
 
         public static readonly string[] LiveOddsProviderIds =
@@ -38,20 +50,6 @@ namespace SportsData.Producer.Application.Contests
             SportsBook.DraftKingsLiveOdds.ToProviderId(),  // 200
         };
 
-        /// <summary>
-        /// The finalized, non-live row to denormalize from. Spread presence
-        /// outranks book preference: a spread-carrying row from ANY book
-        /// beats a spreadless row from a preferred one — EnrichOddsResults
-        /// finalizes spreadless (moneyline/O-U-only) rows too, and choosing
-        /// one while a real pregame line exists elsewhere recreates the
-        /// null-ATS "push" this policy exists to kill (Vortex, PR #732).
-        /// Selection: (1) preference order among spread-carrying rows;
-        /// (2) any spread-carrying row; (3) no spread anywhere — preference
-        /// order among the rest, so O-U still denormalizes from the best
-        /// book while ATS stays legitimately null ("no line", not "push");
-        /// (4) null when nothing qualifies — callers leave the
-        /// Contest-level fields alone.
-        /// </summary>
         public static CompetitionOdds? SelectPrimary(IEnumerable<CompetitionOdds>? allOdds)
         {
             if (allOdds is null) return null;
@@ -60,22 +58,28 @@ namespace SportsData.Producer.Application.Contests
                 .Where(o => o.FinalizedUtc.HasValue && !LiveOddsProviderIds.Contains(o.ProviderId))
                 .ToList();
 
-            foreach (var id in PreferredProviderIds)
+            var displayed = candidates
+                .Where(o => DisplayedProviderIds.Contains(o.ProviderId))
+                .ToList();
+
+            if (displayed.Count > 0)
             {
-                var match = candidates.FirstOrDefault(o => o.ProviderId == id && o.Spread.HasValue);
-                if (match != null) return match;
+                // Modern era: resolve strictly within what the product reads.
+                foreach (var id in DisplayedProviderIds)
+                {
+                    var withSpread = displayed.FirstOrDefault(o => o.ProviderId == id && o.Spread.HasValue);
+                    if (withSpread != null) return withSpread;
+                }
+                foreach (var id in DisplayedProviderIds)
+                {
+                    var any = displayed.FirstOrDefault(o => o.ProviderId == id);
+                    if (any != null) return any;
+                }
             }
 
-            var anyWithSpread = candidates.FirstOrDefault(o => o.Spread.HasValue);
-            if (anyWithSpread != null) return anyWithSpread;
-
-            foreach (var id in PreferredProviderIds)
-            {
-                var match = candidates.FirstOrDefault(o => o.ProviderId == id);
-                if (match != null) return match;
-            }
-
-            return candidates.FirstOrDefault();
+            // Historical era: no displayed-set rows at all.
+            return candidates.FirstOrDefault(o => o.Spread.HasValue)
+                   ?? candidates.FirstOrDefault();
         }
     }
 }

--- a/src/SportsData.Producer/Application/Contests/Queries/Matchups/MatchupSqlBuilder.cs
+++ b/src/SportsData.Producer/Application/Contests/Queries/Matchups/MatchupSqlBuilder.cs
@@ -13,6 +13,12 @@ public static class MatchupSqlBuilder
     /// Preferred odds provider (ESPN Bet). Fallback is DraftKings.
     /// These map to SportsBook enum values stored in CompetitionOdds.ProviderId.
     /// </summary>
+    // These two ids ARE the "displayed set": OddsProviderPreference derives
+    // its finalization set from these constants so contest denorms can only
+    // come from lines the matchup cards and the API scoring snapshot read
+    // (modern era; see its historical fallback). Widening here requires
+    // widening the lateral joins in the Producer GetMatchup*.sql AND the
+    // API's GetMatchupResultByContestId.sql in the same change.
     public const int PreferredOddsProviderId = (int)SportsBook.EspnBet;       // 58
     public const int FallbackOddsProviderId = (int)SportsBook.DraftKings100;   // 100
 }

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Contests/OddsProviderPreferenceTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Contests/OddsProviderPreferenceTests.cs
@@ -1,0 +1,88 @@
+using FluentAssertions;
+
+using SportsData.Producer.Application.Contests;
+using SportsData.Producer.Infrastructure.Data.Entities;
+
+using Xunit;
+
+namespace SportsData.Producer.Tests.Unit.Application.Contests;
+
+public class OddsProviderPreferenceTests
+{
+    private static CompetitionOdds Odds(
+        string providerId, string providerName, decimal? spread, bool finalized = true)
+        => new()
+        {
+            Id = Guid.NewGuid(),
+            CompetitionId = Guid.NewGuid(),
+            ProviderRef = new Uri($"http://sports.core.api.espn.com/v2/providers/{providerId}"),
+            ProviderId = providerId,
+            ProviderName = providerName,
+            Spread = spread,
+            FinalizedUtc = finalized ? DateTime.UtcNow : null,
+        };
+
+    [Fact]
+    public void KentStateRegression_LiveOddsRowNeverWins_PregameDraftKingsSelected()
+    {
+        // 2026-09-05: KENT 0 @ SC 57, DK -35.5. The live-odds row (200) has
+        // no spread; picking it graded the game a push. The pregame
+        // DraftKings row (100) must win regardless of collection order.
+        var live = Odds("200", "DraftKings - Live Odds", spread: null);
+        var pregame = Odds("100", "DraftKings", spread: -35.5m);
+
+        OddsProviderPreference.SelectPrimary(new[] { live, pregame })
+            .Should().BeSameAs(pregame);
+        OddsProviderPreference.SelectPrimary(new[] { pregame, live })
+            .Should().BeSameAs(pregame);
+    }
+
+    [Fact]
+    public void EspnBetPreferredOverDraftKings()
+    {
+        var espnBet = Odds("58", "ESPN BET", spread: -3.5m);
+        var dk = Odds("100", "DraftKings", spread: -3m);
+
+        OddsProviderPreference.SelectPrimary(new[] { dk, espnBet })
+            .Should().BeSameAs(espnBet);
+    }
+
+    [Fact]
+    public void OnlyLiveOddsRows_ReturnsNull_NeverALiveRow()
+    {
+        // Rule 1: live odds are NEVER primary - a null here means callers
+        // leave the Contest-level denorm alone instead of writing garbage.
+        var liveDk = Odds("200", "DraftKings - Live Odds", spread: -20m);
+        var liveEspn = Odds("59", "ESPN BET - Live Odds", spread: -21m);
+
+        OddsProviderPreference.SelectPrimary(new[] { liveDk, liveEspn })
+            .Should().BeNull();
+    }
+
+    [Fact]
+    public void UnfinalizedRowsAreIgnored()
+    {
+        var unfinalized = Odds("58", "ESPN BET", spread: -3.5m, finalized: false);
+        var finalized = Odds("100", "DraftKings", spread: -3m);
+
+        OddsProviderPreference.SelectPrimary(new[] { unfinalized, finalized })
+            .Should().BeSameAs(finalized);
+    }
+
+    [Fact]
+    public void UnknownBooks_RowWithSpreadBeatsRowWithout()
+    {
+        var spreadless = Odds("31", "Caesars", spread: null);
+        var withSpread = Odds("47", "MGM", spread: -7m);
+
+        OddsProviderPreference.SelectPrimary(new[] { spreadless, withSpread })
+            .Should().BeSameAs(withSpread);
+    }
+
+    [Fact]
+    public void EmptyOrNull_ReturnsNull()
+    {
+        OddsProviderPreference.SelectPrimary(null).Should().BeNull();
+        OddsProviderPreference.SelectPrimary(Array.Empty<CompetitionOdds>()).Should().BeNull();
+    }
+}

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Contests/OddsProviderPreferenceTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Contests/OddsProviderPreferenceTests.cs
@@ -89,21 +89,20 @@ public class OddsProviderPreferenceTests
     }
 
     [Fact]
-    public void ModernContest_SpreadCarryingDisplayedRowBeatsSpreadlessOne()
+    public void ModernContest_MirrorsSqlLateralExactly_ProviderOrderSpreadIgnored()
     {
-        // Within the displayed set, spread presence outranks book order:
-        // a spreadless DK100 must not beat an EspnBet line and vice versa.
-        var dkSpreadless = Odds("100", "DraftKings", spread: null);
-        var dkWithSpread2 = Odds("58", "ESPN BET", spread: -3m);
-
-        OddsProviderPreference.SelectPrimary(new[] { dkSpreadless, dkWithSpread2 })
-            .Should().BeSameAs(dkWithSpread2);
-
+        // Vortex round 3 (PR #732): the SQL laterals resolve by provider
+        // order LIMIT 1 with spread never considered, and the denorm row
+        // must be the LITERAL row the display/scoring stack reads. So a
+        // spreadless 58 shadows a spread-carrying 100 - ATS stays null,
+        // matching the no-line-shown, scored-straight-up experience.
+        // (Flipping this to spread-first starts with the SQL laterals on
+        // both services, then this policy, in the same change.)
         var espnSpreadless = Odds("58", "ESPN BET", spread: null);
         var dkWithSpread = Odds("100", "DraftKings", spread: -35.5m);
 
-        OddsProviderPreference.SelectPrimary(new[] { espnSpreadless, dkWithSpread })
-            .Should().BeSameAs(dkWithSpread);
+        OddsProviderPreference.SelectPrimary(new[] { dkWithSpread, espnSpreadless })
+            .Should().BeSameAs(espnSpreadless);
     }
 
     [Fact]

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Contests/OddsProviderPreferenceTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Contests/OddsProviderPreferenceTests.cs
@@ -64,13 +64,19 @@ public class OddsProviderPreferenceTests
     }
 
     [Fact]
-    public void UnfinalizedRowsAreIgnored()
+    public void UnfinalizedDisplayedRow_ShadowsAndAbstains()
     {
+        // The SQL laterals have no finalized filter - they resolve to the
+        // 58 row regardless. If that exact row has no results yet, the
+        // denorm ABSTAINS; falling through to the 100 row would denorm
+        // from a row the product does not read (CodeRabbit, PR #732).
+        // Unobservable at current call sites (enrichment finalizes all
+        // rows before selection) - this pins the contract for future ones.
         var unfinalized = Odds("58", "ESPN BET", spread: -3.5m, finalized: false);
         var finalized = Odds("100", "DraftKings", spread: -3m);
 
         OddsProviderPreference.SelectPrimary(new[] { unfinalized, finalized })
-            .Should().BeSameAs(finalized);
+            .Should().BeNull();
     }
 
     [Fact]

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Contests/OddsProviderPreferenceTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Contests/OddsProviderPreferenceTests.cs
@@ -74,35 +74,46 @@ public class OddsProviderPreferenceTests
     }
 
     [Fact]
-    public void SpreadlessPreferredRow_LosesToSpreadCarryingUnknownBook()
+    public void ModernContest_ResolvesWithinDisplayedSet_ForeignLineNeverFinalizes()
     {
-        // Vortex (PR #732): a preferred-tier row posted moneyline/O-U-only
-        // must not beat a real pregame line from a lesser book - that
-        // recreates the null-ATS push. Spread presence outranks preference.
+        // Vortex round 2 (PR #732): the display/scoring stack reads only
+        // 58/100. When a displayed-set row exists - even spreadless - a
+        // foreign book's line must NOT finalize the contest: the product
+        // showed no line and picks were scored straight-up, so an ATS
+        // winner from a book nobody saw would contradict the pick grades.
         var dkSpreadless = Odds("100", "DraftKings", spread: null);
         var caesarsWithSpread = Odds("31", "Caesars", spread: -6.5m);
 
-        OddsProviderPreference.SelectPrimary(new[] { dkSpreadless, caesarsWithSpread })
-            .Should().BeSameAs(caesarsWithSpread);
-    }
-
-    [Fact]
-    public void NoSpreadAnywhere_PreferredRowStillSelectedForOverUnder()
-    {
-        // With no pregame line at all, ATS legitimately stays null - but the
-        // O-U denorm should still come from the preferred book.
-        var dkSpreadless = Odds("100", "DraftKings", spread: null);
-        var caesarsSpreadless = Odds("31", "Caesars", spread: null);
-
-        OddsProviderPreference.SelectPrimary(new[] { caesarsSpreadless, dkSpreadless })
+        OddsProviderPreference.SelectPrimary(new[] { caesarsWithSpread, dkSpreadless })
             .Should().BeSameAs(dkSpreadless);
     }
 
     [Fact]
-    public void UnknownBooks_RowWithSpreadBeatsRowWithout()
+    public void ModernContest_SpreadCarryingDisplayedRowBeatsSpreadlessOne()
     {
+        // Within the displayed set, spread presence outranks book order:
+        // a spreadless DK100 must not beat an EspnBet line and vice versa.
+        var dkSpreadless = Odds("100", "DraftKings", spread: null);
+        var dkWithSpread2 = Odds("58", "ESPN BET", spread: -3m);
+
+        OddsProviderPreference.SelectPrimary(new[] { dkSpreadless, dkWithSpread2 })
+            .Should().BeSameAs(dkWithSpread2);
+
+        var espnSpreadless = Odds("58", "ESPN BET", spread: null);
+        var dkWithSpread = Odds("100", "DraftKings", spread: -35.5m);
+
+        OddsProviderPreference.SelectPrimary(new[] { espnSpreadless, dkWithSpread })
+            .Should().BeSameAs(dkWithSpread);
+    }
+
+    [Fact]
+    public void HistoricalContest_NoDisplayedRows_FallsBackToSpreadCarryingEraBook()
+    {
+        // The pre-2023 corpus (10,588 contests measured 2026-09-06) carries
+        // spreads only from era books - historical re-finalization must
+        // preserve their ATS record.
         var spreadless = Odds("31", "Caesars", spread: null);
-        var withSpread = Odds("47", "MGM", spread: -7m);
+        var withSpread = Odds("25", "Westgate", spread: -7m);
 
         OddsProviderPreference.SelectPrimary(new[] { spreadless, withSpread })
             .Should().BeSameAs(withSpread);

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Contests/OddsProviderPreferenceTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Contests/OddsProviderPreferenceTests.cs
@@ -9,6 +9,10 @@ namespace SportsData.Producer.Tests.Unit.Application.Contests;
 
 public class OddsProviderPreferenceTests
 {
+    // Fixed timestamp: only HasValue matters to the policy, and the repo
+    // convention bans direct clock access in tests either way.
+    private static readonly DateTime FinalizedAt = new(2026, 9, 5, 23, 0, 0, DateTimeKind.Utc);
+
     private static CompetitionOdds Odds(
         string providerId, string providerName, decimal? spread, bool finalized = true)
         => new()
@@ -19,7 +23,7 @@ public class OddsProviderPreferenceTests
             ProviderId = providerId,
             ProviderName = providerName,
             Spread = spread,
-            FinalizedUtc = finalized ? DateTime.UtcNow : null,
+            FinalizedUtc = finalized ? FinalizedAt : null,
         };
 
     [Fact]
@@ -67,6 +71,31 @@ public class OddsProviderPreferenceTests
 
         OddsProviderPreference.SelectPrimary(new[] { unfinalized, finalized })
             .Should().BeSameAs(finalized);
+    }
+
+    [Fact]
+    public void SpreadlessPreferredRow_LosesToSpreadCarryingUnknownBook()
+    {
+        // Vortex (PR #732): a preferred-tier row posted moneyline/O-U-only
+        // must not beat a real pregame line from a lesser book - that
+        // recreates the null-ATS push. Spread presence outranks preference.
+        var dkSpreadless = Odds("100", "DraftKings", spread: null);
+        var caesarsWithSpread = Odds("31", "Caesars", spread: -6.5m);
+
+        OddsProviderPreference.SelectPrimary(new[] { dkSpreadless, caesarsWithSpread })
+            .Should().BeSameAs(caesarsWithSpread);
+    }
+
+    [Fact]
+    public void NoSpreadAnywhere_PreferredRowStillSelectedForOverUnder()
+    {
+        // With no pregame line at all, ATS legitimately stays null - but the
+        // O-U denorm should still come from the preferred book.
+        var dkSpreadless = Odds("100", "DraftKings", spread: null);
+        var caesarsSpreadless = Odds("31", "Caesars", spread: null);
+
+        OddsProviderPreference.SelectPrimary(new[] { caesarsSpreadless, dkSpreadless })
+            .Should().BeSameAs(dkSpreadless);
     }
 
     [Fact]


### PR DESCRIPTION
**Incident**: Kent State @ South Carolina, 0–57 against SC −35.5, graded a **push**. Full analysis: `docs/audit/kent-at-scar.txt`.

**Root cause**: the enrichment processors selected the primary `CompetitionOdds` row as *EspnBet-or-arbitrary-FirstOrDefault*. ESPN's featured book switched to DraftKings for 2026, so EspnBet is absent and the fallback took whatever EF loaded first — for this game, "DraftKings - Live Odds" (null spread → null ATS winner → push). The worse, invisible mode (operator's catch): a live row that *carries* an in-game spread finalizes a plausible but wrong ATS winner. `MatchupSqlBuilder` already had the correct preference order for display SQL, which is why matchup cards were right all season while finalization was load-order roulette.

**Fix**: `OddsProviderPreference.SelectPrimary`, consumed by all four selection sites (Football + Baseball, fresh-finalization + odds-late):
- Live rows (59, 200) are **never** primary; live-only → null → contest denorm untouched ("no line", never "push") — nobody gets graded against a line that didn't exist pregame.
- Ordered preference 58 → 100 → 40; unknown books prefer a spread-carrying row.

**Tests**: Kent–SC regression (order-independent), live-only → null, preference ordering, unfinalized exclusion, empty/null. Producer 653/653.

**Post-merge remediation** (operator-directed, staged in `sql/pgsql/_remediation_odds_provider_2026_09.sql`): snapshot → clear finalization/audit flags for `FinalizedUtc >= 2026-09-04` (scores untouched) → finalization sweep re-derives under the new policy and re-scores picks → diff reports every flipped game. MLB scope pending its detection count. Must deploy before tonight's three NCAAFB finals.

**Deferred follow-up**: `CompetitionOdds.SpreadWinner`/`MoneylineWinner` bool → bool? (false-with-null-spread is misleading; enrichment never reads them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnJySMvfUPeQSMufNNcKSK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Contest odds now consistently prioritize preferred sportsbook providers.
  * Live and unfinalized odds are excluded from primary contest odds selection.
  * Preferred providers take precedence regardless of spread availability.
  * Eligible finalized alternatives are selected when preferred providers are unavailable.
  * Primary odds remain unset when no qualifying options are available.

* **Tests**
  * Added coverage for provider preference ordering, live and unfinalized odds exclusion, fallback selection, spread-independent prioritization, and empty or unavailable odds scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->