### PR TITLE
feat(provider): index-level already-seen skip for live streamer fan-out

### DIFF
--- a/docs/features/live-sourcing-already-seen-skip.md
+++ b/docs/features/live-sourcing-already-seen-skip.md
@@ -1,0 +1,281 @@
+# Live Sourcing O(N) Re-Emission — Index-Level Already-Seen Skip
+
+Status: **Implemented in working tree** (branch `feat/live-sourcing-seen-skip`;
+awaiting operator review — no commit/PR yet)
+Last updated: 2026-09-07
+Scope: live competition streaming (NCAAFB/NFL now; any streamed sport). Successor to
+`docs/features/in-season-cache-bypass-fix.md` — this implements that doc's deferred
+**Design option #2 ("Reduce demand at the source")**, promoted from follow-on to
+required by the 2026-09-06 evidence below.
+
+## Problem
+
+During a live game, every polling cycle re-enqueues **every item the game has ever
+produced**, not just what is new. The 2026-07 fix (#549/#551) redirected the redundant
+fetches from ESPN to Mongo for `EventCompetitionPlay` — but the redundant *work* still
+exists at every other stage: a Hangfire job on `00-live`, a Mongo read, a
+`DocumentCreated` publish to RabbitMQ, and a full Producer processing hop, for every
+already-seen item, every cycle.
+
+### Evidence (2026-09-06 evening, 2 streamed NCAAFB games)
+
+Grafana, per-interval counts (NOT cumulative):
+
+- **MongoDB Cache Hits vs ESPN Live Fetches** (Provider): both series climb
+  *linearly* for the duration of each game — cache hits ~500 → ~3,800/interval,
+  ESPN fetches ~500 → ~1,700/interval — then drop when a game ends (~19:45, ~23:10
+  sawtooth resets).
+- **Documents Processed by Type** (Producer): `EventCompetitionPlay`
+  **1,314,943** documents processed in one evening; `EventCompetitionProbability`
+  **611,931**; `EventCompetitionDrive` 118,409. The games contained roughly
+  500–600 real plays. **Amplification ≈ 2,000x.**
+
+### Growth model
+
+Per-interval work proportional to N (items so far) with N growing ~linearly in game
+time ⇒ the chart's linear per-interval climb ⇒ **quadratic cumulative cost per game**
+(≈ N²/2 fetch-units for an N-play game). A 180-play game at the 10s play cadence
+(~720 cycles over 2h) costs ~720 × N/2 ≈ 65,000 pipeline traversals for plays alone.
+
+## Root cause — three compounding gaps
+
+`FootballCompetitionStreamer` polls per live game: plays index every **10s**,
+probabilities every **15s**, drives 15s, situation 5s, leaders 60s. Each poll lands in
+`DocumentRequestedHandler.ProcessResourceIndex`, which pages the entire index and
+enqueues one `ProcessResourceIndexItemCommand` per item.
+
+1. **The fan-out has no memory.** Nothing at the enqueue site knows an item was
+   already sourced and published. All N items become Hangfire jobs every cycle;
+   only the *fetch destination* (Mongo vs ESPN) is optimized downstream.
+2. **`EventCompetitionProbability` is not in `InSeasonDocumentPolicy`.** The
+   predecessor doc's *draft* classification listed it as mutable ("needs
+   confirmation") and deliberately shipped the allow-list as
+   `{ EventCompetitionPlay }` only. Probability items are per-play and immutable
+   once the play completes — so the probabilities fan-out sends all N items to
+   **ESPN** every 15s. This is the bulk of the ESPN-fetch line's linear growth.
+3. **Cache hits still republish.** `ResourceIndexItemProcessor.HandleValid`: the
+   unchanged-content/cooldown suppression is gated `!IsCurrentSeason(...)`
+   (correct for mutable in-season docs, which must always flow), so a
+   current-season cache HIT for an immutable play still publishes a full
+   `DocumentCreated` → Producer processes every play once per ~10s for the rest
+   of the game. This is the Producer chart's cyan line.
+
+Additionally (smaller, uncounted): the index *pages themselves* are fetched from
+ESPN with `bypassCache: true` every cycle, and page count grows with the game.
+These fetches don't increment `espn.live.fetch`, so they are invisible on the
+current panel.
+
+## The pipeline, visualized
+
+### Today — where the amplification lives
+
+Every polling cycle (plays every 10s, probs every 15s, per live game), with N =
+items the game has produced so far (~180 plays by game end):
+
+```mermaid
+flowchart TD
+    S["CompetitionStreamer (Producer)<br/>polls plays index 10s, probs 15s"]
+    S -->|"DocumentRequested (Priority)"| H["DocumentRequestedHandler.ProcessResourceIndex<br/>(Provider)"]
+    H -->|"re-pages FULL index from ESPN<br/>every cycle (uncounted fetches)"| ESPNIDX["ESPN index pages"]
+    H -->|"GAP 1: no memory —<br/>enqueues ALL N items, every cycle"| Q["Hangfire 00-live<br/>N jobs per cycle"]
+    Q --> P["ResourceIndexItemProcessor<br/>(any Provider pod)"]
+    P -->|"Play: in policy —<br/>served from Mongo<br/>(green line, N/cycle)"| M[("Mongo doc store")]
+    P -->|"GAP 2: Probability NOT in policy —<br/>fetched from ESPN<br/>(red line, N/cycle)"| ESPN["ESPN item fetch"]
+    P -->|"GAP 3: in-season cache hit<br/>ALWAYS republishes"| PUB["DocumentCreated x N per cycle"]
+    PUB --> R["RabbitMQ"]
+    R --> PROD["Producer processors<br/>1,314,943 plays processed in one evening"]
+```
+
+The three gaps compound: gap 1 creates N-per-cycle work, gap 2 points most of it
+at ESPN, gap 3 forwards all of it to Producer even when it lands on Mongo.
+
+### The fix — layered checks at the fan-out
+
+One decision point, at the enqueue site, so skipped work never exists anywhere
+downstream (no Hangfire job, no Mongo read, no publish, no Producer hop):
+
+```mermaid
+flowchart TD
+    ITEM["index item (per cycle)"] --> G{"Priority + immutable type<br/>+ current season + NOT live edge?"}
+    G -->|"no — mutable, live edge,<br/>reenrich/on-final/historical"| ENQ["enqueue (unchanged behavior)"]
+    G -->|yes| L1{"L1: in-memory SeenUriCache<br/>did THIS POD enqueue it already?"}
+    L1 -->|yes| SKIP["SKIP — nothing downstream"]
+    L1 -->|no| L2{"L2: batched Mongo _id $in<br/>is the document ALREADY PERSISTED?"}
+    L2 -->|yes| SKIP
+    L2 -->|no| ENQ2["enqueue + mark seen"]
+```
+
+- **L1** is per-pod and covers the in-flight window: items enqueued seconds
+  ago whose Hangfire job hasn't persisted yet. Its weakness alone: a
+  fresh/other pod hasn't marked anything (residual ≈ one full walk per pod), and
+  a mark can outlive a job that failed permanently (masked until TTL).
+- **L2** is the durable, cross-pod truth: one `$in` query on `_id` (primary
+  key) per index page (`IDocumentStore.GetExistingIdsAsync`), built only from
+  hashes L1 doesn't already know, against the collection the item processor
+  would read anyway. "Seen" = "persisted" — it cannot drift and cannot mask a
+  failed job, because a document that never landed is simply not there and
+  re-enqueues next cycle. It also *replaces* N individual per-item Mongo reads
+  with one batched read. **Fails open**: on a store error the items simply
+  enqueue (pre-skip behavior) — a Mongo hiccup must never stall live sourcing.
+  L2 hits are promoted into L1, so the next cycle's batch query shrinks to
+  genuinely new items.
+- Together: same-pod repeats die at L1 for free; everything else — restarts,
+  KEDA scale-out, cross-pod cycles — dies at L2. Effectively 100%.
+
+### Why not `ResourceIndexItem` (Postgres)?
+
+The natural-looking candidate — it carries `SourceUrlHash` — but it is
+bookkeeping for *sourcing-job progress*: rows belong to a parent
+`ResourceIndexJobs` row via `ResourceIndexId`. Ad-hoc live traffic has no parent
+job (`ResourceIndexId == Guid.Empty`), which is why
+`ResourceIndexItemProcessor.ProcessInternal` deliberately skips writing rows for
+it. Using it as the seen-signal would require:
+
+- starting to write a **Postgres row per live item** — re-adding per-item write
+  load on the hottest path (the thing this fix removes), plus a schema change to
+  permit parentless rows; and
+- accepting that a row means "a command was created", NOT "the document
+  persisted" — the same masking weakness as any seen-cache.
+
+Mongo's `_id` is the **same hash value** (`HashProvider.GenerateHashFromUri`)
+that `SourceUrlHash` carries, written only on successful persistence, in the
+store the item processor already reads. The durable URL registry this table
+suggests already exists — it is the document store itself, and it is more honest.
+
+### Why not Redis?
+
+Works (SET NX EX / MGET), cross-pod, cheap — but it is a *second* source of
+truth that can drift (flush, eviction, TTL tuning, circuit-breaker fail-open)
+and shares the seen-cache weakness: "marked" is not "persisted". Everything
+Redis would record, Mongo already knows authoritatively at trivial cost (~10–20
+batched primary-key reads/sec cluster-wide at 10 concurrent games). Reserve
+Redis for if the existence check itself ever becomes hot; at these volumes it
+will not.
+
+## Fix
+
+### Tier 1 — classify `EventCompetitionProbability` immutable-in-season
+
+Add it to `InSeasonDocumentPolicy.ImmutableInSeasonTypes`. Rationale: ESPN emits one
+probability item per play; like plays, the index is append-only and completed entries
+do not change. The existing live-edge carve-out (last item, last page) keeps the
+still-finalizing entry fresh. This revises the predecessor's draft classification with
+production evidence: 611,931 processed/evening for ~500 real items.
+
+Effect alone: moves the probability bleed from ESPN to Mongo (red line flattens per
+cycle) — but converts it into additional cache-hit/republish churn. Tier 1 without
+tier 2 just recolors the problem.
+
+### Tier 2 — already-seen skip at the fan-out (the core fix)
+
+In `ProcessResourceIndex`, before enqueueing an item, skip it when **all** of:
+
+- `evt.Priority` is `true` — streamer-originated live traffic only. Manual
+  reenrich, on-final contest refresh, historical sourcing, backfills, and
+  dependency requests are untouched by construction.
+- `InSeasonDocumentPolicy.IsImmutableInSeason(evt.DocumentType)` — mutable types
+  (situation, status, score, leaders, active drives) always flow.
+- `isCurrentSeason` — same gate as the existing immutable-serve carve-out.
+- NOT the live edge (`dto.PageIndex >= dto.PageCount && i == last`) — the newest,
+  possibly still-finalizing item keeps flowing every cycle, exactly as today.
+- The item's urlHash is in the **seen cache** (below).
+
+Items are **marked seen at enqueue time**, in the same loop. Marking at enqueue
+(rather than at publish, in `ResourceIndexItemProcessor`) is deliberate:
+
+- The enqueuing consumer and the Hangfire worker that processes the item can be
+  different pods (Hangfire is a shared DB-backed queue), so a mark-at-publish
+  in-memory signal is cross-pod broken in both directions. Mark-at-enqueue is
+  consistent within the pod that makes the skip decision.
+- "Seen" then means "handed to Hangfire once" — and Hangfire owns delivery with
+  its own retry semantics. A job that fails all retries is rare, and recovery
+  paths remain: TTL expiry, Producer's dependency-request leaf path (unaffected
+  by the skip), and manual reenrich.
+
+### Seen cache
+
+Per-pod in-memory `ConcurrentDictionary<string urlHash, DateTime expiresUtc>` with a
+TTL comfortably beyond `MaxStreamDuration` (8h), pruned opportunistically. Shape
+mirrors `KnownBadUriCache` minus the durable table — durability is not worth a table
+here because the cost of a cold cache is exactly **one** full-index cycle (the
+pre-fix steady state), after which the pod converges. Consequences accepted:
+
+- **Pod restart / deploy mid-game**: one full walk, then flat.
+- **KEDA scale-out**: each new pod pays one full walk per active index it happens
+  to consume; worst-case amplification bounded by pod count (single digits)
+  instead of cycle count (~720/game). If pod counts grow later, the cache can be
+  moved to Redis (already in the cluster, circuit-breaker wrapped) without
+  changing the call sites.
+- Memory: ~360 entries/game (plays + probs). Negligible.
+
+### Correctness analysis — what could we miss?
+
+- **A play arrives while its earlier enqueue is still queued/failed**: it is in
+  the seen cache, so it won't re-enqueue. If the original Hangfire job ultimately
+  fails, the play is absent canonically; Producer's situation processor
+  (`lastPlay.$ref`) or any dependent processor issues a dependency request via the
+  **leaf path**, which this fix does not touch — the play is then fetched/served
+  and published. Same recovery contract as today.
+- **Mid-game ESPN corrections to old plays**: already not picked up today (the
+  predecessor doc's "correction coverage — DEFERRED" gap; cached plays serve from
+  Mongo and only the edge refetches). This fix does not widen that gap; the
+  on-final force-bypass re-validate remains the deferred follow-on that closes it.
+- **On-final contest refresh**: flows through the same handler but is not
+  `Priority` streamer traffic, so the skip does not apply. Its behavior is
+  unchanged (serves plays from Mongo per #549 — the deferred on-final
+  force-bypass is orthogonal).
+- **Live edge**: never skipped, so the finalizing item's transition is captured on
+  the next cycle, exactly as today.
+
+## Deliberately out of scope (follow-ups)
+
+- **Drives**: 118K/evening. Completed drives are immutable but the *active* drive
+  mutates as plays append; the "all but the last drive" positional rule would work
+  but expands classification risk. Revisit after plays/probs prove out.
+- **Index-page paging**: the plays index is re-paged in full from ESPN every cycle
+  and grows with the game (uncounted on current panels). A "last page only after
+  first full walk" optimization or a larger `limit` on the streamer's index
+  request would collapse it; separate change, separate risk.
+- **On-final force-bypass re-validate**: still the predecessor doc's open
+  follow-on; unchanged by this work.
+- **Cache-hit republish suppression for immutable types** (gap #3 directly):
+  superseded for indexed items by the fan-out skip; the leaf path's republish is
+  load-bearing for dependency resolution and stays.
+
+## Testing
+
+- Unit (`DocumentRequestedHandler`): second cycle of an identical index enqueues
+  only the live edge; first cycle enqueues all; cache-missing item (evicted /
+  fresh pod) enqueues; mutable type never skipped; non-Priority request never
+  skipped; historical/future season never skipped; live edge never skipped.
+- Unit (`InSeasonDocumentPolicy`): `EventCompetitionProbability` classified
+  immutable (locks tier 1).
+- Unit (seen cache): TTL expiry re-allows; mark is idempotent.
+- Unit (L2): persisted non-edge items skip with a cold L1 (the cross-pod case)
+  and are promoted into L1; the live edge never enters the batch query and
+  always flows; the batch is never consulted for non-Priority traffic; a
+  throwing store fails open (all items enqueue, consumer does not fault).
+
+## Rollout / verification
+
+- Deploy Provider; no config, no migration, no Producer change.
+- Success metrics on the next live slate (same two Grafana panels):
+  - *MongoDB Cache Hits vs ESPN Live Fetches*: both series **flat** per game
+    (proportional to new events + mutable-aggregate cadence), no intra-game slope.
+  - *Documents Processed by Type* (Producer): `EventCompetitionPlay` and
+    `EventCompetitionProbability` totals within ~2–3x of real event counts
+    (edge re-fetch + per-pod rewarm), not 2,000x.
+  - Hangfire `00-live` queue age percentiles stay flat through the late window.
+- Risk: an immutable item skipped whose Hangfire job permanently failed stays
+  absent until a dependency request or reenrich touches it — same class of gap as
+  today's DLQ-mediated flow, and the reason the skip is Priority-gated and
+  TTL-bounded rather than durable.
+
+## Related
+
+- `docs/features/in-season-cache-bypass-fix.md` — predecessor; this is its
+  option #2, promoted.
+- `reference_stuck_live_finalization_rate_limit` — the original symptom class.
+- SUNDAY 09-06 docket item: "index-level already-seen skip (93% of live queue =
+  immutable plays/probs)" — this doc is that item, with the 09-06 evening charts
+  as the quantified motivation.

--- a/docs/features/live-sourcing-already-seen-skip.md
+++ b/docs/features/live-sourcing-already-seen-skip.md
@@ -100,7 +100,7 @@ downstream (no Hangfire job, no Mongo read, no publish, no Producer hop):
 flowchart TD
     ITEM["index item (per cycle)"] --> G{"Priority + immutable type<br/>+ current season + NOT live edge?"}
     G -->|"no — mutable, live edge,<br/>reenrich/on-final/historical"| ENQ["enqueue (unchanged behavior)"]
-    G -->|yes| L2{"L2: batched Mongo _id $in<br/>is the document ALREADY PERSISTED?"}
+    G -->|yes| L2{"L2: batched Mongo _id $in<br/>PERSISTED + PUBLISHED at least once?"}
     L2 -->|yes| SKIP["SKIP — nothing downstream"]
     L2 -->|no| L1{"L1: TryMarkSeen —<br/>atomic short-TTL in-flight claim<br/>already held by this pod?"}
     L1 -->|"claim held"| SKIP
@@ -109,11 +109,15 @@ flowchart TD
 
 - **L2 is the primary check** and the durable, cross-pod truth: one `$in`
   query on `_id` (primary key) per index page
-  (`IDocumentStore.GetExistingIdsAsync`) for **every** eligible non-edge hash
-  — deliberately not pre-filtered by L1, so persistence is re-verified every
-  cycle. "Seen" = "persisted" — it cannot drift and cannot mask a failed job:
-  a document that never landed is simply not there, and re-enqueues as soon as
-  its L1 claim lapses (minutes). It also *replaces* N individual per-item
+  (`IDocumentStore.GetPublishedIdsAsync`) for **every** eligible non-edge hash
+  — deliberately not pre-filtered by L1, so it is re-verified every cycle.
+  "Seen" = "persisted AND published at least once" (`LastPublishedUtc`,
+  written only after a successful `DocumentCreated` publish) — it cannot
+  drift and cannot mask a failed job on either side of the Mongo insert: a
+  document that never landed is simply not there, and one that landed but
+  whose publish never went out has no marker; both re-enqueue as soon as the
+  L1 claim lapses (minutes) and the cache-hit path republishes (which then
+  writes the marker — pre-marker legacy documents converge the same way). It also *replaces* N individual per-item
   Mongo reads with one batched read. **Fails open**: on a store error the
   items simply enqueue (pre-skip behavior) — a Mongo hiccup must never stall
   live sourcing.
@@ -188,8 +192,9 @@ In `ProcessResourceIndex`, before enqueueing an item, skip it when **all** of:
 - `isCurrentSeason` — same gate as the existing immutable-serve carve-out.
 - NOT the live edge (`dto.PageIndex >= dto.PageCount && i == last`) — the newest,
   possibly still-finalizing item keeps flowing every cycle, exactly as today.
-- The document is already persisted in Mongo (**L2**, checked first), or this
-  pod holds a live in-flight claim for it (**L1** `SeenUriCache.TryMarkSeen`) —
+- The document is persisted in Mongo AND has been published at least once
+  (**L2**, checked first), or this pod holds a live in-flight claim for it
+  (**L1** `SeenUriCache.TryMarkSeen`) —
   the cross-pod cold-L1 case is covered by L2 (see
   `L2_PersistedItems_SkippedAcrossPods_ExceptLiveEdge`).
 
@@ -219,9 +224,12 @@ Consequences accepted:
 ### Correctness analysis — what could we miss?
 
 - **A play's job never persists** (ESPN 404 → known-bad clean return with no
-  Hangfire retry, exhausted retries, enqueue failure after claiming): the item
-  is absent from Mongo, so L2 never vouches for it; its L1 claim lapses in
-  ~10 minutes and it re-enqueues — the pre-skip self-healing cadence, bounded
+  Hangfire retry, exhausted retries, enqueue failure after claiming), **or
+  persists but its publish never lands** (`InsertOneAsync` succeeded, the
+  `DocumentCreated` publish/outbox flush did not — Vortex round 2): L2 keys on
+  the `LastPublishedUtc` marker, written only after a successful publish, so
+  neither case is vouched for; the L1 claim lapses in ~10 minutes and the item
+  re-enqueues — the pre-skip self-healing cadence, bounded
   by the claim TTL instead of masked for hours. Producer's dependency-request
   **leaf path** (untouched by the skip) remains an independent recovery route.
 - **Mid-game ESPN corrections to old plays**: already not picked up today (the
@@ -260,7 +268,7 @@ Consequences accepted:
   immutable (locks tier 1).
 - Unit (seen cache): first claim wins; a second claim within the TTL is
   refused; a lapsed claim is claimable again and restarts its TTL.
-- Unit (L2): persisted non-edge items skip with a cold L1 (the cross-pod case)
+- Unit (L2): published non-edge items skip with a cold L1 (the cross-pod case)
   without taking claims; the L2 query includes ALL eligible non-edge hashes
   even when their claims are held (the failed-job re-check); the live edge
   never enters the batch query and always flows; the batch is never consulted
@@ -277,9 +285,10 @@ Consequences accepted:
     `EventCompetitionProbability` totals within ~2–3x of real event counts
     (edge re-fetch + per-pod rewarm), not 2,000x.
   - Hangfire `00-live` queue age percentiles stay flat through the late window.
-- Risk: an immutable item whose Hangfire job never persists is suppressed only
-  for the L1 claim TTL (~10 min) — L2 re-verifies persistence every cycle, so
-  the item re-enqueues on the first cycle after the claim lapses. Recovery is
+- Risk: an immutable item whose Hangfire job never persists — or never
+  publishes — is suppressed only for the L1 claim TTL (~10 min): L2 re-verifies
+  the persisted+published marker every cycle, so the item re-enqueues on the
+  first cycle after the claim lapses. Recovery is
   further backed by Producer's dependency-request leaf path and manual
   reenrich.
 

--- a/docs/features/live-sourcing-already-seen-skip.md
+++ b/docs/features/live-sourcing-already-seen-skip.md
@@ -1,7 +1,9 @@
 # Live Sourcing O(N) Re-Emission — Index-Level Already-Seen Skip
 
-Status: **Implemented in working tree** (branch `feat/live-sourcing-seen-skip`;
-awaiting operator review — no commit/PR yet)
+Status: **In review — PR #733** (branch `feat/live-sourcing-seen-skip`).
+Review round 1 (Vortex + CodeRabbit) reshaped L1 into a short-TTL atomic
+in-flight claim and made L2 the every-cycle durable check — see "The fix —
+layered checks at the fan-out" below for the current semantics.
 Last updated: 2026-09-07
 Scope: live competition streaming (NCAAFB/NFL now; any streamed sport). Successor to
 `docs/features/in-season-cache-bypass-fix.md` — this implements that doc's deferred
@@ -98,29 +100,37 @@ downstream (no Hangfire job, no Mongo read, no publish, no Producer hop):
 flowchart TD
     ITEM["index item (per cycle)"] --> G{"Priority + immutable type<br/>+ current season + NOT live edge?"}
     G -->|"no — mutable, live edge,<br/>reenrich/on-final/historical"| ENQ["enqueue (unchanged behavior)"]
-    G -->|yes| L1{"L1: in-memory SeenUriCache<br/>did THIS POD enqueue it already?"}
-    L1 -->|yes| SKIP["SKIP — nothing downstream"]
-    L1 -->|no| L2{"L2: batched Mongo _id $in<br/>is the document ALREADY PERSISTED?"}
-    L2 -->|yes| SKIP
-    L2 -->|no| ENQ2["enqueue + mark seen"]
+    G -->|yes| L2{"L2: batched Mongo _id $in<br/>is the document ALREADY PERSISTED?"}
+    L2 -->|yes| SKIP["SKIP — nothing downstream"]
+    L2 -->|no| L1{"L1: TryMarkSeen —<br/>atomic short-TTL in-flight claim<br/>already held by this pod?"}
+    L1 -->|"claim held"| SKIP
+    L1 -->|"claim taken now"| ENQ2["enqueue"]
 ```
 
-- **L1** is per-pod and covers the in-flight window: items enqueued seconds
-  ago whose Hangfire job hasn't persisted yet. Its weakness alone: a
-  fresh/other pod hasn't marked anything (residual ≈ one full walk per pod), and
-  a mark can outlive a job that failed permanently (masked until TTL).
-- **L2** is the durable, cross-pod truth: one `$in` query on `_id` (primary
-  key) per index page (`IDocumentStore.GetExistingIdsAsync`), built only from
-  hashes L1 doesn't already know, against the collection the item processor
-  would read anyway. "Seen" = "persisted" — it cannot drift and cannot mask a
-  failed job, because a document that never landed is simply not there and
-  re-enqueues next cycle. It also *replaces* N individual per-item Mongo reads
-  with one batched read. **Fails open**: on a store error the items simply
-  enqueue (pre-skip behavior) — a Mongo hiccup must never stall live sourcing.
-  L2 hits are promoted into L1, so the next cycle's batch query shrinks to
-  genuinely new items.
-- Together: same-pod repeats die at L1 for free; everything else — restarts,
-  KEDA scale-out, cross-pod cycles — dies at L2. Effectively 100%.
+- **L2 is the primary check** and the durable, cross-pod truth: one `$in`
+  query on `_id` (primary key) per index page
+  (`IDocumentStore.GetExistingIdsAsync`) for **every** eligible non-edge hash
+  — deliberately not pre-filtered by L1, so persistence is re-verified every
+  cycle. "Seen" = "persisted" — it cannot drift and cannot mask a failed job:
+  a document that never landed is simply not there, and re-enqueues as soon as
+  its L1 claim lapses (minutes). It also *replaces* N individual per-item
+  Mongo reads with one batched read. **Fails open**: on a store error the
+  items simply enqueue (pre-skip behavior) — a Mongo hiccup must never stall
+  live sourcing.
+- **L1** (`SeenUriCache.TryMarkSeen`) is a per-pod **atomic short-TTL
+  in-flight claim** (~10 min): it only bridges the window between an item's
+  enqueue and its persistence, including under queue backlog. Taking the claim
+  is test-and-set, so concurrent `DocumentRequested` deliveries for the same
+  index cannot double-enqueue an item. A claim is never refreshed by later
+  cycles (persisted items skip on L2 before reaching it), so a job that
+  cleanly failed to persist — e.g. ESPN 404 → known-bad → return, no Hangfire
+  retry — re-enqueues within minutes, preserving the pre-skip self-healing
+  cadence. An enqueue that throws after claiming self-heals the same way. The
+  live edge is never claimed: it must re-fetch every cycle, and once displaced
+  its persisted copy is caught by L2.
+- Together: persisted items die at L2 (any pod, restarts, KEDA scale-out);
+  in-flight items die at L1 for the minutes their job needs to land.
+  Effectively 100%, with failed-job masking bounded by the claim TTL.
 
 ### Why not `ResourceIndexItem` (Postgres)?
 
@@ -178,44 +188,42 @@ In `ProcessResourceIndex`, before enqueueing an item, skip it when **all** of:
 - `isCurrentSeason` — same gate as the existing immutable-serve carve-out.
 - NOT the live edge (`dto.PageIndex >= dto.PageCount && i == last`) — the newest,
   possibly still-finalizing item keeps flowing every cycle, exactly as today.
-- The item's urlHash is in the **seen cache** (below).
+- The document is already persisted in Mongo (**L2**, checked first), or this
+  pod holds a live in-flight claim for it (**L1** `SeenUriCache.TryMarkSeen`) —
+  the cross-pod cold-L1 case is covered by L2 (see
+  `L2_PersistedItems_SkippedAcrossPods_ExceptLiveEdge`).
 
-Items are **marked seen at enqueue time**, in the same loop. Marking at enqueue
-(rather than at publish, in `ResourceIndexItemProcessor`) is deliberate:
+The in-flight claim is taken **atomically at enqueue time**, in the same loop.
+Claiming at enqueue (rather than marking at publish, in
+`ResourceIndexItemProcessor`) is deliberate: the enqueuing consumer and the
+Hangfire worker that processes the item can be different pods (Hangfire is a
+shared DB-backed queue), so a mark-at-publish in-memory signal is cross-pod
+broken in both directions. The claim only asserts "handed to Hangfire minutes
+ago, presumed in flight" — persistence itself is what L2 verifies, every cycle.
 
-- The enqueuing consumer and the Hangfire worker that processes the item can be
-  different pods (Hangfire is a shared DB-backed queue), so a mark-at-publish
-  in-memory signal is cross-pod broken in both directions. Mark-at-enqueue is
-  consistent within the pod that makes the skip decision.
-- "Seen" then means "handed to Hangfire once" — and Hangfire owns delivery with
-  its own retry semantics. A job that fails all retries is rare, and recovery
-  paths remain: TTL expiry, Producer's dependency-request leaf path (unaffected
-  by the skip), and manual reenrich.
+### Seen cache (L1 claim)
 
-### Seen cache
+Per-pod in-memory `ConcurrentDictionary<string urlHash, DateTime expiresUtc>`,
+claim TTL ~10 minutes, atomic test-and-set (`TryAdd`/`TryUpdate`), pruned
+opportunistically. No durable backing — durability lives at L2 (the document
+store itself), so the claim's only job is the enqueue-to-persistence window.
+Consequences accepted:
 
-Per-pod in-memory `ConcurrentDictionary<string urlHash, DateTime expiresUtc>` with a
-TTL comfortably beyond `MaxStreamDuration` (8h), pruned opportunistically. Shape
-mirrors `KnownBadUriCache` minus the durable table — durability is not worth a table
-here because the cost of a cold cache is exactly **one** full-index cycle (the
-pre-fix steady state), after which the pod converges. Consequences accepted:
-
-- **Pod restart / deploy mid-game**: one full walk, then flat.
-- **KEDA scale-out**: each new pod pays one full walk per active index it happens
-  to consume; worst-case amplification bounded by pod count (single digits)
-  instead of cycle count (~720/game). If pod counts grow later, the cache can be
-  moved to Redis (already in the cluster, circuit-breaker wrapped) without
-  changing the call sites.
+- **Pod restart / deploy mid-game**: nothing lost — L2 skips everything
+  persisted on the very first cycle; at most the currently in-flight handful
+  double-enqueues once (idempotent downstream).
+- **KEDA scale-out**: same — L2 is shared truth, so a new pod does not re-walk
+  persisted history; only unpersisted in-flight items can double-enqueue.
 - Memory: ~360 entries/game (plays + probs). Negligible.
 
 ### Correctness analysis — what could we miss?
 
-- **A play arrives while its earlier enqueue is still queued/failed**: it is in
-  the seen cache, so it won't re-enqueue. If the original Hangfire job ultimately
-  fails, the play is absent canonically; Producer's situation processor
-  (`lastPlay.$ref`) or any dependent processor issues a dependency request via the
-  **leaf path**, which this fix does not touch — the play is then fetched/served
-  and published. Same recovery contract as today.
+- **A play's job never persists** (ESPN 404 → known-bad clean return with no
+  Hangfire retry, exhausted retries, enqueue failure after claiming): the item
+  is absent from Mongo, so L2 never vouches for it; its L1 claim lapses in
+  ~10 minutes and it re-enqueues — the pre-skip self-healing cadence, bounded
+  by the claim TTL instead of masked for hours. Producer's dependency-request
+  **leaf path** (untouched by the skip) remains an independent recovery route.
 - **Mid-game ESPN corrections to old plays**: already not picked up today (the
   predecessor doc's "correction coverage — DEFERRED" gap; cached plays serve from
   Mongo and only the edge refetches). This fix does not widen that gap; the
@@ -250,11 +258,14 @@ pre-fix steady state), after which the pod converges. Consequences accepted:
   skipped; historical/future season never skipped; live edge never skipped.
 - Unit (`InSeasonDocumentPolicy`): `EventCompetitionProbability` classified
   immutable (locks tier 1).
-- Unit (seen cache): TTL expiry re-allows; mark is idempotent.
+- Unit (seen cache): first claim wins; a second claim within the TTL is
+  refused; a lapsed claim is claimable again and restarts its TTL.
 - Unit (L2): persisted non-edge items skip with a cold L1 (the cross-pod case)
-  and are promoted into L1; the live edge never enters the batch query and
-  always flows; the batch is never consulted for non-Priority traffic; a
-  throwing store fails open (all items enqueue, consumer does not fault).
+  without taking claims; the L2 query includes ALL eligible non-edge hashes
+  even when their claims are held (the failed-job re-check); the live edge
+  never enters the batch query and always flows; the batch is never consulted
+  for non-Priority traffic; a throwing store fails open (all items enqueue,
+  consumer does not fault).
 
 ## Rollout / verification
 
@@ -266,10 +277,11 @@ pre-fix steady state), after which the pod converges. Consequences accepted:
     `EventCompetitionProbability` totals within ~2–3x of real event counts
     (edge re-fetch + per-pod rewarm), not 2,000x.
   - Hangfire `00-live` queue age percentiles stay flat through the late window.
-- Risk: an immutable item skipped whose Hangfire job permanently failed stays
-  absent until a dependency request or reenrich touches it — same class of gap as
-  today's DLQ-mediated flow, and the reason the skip is Priority-gated and
-  TTL-bounded rather than durable.
+- Risk: an immutable item whose Hangfire job never persists is suppressed only
+  for the L1 claim TTL (~10 min) — L2 re-verifies persistence every cycle, so
+  the item re-enqueues on the first cycle after the claim lapses. Recovery is
+  further backed by Producer's dependency-request leaf path and manual
+  reenrich.
 
 ## Related
 

--- a/src/SportsData.Provider/Application/Documents/DocumentRequestedHandler.cs
+++ b/src/SportsData.Provider/Application/Documents/DocumentRequestedHandler.cs
@@ -11,6 +11,7 @@ using SportsData.Core.Infrastructure.DataSources.Espn;
 using SportsData.Core.Infrastructure.DataSources.Espn.Dtos;
 using SportsData.Core.Processing;
 using SportsData.Provider.Application.Processors;
+using SportsData.Provider.Infrastructure.Data;
 using SportsData.Provider.Infrastructure.Providers.Espn;
 
 using System.Diagnostics.Metrics;
@@ -25,7 +26,10 @@ public class DocumentRequestedHandler : IConsumer<DocumentRequested>
     private readonly IProvideBackgroundJobs _backgroundJobProvider;
     private readonly CommonConfig _commonConfig;
     private readonly IKnownBadUriCache _knownBadUris;
+    private readonly ISeenUriCache _seenUris;
+    private readonly IDocumentStore _documentStore;
     private readonly Counter<long> _documentsRequestedCounter;
+    private readonly Counter<long> _itemsSkippedSeenCounter;
 
     public DocumentRequestedHandler(
         IProvideEspnApiData espnApi,
@@ -33,6 +37,8 @@ public class DocumentRequestedHandler : IConsumer<DocumentRequested>
         IProvideBackgroundJobs backgroundJobProvider,
         IOptions<CommonConfig> commonConfig,
         IKnownBadUriCache knownBadUris,
+        ISeenUriCache seenUris,
+        IDocumentStore documentStore,
         IMeterFactory meterFactory)
     {
         _espnApi = espnApi;
@@ -40,6 +46,8 @@ public class DocumentRequestedHandler : IConsumer<DocumentRequested>
         _backgroundJobProvider = backgroundJobProvider;
         _commonConfig = commonConfig.Value;
         _knownBadUris = knownBadUris;
+        _seenUris = seenUris;
+        _documentStore = documentStore;
 
         // Counted at ARRIVAL — before dedupe/skip/cache decisions — so the
         // metric answers "what is being asked of Provider, per type", not
@@ -49,6 +57,9 @@ public class DocumentRequestedHandler : IConsumer<DocumentRequested>
         _documentsRequestedCounter = meter.CreateCounter<long>(
             "provider.documents.requested",
             description: "DocumentRequested events arriving at Provider, tagged by document type and sport");
+        _itemsSkippedSeenCounter = meter.CreateCounter<long>(
+            "provider.documents.skipped_seen",
+            description: "Live-index items skipped at the fan-out because an identical immutable item was already enqueued this stream");
     }
 
     public async Task Consume(ConsumeContext<DocumentRequested> context)
@@ -273,12 +284,16 @@ public class DocumentRequestedHandler : IConsumer<DocumentRequested>
             return;
         }
 
-        var seenPages = new HashSet<string>();
+        // Pagination cycle guard, scoped to THIS invocation only: stop paging
+        // if ESPN ever hands back a page URL we already fetched in this call.
+        // Unrelated to ISeenUriCache (cross-cycle, item-level already-seen skip).
+        var visitedPageUrls = new HashSet<string>();
         var enqueuedAnyRefs = false;
         var totalItemsEnqueued = 0;
+        var totalItemsSkippedSeen = 0;
         bool? useInlineJson = null; // null = not yet probed, true = $refs are broken, false = $refs work
 
-        while (uri is not null && seenPages.Add(uri.ToString()))
+        while (uri is not null && visitedPageUrls.Add(uri.ToString()))
         {
             _logger.LogInformation(
                 "Fetching resource index page. PageUri={PageUri}",
@@ -373,6 +388,10 @@ public class DocumentRequestedHandler : IConsumer<DocumentRequested>
                 rawItemJsonList = null;
             }
 
+            // Resolve every item's URI/hash up front so the L2 existence check
+            // below can run as ONE batched primary-key read per page instead
+            // of N individual reads downstream.
+            var resolvedItems = new List<(int Index, Uri RefUri, string RefHash)>(dto.Items.Count);
             for (var i = 0; i < dto.Items.Count; i++)
             {
                 var item = dto.Items[i];
@@ -407,33 +426,99 @@ public class DocumentRequestedHandler : IConsumer<DocumentRequested>
                     refUri = item.Ref.ToCleanUri();
                 }
 
-                var refHash = HashProvider.GenerateHashFromUri(refUri);
+                resolvedItems.Add((i, refUri, HashProvider.GenerateHashFromUri(refUri)));
+            }
 
-                // Cache policy mirrors ProcessResourceIndexItem (and ResourceIndexJob).
-                // PR #282 fixed the leaf path; this fan-out path was missed and kept
-                // hardcoding BypassCache=true, forcing an ESPN call for every child of
-                // every resource index — defeating Mongo cache entirely for re-finalize
-                // and historical-sourcing runs.
-                //
-                // In-season immutable items (e.g. a completed play) are served from
-                // Mongo instead of re-fetched from ESPN every live-poll cycle — the
-                // fix for the live-slate rate-limit storm. The one exception is the
-                // "live edge": the newest item (last item on the last page — the
-                // index is ordered ascending), which may still be finalizing, so it
-                // keeps bypassing. See docs/features/in-season-cache-bypass-fix.md.
-                //
-                // Scope the immutable exception to EXACTLY the current season. When
-                // the feature is disabled (CurrentSeason == 0), the season is unknown
-                // (null), or the request is for a future season, keep the original
-                // bypass behavior for every item (no immutable-serve). Historical
-                // seasons already serve from cache via ShouldBypassCache == false.
+            // Cache policy mirrors ProcessResourceIndexItem (and ResourceIndexJob).
+            // PR #282 fixed the leaf path; this fan-out path was missed and kept
+            // hardcoding BypassCache=true, forcing an ESPN call for every child of
+            // every resource index — defeating Mongo cache entirely for re-finalize
+            // and historical-sourcing runs.
+            //
+            // In-season immutable items (e.g. a completed play) are served from
+            // Mongo instead of re-fetched from ESPN every live-poll cycle — the
+            // fix for the live-slate rate-limit storm. The one exception is the
+            // "live edge": the newest item (last item on the last page — the
+            // index is ordered ascending), which may still be finalizing, so it
+            // keeps bypassing. See docs/features/in-season-cache-bypass-fix.md.
+            //
+            // Scope the immutable exception to EXACTLY the current season. When
+            // the feature is disabled (CurrentSeason == 0), the season is unknown
+            // (null), or the request is for a future season, keep the original
+            // bypass behavior for every item (no immutable-serve). Historical
+            // seasons already serve from cache via ShouldBypassCache == false.
+            var isCurrentSeason = _commonConfig.CurrentSeason != 0
+                && evt.SeasonYear == _commonConfig.CurrentSeason;
+            var isImmutableType = InSeasonDocumentPolicy.IsImmutableInSeason(evt.DocumentType);
+
+            // L2 of the already-seen skip: for immutable documents, existence
+            // in the Mongo store IS the durable, cross-pod "seen" signal —
+            // "seen" = "persisted", so it cannot drift and cannot mask a
+            // failed Hangfire job (a document that never landed is simply not
+            // there and re-enqueues next cycle). One batched primary-key read
+            // per page, only for hashes L1 doesn't already know. Fails OPEN:
+            // a Mongo hiccup must never stall live sourcing, so on error the
+            // items simply enqueue (pre-skip behavior).
+            HashSet<string>? persistedIds = null;
+            if (evt.Priority && isCurrentSeason && isImmutableType)
+            {
+                var candidates = new List<string>(resolvedItems.Count);
+                foreach (var (index, _, candidateHash) in resolvedItems)
+                {
+                    var isEdge = dto.PageIndex >= dto.PageCount && index == dto.Items.Count - 1;
+                    if (!isEdge && !_seenUris.IsSeen(candidateHash))
+                        candidates.Add(candidateHash);
+                }
+
+                if (candidates.Count > 0)
+                {
+                    try
+                    {
+                        persistedIds = await _documentStore.GetExistingIdsAsync(
+                            evt.DocumentType.ToString(),
+                            candidates);
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogWarning(
+                            ex,
+                            "L2 existence check failed; failing open (items will enqueue). Collection={Collection}, CandidateCount={CandidateCount}",
+                            evt.DocumentType,
+                            candidates.Count);
+                    }
+                }
+            }
+
+            foreach (var (i, refUri, refHash) in resolvedItems)
+            {
                 var isLiveEdge = dto.PageIndex >= dto.PageCount && i == dto.Items.Count - 1;
-                var isCurrentSeason = _commonConfig.CurrentSeason != 0
-                    && evt.SeasonYear == _commonConfig.CurrentSeason;
                 var serveImmutableFromCache = isCurrentSeason
-                    && InSeasonDocumentPolicy.IsImmutableInSeason(evt.DocumentType)
+                    && isImmutableType
                     && !isLiveEdge;
                 var bypassCache = ShouldBypassCache(evt.SeasonYear) && !serveImmutableFromCache;
+
+                // Already-seen skip (streamer live traffic ONLY — Priority):
+                // an immutable item already handed to Hangfire (L1, this pod)
+                // or already persisted to Mongo (L2, any pod) needs no further
+                // work at all — not a job, not a Mongo read, not a re-publish
+                // to Producer. Without it, every polling cycle re-enqueues
+                // every item the game has ever produced (observed 2026-09-06:
+                // ~2,000x amplification). The live edge never qualifies
+                // (serveImmutableFromCache is false for it), so the
+                // still-finalizing item keeps flowing every cycle. Non-priority
+                // callers (reenrich, on-final refresh, historical sourcing)
+                // are untouched by construction.
+                // See docs/features/live-sourcing-already-seen-skip.md.
+                if (evt.Priority && serveImmutableFromCache
+                    && (_seenUris.IsSeen(refHash) || persistedIds?.Contains(refHash) == true))
+                {
+                    totalItemsSkippedSeen++;
+
+                    // Promote L2 knowledge into L1 so next cycle's candidate
+                    // list (and batch query) shrinks to genuinely new items.
+                    _seenUris.MarkSeen(refHash);
+                    continue;
+                }
 
                 var cmd = new ProcessResourceIndexItemCommand(
                     CorrelationId: evt.CorrelationId,
@@ -458,6 +543,15 @@ public class DocumentRequestedHandler : IConsumer<DocumentRequested>
                     _backgroundJobProvider.Enqueue<IProcessResourceIndexItems>(p => p.Process(cmd));
                 enqueuedAnyRefs = true;
                 totalItemsEnqueued++;
+
+                // Mark at enqueue (not at publish): the Hangfire worker that
+                // processes this item may be a different pod, so a publish-time
+                // signal can't reach this cache. "Seen" = handed to Hangfire
+                // once; Hangfire owns delivery from there. The live edge is
+                // marked too — once a newer item displaces it, it is complete
+                // and the skip above applies to it.
+                if (evt.Priority && isCurrentSeason && isImmutableType)
+                    _seenUris.MarkSeen(refHash);
             }
 
             if (dto.PageIndex >= dto.PageCount)
@@ -480,11 +574,19 @@ public class DocumentRequestedHandler : IConsumer<DocumentRequested>
             uri = new Uri($"{baseUri}?{newQuery}");
         }
 
-        if (enqueuedAnyRefs)
+        if (totalItemsSkippedSeen > 0)
+        {
+            _itemsSkippedSeenCounter.Add(totalItemsSkippedSeen,
+                new KeyValuePair<string, object?>("DocumentType", evt.DocumentType.ToString()),
+                new KeyValuePair<string, object?>("Sport", evt.Sport.ToString()));
+        }
+
+        if (enqueuedAnyRefs || totalItemsSkippedSeen > 0)
         {
             _logger.LogInformation(
-                "All resource index items enqueued. TotalItems={TotalItems}",
-                totalItemsEnqueued);
+                "All resource index items enqueued. TotalItems={TotalItems}, SkippedAlreadySeen={SkippedAlreadySeen}",
+                totalItemsEnqueued,
+                totalItemsSkippedSeen);
         }
         else
         {

--- a/src/SportsData.Provider/Application/Documents/DocumentRequestedHandler.cs
+++ b/src/SportsData.Provider/Application/Documents/DocumentRequestedHandler.cs
@@ -451,17 +451,19 @@ public class DocumentRequestedHandler : IConsumer<DocumentRequested>
                 && evt.SeasonYear == _commonConfig.CurrentSeason;
             var isImmutableType = InSeasonDocumentPolicy.IsImmutableInSeason(evt.DocumentType);
 
-            // L2 of the already-seen skip: for immutable documents, existence
-            // in the Mongo store IS the durable, cross-pod "seen" signal —
-            // "seen" = "persisted", so it cannot drift and cannot mask a
-            // failed Hangfire job (a document that never landed is simply not
-            // there and re-enqueues once its L1 claim lapses). One batched
+            // L2 of the already-seen skip: the durable, cross-pod "seen"
+            // signal is "persisted AND published at least once"
+            // (LastPublishedUtc, written only after a successful
+            // DocumentCreated publish) — so it cannot drift and cannot mask a
+            // failed Hangfire job on EITHER side of the Mongo insert: a doc
+            // that never landed is not there, and a doc that landed but whose
+            // publish never went out has no marker; both re-enqueue once the
+            // L1 claim lapses and the cache-hit path republishes. One batched
             // primary-key read per page for EVERY eligible non-edge hash —
             // deliberately NOT pre-filtered by L1, so the durable check is
-            // re-consulted every cycle and an L1 claim can never mask a
-            // non-persisted item beyond its short TTL. Fails OPEN: a Mongo
-            // hiccup must never stall live sourcing, so on error the items
-            // simply enqueue (pre-skip behavior).
+            // re-consulted every cycle. Fails OPEN: a Mongo hiccup must never
+            // stall live sourcing, so on error the items simply enqueue
+            // (pre-skip behavior).
             HashSet<string>? persistedIds = null;
             if (evt.Priority && isCurrentSeason && isImmutableType)
             {
@@ -477,7 +479,7 @@ public class DocumentRequestedHandler : IConsumer<DocumentRequested>
                 {
                     try
                     {
-                        persistedIds = await _documentStore.GetExistingIdsAsync(
+                        persistedIds = await _documentStore.GetPublishedIdsAsync(
                             evt.DocumentType.ToString(),
                             candidates);
                     }

--- a/src/SportsData.Provider/Application/Documents/DocumentRequestedHandler.cs
+++ b/src/SportsData.Provider/Application/Documents/DocumentRequestedHandler.cs
@@ -455,10 +455,13 @@ public class DocumentRequestedHandler : IConsumer<DocumentRequested>
             // in the Mongo store IS the durable, cross-pod "seen" signal —
             // "seen" = "persisted", so it cannot drift and cannot mask a
             // failed Hangfire job (a document that never landed is simply not
-            // there and re-enqueues next cycle). One batched primary-key read
-            // per page, only for hashes L1 doesn't already know. Fails OPEN:
-            // a Mongo hiccup must never stall live sourcing, so on error the
-            // items simply enqueue (pre-skip behavior).
+            // there and re-enqueues once its L1 claim lapses). One batched
+            // primary-key read per page for EVERY eligible non-edge hash —
+            // deliberately NOT pre-filtered by L1, so the durable check is
+            // re-consulted every cycle and an L1 claim can never mask a
+            // non-persisted item beyond its short TTL. Fails OPEN: a Mongo
+            // hiccup must never stall live sourcing, so on error the items
+            // simply enqueue (pre-skip behavior).
             HashSet<string>? persistedIds = null;
             if (evt.Priority && isCurrentSeason && isImmutableType)
             {
@@ -466,7 +469,7 @@ public class DocumentRequestedHandler : IConsumer<DocumentRequested>
                 foreach (var (index, _, candidateHash) in resolvedItems)
                 {
                     var isEdge = dto.PageIndex >= dto.PageCount && index == dto.Items.Count - 1;
-                    if (!isEdge && !_seenUris.IsSeen(candidateHash))
+                    if (!isEdge)
                         candidates.Add(candidateHash);
                 }
 
@@ -498,26 +501,40 @@ public class DocumentRequestedHandler : IConsumer<DocumentRequested>
                 var bypassCache = ShouldBypassCache(evt.SeasonYear) && !serveImmutableFromCache;
 
                 // Already-seen skip (streamer live traffic ONLY — Priority):
-                // an immutable item already handed to Hangfire (L1, this pod)
-                // or already persisted to Mongo (L2, any pod) needs no further
-                // work at all — not a job, not a Mongo read, not a re-publish
-                // to Producer. Without it, every polling cycle re-enqueues
-                // every item the game has ever produced (observed 2026-09-06:
-                // ~2,000x amplification). The live edge never qualifies
-                // (serveImmutableFromCache is false for it), so the
-                // still-finalizing item keeps flowing every cycle. Non-priority
-                // callers (reenrich, on-final refresh, historical sourcing)
-                // are untouched by construction.
+                // an immutable item already persisted to Mongo (L2, any pod)
+                // or claimed in-flight by this pod within the last few minutes
+                // (L1) needs no further work at all — not a job, not a Mongo
+                // read, not a re-publish to Producer. Without it, every
+                // polling cycle re-enqueues every item the game has ever
+                // produced (observed 2026-09-06: ~2,000x amplification). The
+                // live edge never qualifies (serveImmutableFromCache is false
+                // for it), so the still-finalizing item keeps flowing every
+                // cycle. Non-priority callers (reenrich, on-final refresh,
+                // historical sourcing) are untouched by construction.
                 // See docs/features/live-sourcing-already-seen-skip.md.
-                if (evt.Priority && serveImmutableFromCache
-                    && (_seenUris.IsSeen(refHash) || persistedIds?.Contains(refHash) == true))
+                if (evt.Priority && serveImmutableFromCache)
                 {
-                    totalItemsSkippedSeen++;
+                    if (persistedIds?.Contains(refHash) == true)
+                    {
+                        totalItemsSkippedSeen++;
+                        continue;
+                    }
 
-                    // Promote L2 knowledge into L1 so next cycle's candidate
-                    // list (and batch query) shrinks to genuinely new items.
-                    _seenUris.MarkSeen(refHash);
-                    continue;
+                    // Not (known to be) persisted: take the atomic short-TTL
+                    // in-flight claim. Losing it means a prior cycle or a
+                    // concurrent consumer already enqueued this item and its
+                    // job is presumed pending; if that job never persists,
+                    // the claim lapses in minutes and the item re-enqueues —
+                    // an enqueue that fails after claiming self-heals the
+                    // same way. The live edge is never claimed: it must
+                    // re-fetch every cycle, and once displaced its persisted
+                    // copy is picked up by L2 (or re-enqueued if it never
+                    // landed).
+                    if (!_seenUris.TryMarkSeen(refHash))
+                    {
+                        totalItemsSkippedSeen++;
+                        continue;
+                    }
                 }
 
                 var cmd = new ProcessResourceIndexItemCommand(
@@ -543,15 +560,6 @@ public class DocumentRequestedHandler : IConsumer<DocumentRequested>
                     _backgroundJobProvider.Enqueue<IProcessResourceIndexItems>(p => p.Process(cmd));
                 enqueuedAnyRefs = true;
                 totalItemsEnqueued++;
-
-                // Mark at enqueue (not at publish): the Hangfire worker that
-                // processes this item may be a different pod, so a publish-time
-                // signal can't reach this cache. "Seen" = handed to Hangfire
-                // once; Hangfire owns delivery from there. The live edge is
-                // marked too — once a newer item displaces it, it is complete
-                // and the skip above applies to it.
-                if (evt.Priority && isCurrentSeason && isImmutableType)
-                    _seenUris.MarkSeen(refHash);
             }
 
             if (dto.PageIndex >= dto.PageCount)

--- a/src/SportsData.Provider/Application/Processors/InSeasonDocumentPolicy.cs
+++ b/src/SportsData.Provider/Application/Processors/InSeasonDocumentPolicy.cs
@@ -18,17 +18,23 @@ namespace SportsData.Provider.Application.Processors
     /// current season (except the live edge — the newest, still-finalizing item,
     /// handled at the enqueue site). Mutable aggregates must NOT be listed here.
     ///
-    /// PoC allow-list = <see cref="DocumentType.EventCompetitionPlay"/> only —
-    /// that captures effectively all of the bleeding at near-zero risk. Expand
-    /// deliberately (drives, per-game roster) once proven.
+    /// Allow-list started as <see cref="DocumentType.EventCompetitionPlay"/> only
+    /// (the PoC). <see cref="DocumentType.EventCompetitionProbability"/> added
+    /// 2026-09-07: ESPN emits one probability item per play — the index is
+    /// append-only and completed entries never change, and its exclusion sent
+    /// every item to ESPN each 15s live cycle (611,931 processed in one evening
+    /// for ~500 real items). Expand further (drives, per-game roster)
+    /// deliberately, once proven.
     ///
-    /// See docs/features/in-season-cache-bypass-fix.md.
+    /// See docs/features/in-season-cache-bypass-fix.md and
+    /// docs/features/live-sourcing-already-seen-skip.md.
     /// </summary>
     public static class InSeasonDocumentPolicy
     {
         private static readonly HashSet<DocumentType> ImmutableInSeasonTypes = new()
         {
             DocumentType.EventCompetitionPlay,
+            DocumentType.EventCompetitionProbability,
         };
 
         public static bool IsImmutableInSeason(DocumentType documentType)

--- a/src/SportsData.Provider/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Provider/DependencyInjection/ServiceRegistration.cs
@@ -45,11 +45,11 @@ namespace SportsData.Provider.DependencyInjection
             // first use, write-through) so fresh pods inherit the knowledge.
             services.AddSingleton<IKnownBadUriCache, KnownBadUriCache>();
 
-            // Singleton: immutable in-season items the live-index fan-out has
-            // already handed to Hangfire, so subsequent polling cycles skip
-            // them at the enqueue site. Deliberately per-pod, no durable
-            // backing — a cold cache costs one full-index cycle, then
-            // converges. See docs/features/live-sourcing-already-seen-skip.md.
+            // Singleton: short-TTL atomic in-flight claims for the live-index
+            // already-seen skip (L1) — bridges the window between an item's
+            // enqueue and its persistence, while the durable cross-pod skip
+            // comes from Mongo existence (L2) each cycle. Per-pod by design.
+            // See docs/features/live-sourcing-already-seen-skip.md.
             services.AddSingleton<ISeenUriCache, SeenUriCache>();
 
             // Historical sourcing services

--- a/src/SportsData.Provider/DependencyInjection/ServiceRegistration.cs
+++ b/src/SportsData.Provider/DependencyInjection/ServiceRegistration.cs
@@ -45,6 +45,13 @@ namespace SportsData.Provider.DependencyInjection
             // first use, write-through) so fresh pods inherit the knowledge.
             services.AddSingleton<IKnownBadUriCache, KnownBadUriCache>();
 
+            // Singleton: immutable in-season items the live-index fan-out has
+            // already handed to Hangfire, so subsequent polling cycles skip
+            // them at the enqueue site. Deliberately per-pod, no durable
+            // backing — a cold cache costs one full-index cycle, then
+            // converges. See docs/features/live-sourcing-already-seen-skip.md.
+            services.AddSingleton<ISeenUriCache, SeenUriCache>();
+
             // Historical sourcing services
             services.AddOptions<HistoricalSourcingConfig>()
                 .Bind(configuration.GetSection($"SportsData.Provider:{HistoricalSourcingConfig.SectionName}"))

--- a/src/SportsData.Provider/Infrastructure/Data/CosmosDocumentService.cs
+++ b/src/SportsData.Provider/Infrastructure/Data/CosmosDocumentService.cs
@@ -154,10 +154,37 @@ namespace SportsData.Provider.Infrastructure.Data
             return default;
         }
 
+        public async Task<HashSet<string>> GetExistingIdsAsync(string collectionName, IReadOnlyCollection<string> ids)
+        {
+            if (ids.Count == 0)
+                return new HashSet<string>();
+
+            ValidateContainer(collectionName);
+            var container = _client.GetContainer(_databaseName, collectionName);
+
+            // Cross-partition id-only read (partition key is the 3-char
+            // routing prefix, so a single-partition query is not possible);
+            // Contains translates to an IN clause.
+            var iterator = container.GetItemLinqQueryable<DocumentBase>()
+                .Where(x => ids.Contains(x.Id))
+                .Select(x => x.Id)
+                .ToFeedIterator();
+
+            var found = new HashSet<string>();
+            while (iterator.HasMoreResults)
+            {
+                var response = await iterator.ReadNextAsync();
+                foreach (var id in response)
+                    found.Add(id);
+            }
+
+            return found;
+        }
+
         public async Task InsertOneAsync<T>(string collectionName, T document) where T : IHasSourceUrl
         {
             ValidateContainer(collectionName);
-            
+
             if (string.IsNullOrWhiteSpace(document.SourceUrlHash))
             {
                 if (string.IsNullOrWhiteSpace(document.Uri.AbsoluteUri))

--- a/src/SportsData.Provider/Infrastructure/Data/CosmosDocumentService.cs
+++ b/src/SportsData.Provider/Infrastructure/Data/CosmosDocumentService.cs
@@ -159,13 +159,17 @@ namespace SportsData.Provider.Infrastructure.Data
             if (ids.Count == 0)
                 return new HashSet<string>();
 
-            ValidateContainer(collectionName);
-            var container = _client.GetContainer(_databaseName, collectionName);
-
-            // Cross-partition id-only read (partition key is the 3-char
-            // routing prefix, so a single-partition query is not possible);
-            // Contains translates to an IN clause.
-            var iterator = container.GetItemLinqQueryable<DocumentBase>()
+            // Deliberately NOT ValidateContainer(collectionName): callers pass
+            // the Mongo-style collection name (the DocumentType, e.g.
+            // "EventCompetitionPlay"), but Cosmos co-locates every document
+            // type in the single sport-scoped container — validating the type
+            // name against the sport container would throw on every call and
+            // silently disable the L2 already-seen skip on this backend. The
+            // ids are SourceUrlHashes, globally unique across types, so
+            // querying the sport container by id alone is exact. Cross-
+            // partition id-only read (partition key is the 3-char routing
+            // prefix); Contains translates to an IN clause.
+            var iterator = _defaultContainer.GetItemLinqQueryable<DocumentBase>()
                 .Where(x => ids.Contains(x.Id))
                 .Select(x => x.Id)
                 .ToFeedIterator();

--- a/src/SportsData.Provider/Infrastructure/Data/CosmosDocumentService.cs
+++ b/src/SportsData.Provider/Infrastructure/Data/CosmosDocumentService.cs
@@ -154,7 +154,7 @@ namespace SportsData.Provider.Infrastructure.Data
             return default;
         }
 
-        public async Task<HashSet<string>> GetExistingIdsAsync(string collectionName, IReadOnlyCollection<string> ids)
+        public async Task<HashSet<string>> GetPublishedIdsAsync(string collectionName, IReadOnlyCollection<string> ids)
         {
             if (ids.Count == 0)
                 return new HashSet<string>();
@@ -168,9 +168,12 @@ namespace SportsData.Provider.Infrastructure.Data
             // ids are SourceUrlHashes, globally unique across types, so
             // querying the sport container by id alone is exact. Cross-
             // partition id-only read (partition key is the 3-char routing
-            // prefix); Contains translates to an IN clause.
+            // prefix); Contains translates to an IN clause. LastPublishedUtc
+            // != null is the "published at least once" half of the contract —
+            // persisted-but-never-published docs re-enqueue and get
+            // republished by the cache-hit path.
             var iterator = _defaultContainer.GetItemLinqQueryable<DocumentBase>()
-                .Where(x => ids.Contains(x.Id))
+                .Where(x => ids.Contains(x.Id) && x.LastPublishedUtc != null)
                 .Select(x => x.Id)
                 .ToFeedIterator();
 

--- a/src/SportsData.Provider/Infrastructure/Data/MongoDocumentService.cs
+++ b/src/SportsData.Provider/Infrastructure/Data/MongoDocumentService.cs
@@ -38,6 +38,15 @@ namespace SportsData.Provider.Infrastructure.Data
 
         Task<T?> GetFirstOrDefaultAsync<T>(string collectionName, Expression<Func<T, bool>> filter);
 
+        /// <summary>
+        /// Returns the subset of <paramref name="ids"/> that already exist as
+        /// document <c>_id</c>s in the collection — one batched primary-key
+        /// read. Used by the live-index already-seen skip (L2): for immutable
+        /// documents, existence in the store IS the durable "seen" signal.
+        /// See docs/features/live-sourcing-already-seen-skip.md.
+        /// </summary>
+        Task<HashSet<string>> GetExistingIdsAsync(string collectionName, IReadOnlyCollection<string> ids);
+
         Task InsertOneAsync<T>(string collectionName, T document) where T : IHasSourceUrl;
 
         Task ReplaceOneAsync<T>(string collectionName, string id, T document) where T : IHasSourceUrl;
@@ -150,6 +159,26 @@ namespace SportsData.Provider.Infrastructure.Data
             var collection = _database.GetCollection<T>(collectionName);
             var cursor = await collection.FindAsync(filter);
             return await cursor.FirstOrDefaultAsync();
+        }
+
+        public async Task<HashSet<string>> GetExistingIdsAsync(string collectionName, IReadOnlyCollection<string> ids)
+        {
+            if (ids.Count == 0)
+                return new HashSet<string>();
+
+            // BsonDocument on "_id" (rather than a typed filter) so the query
+            // is a pure primary-key $in with an _id-only projection — the
+            // driver maps DocumentBase.Id to _id by convention, and Id is
+            // assigned from SourceUrlHash on insert.
+            var collection = _database.GetCollection<BsonDocument>(collectionName);
+            var filter = Builders<BsonDocument>.Filter.In("_id", ids);
+
+            var found = await collection
+                .Find(filter)
+                .Project(Builders<BsonDocument>.Projection.Include("_id"))
+                .ToListAsync();
+
+            return found.Select(d => d["_id"].AsString).ToHashSet();
         }
 
         public async Task InsertOneAsync<T>(string collectionName, T document) where T : IHasSourceUrl

--- a/src/SportsData.Provider/Infrastructure/Data/MongoDocumentService.cs
+++ b/src/SportsData.Provider/Infrastructure/Data/MongoDocumentService.cs
@@ -39,17 +39,20 @@ namespace SportsData.Provider.Infrastructure.Data
         Task<T?> GetFirstOrDefaultAsync<T>(string collectionName, Expression<Func<T, bool>> filter);
 
         /// <summary>
-        /// Returns the subset of <paramref name="ids"/> that already exist as
-        /// document <c>_id</c>s — one batched primary-key read. Used by the
-        /// live-index already-seen skip (L2): for immutable documents,
-        /// existence in the store IS the durable "seen" signal.
+        /// Returns the subset of <paramref name="ids"/> whose documents are
+        /// both persisted AND have been published downstream at least once
+        /// (LastPublishedUtc set — written only after a successful
+        /// DocumentCreated publish) — one batched primary-key read. Used by
+        /// the live-index already-seen skip (L2): a document that persisted
+        /// but whose publish never landed is deliberately NOT returned, so it
+        /// re-enqueues and the cache-hit path republishes it.
         /// <paramref name="collectionName"/> is the Mongo (per-DocumentType)
         /// collection; the Cosmos implementation ignores it and queries the
         /// sport-scoped container where all types are co-located, which is
         /// exact because ids are globally unique SourceUrlHashes.
         /// See docs/features/live-sourcing-already-seen-skip.md.
         /// </summary>
-        Task<HashSet<string>> GetExistingIdsAsync(string collectionName, IReadOnlyCollection<string> ids);
+        Task<HashSet<string>> GetPublishedIdsAsync(string collectionName, IReadOnlyCollection<string> ids);
 
         Task InsertOneAsync<T>(string collectionName, T document) where T : IHasSourceUrl;
 
@@ -165,7 +168,7 @@ namespace SportsData.Provider.Infrastructure.Data
             return await cursor.FirstOrDefaultAsync();
         }
 
-        public async Task<HashSet<string>> GetExistingIdsAsync(string collectionName, IReadOnlyCollection<string> ids)
+        public async Task<HashSet<string>> GetPublishedIdsAsync(string collectionName, IReadOnlyCollection<string> ids)
         {
             if (ids.Count == 0)
                 return new HashSet<string>();
@@ -174,8 +177,16 @@ namespace SportsData.Provider.Infrastructure.Data
             // is a pure primary-key $in with an _id-only projection — the
             // driver maps DocumentBase.Id to _id by convention, and Id is
             // assigned from SourceUrlHash on insert.
+            //
+            // The LastPublishedUtc $ne null clause is the "published at least
+            // once" half of the contract: Mongo's $ne null excludes documents
+            // where the field is null OR missing, so a doc that persisted but
+            // whose publish never landed (and pre-marker legacy docs) is not
+            // returned — it re-enqueues and the cache-hit path republishes it,
+            // which then writes the marker.
             var collection = _database.GetCollection<BsonDocument>(collectionName);
-            var filter = Builders<BsonDocument>.Filter.In("_id", ids);
+            var filter = Builders<BsonDocument>.Filter.In("_id", ids)
+                & Builders<BsonDocument>.Filter.Ne(nameof(DocumentBase.LastPublishedUtc), BsonNull.Value);
 
             var found = await collection
                 .Find(filter)

--- a/src/SportsData.Provider/Infrastructure/Data/MongoDocumentService.cs
+++ b/src/SportsData.Provider/Infrastructure/Data/MongoDocumentService.cs
@@ -40,9 +40,13 @@ namespace SportsData.Provider.Infrastructure.Data
 
         /// <summary>
         /// Returns the subset of <paramref name="ids"/> that already exist as
-        /// document <c>_id</c>s in the collection — one batched primary-key
-        /// read. Used by the live-index already-seen skip (L2): for immutable
-        /// documents, existence in the store IS the durable "seen" signal.
+        /// document <c>_id</c>s — one batched primary-key read. Used by the
+        /// live-index already-seen skip (L2): for immutable documents,
+        /// existence in the store IS the durable "seen" signal.
+        /// <paramref name="collectionName"/> is the Mongo (per-DocumentType)
+        /// collection; the Cosmos implementation ignores it and queries the
+        /// sport-scoped container where all types are co-located, which is
+        /// exact because ids are globally unique SourceUrlHashes.
         /// See docs/features/live-sourcing-already-seen-skip.md.
         /// </summary>
         Task<HashSet<string>> GetExistingIdsAsync(string collectionName, IReadOnlyCollection<string> ids);

--- a/src/SportsData.Provider/Infrastructure/Providers/Espn/SeenUriCache.cs
+++ b/src/SportsData.Provider/Infrastructure/Providers/Espn/SeenUriCache.cs
@@ -6,36 +6,41 @@ using System.Collections.Concurrent;
 namespace SportsData.Provider.Infrastructure.Providers.Espn
 {
     /// <summary>
-    /// Remembers which immutable in-season items the live-index fan-out has
-    /// already handed to Hangfire, so subsequent polling cycles skip them at
-    /// the enqueue site — no Hangfire job, no Mongo read, no re-publish to
-    /// Producer. Without this, every cycle re-enqueues every item the game
-    /// has ever produced (observed 2026-09-06: 1.31M play documents processed
-    /// for ~500 real plays — quadratic cumulative cost per game).
+    /// Short-TTL, per-pod, atomic in-flight claim for the live-index
+    /// already-seen skip (L1). A claim means "this pod handed the item to
+    /// Hangfire within the last few minutes — don't enqueue it again while
+    /// that job is still landing." The durable, cross-pod skip signal is L2
+    /// (document existence in Mongo, consulted every cycle); L1 only bridges
+    /// the window between enqueue and persistence.
     ///
-    /// Deliberately per-pod and in-memory (no durable table, unlike
-    /// <see cref="KnownBadUriCache"/>): a cold cache costs exactly one
-    /// full-index cycle — the pre-fix steady state — after which the pod
-    /// converges. "Seen" means "enqueued once"; Hangfire owns delivery from
-    /// there with its own retries, and a permanently failed item remains
-    /// recoverable via the dependency-request leaf path, TTL expiry, or
-    /// manual reenrich. See docs/features/live-sourcing-already-seen-skip.md.
+    /// The TTL is deliberately SHORT: a claimed item whose Hangfire job never
+    /// persists (e.g. ESPN 404 → known-bad → clean return, no retry) is
+    /// re-enqueued when the claim lapses, restoring the pre-skip self-healing
+    /// cadence instead of masking the item for hours. The claim is atomic
+    /// (test-and-set), so concurrent DocumentRequested deliveries for the
+    /// same index cannot double-enqueue an item.
+    /// See docs/features/live-sourcing-already-seen-skip.md.
     /// </summary>
     public interface ISeenUriCache
     {
-        bool IsSeen(string urlHash);
-        void MarkSeen(string urlHash);
+        /// <summary>
+        /// Atomically claims the hash. Returns true when the caller now holds
+        /// the claim (no live claim existed) and should enqueue; false when an
+        /// unexpired claim already exists and the item should be skipped.
+        /// </summary>
+        bool TryMarkSeen(string urlHash);
     }
 
     public class SeenUriCache : ISeenUriCache
     {
-        // Comfortably beyond MaxStreamDuration (5h) so no live stream ever
-        // sees its own entries expire mid-game.
-        private static readonly TimeSpan Ttl = TimeSpan.FromHours(8);
+        // Long enough for a live-queue backlog to drain a pending job; short
+        // enough that a job which never persisted re-enqueues within minutes
+        // (L2 then vouches for items that DID persist, so a lapsed claim on a
+        // healthy item costs nothing — the Mongo existence check skips it).
+        private static readonly TimeSpan ClaimTtl = TimeSpan.FromMinutes(10);
 
-        // Entries for finished games are never read again (the stream stops
-        // asking), so remove-on-read alone would leak; a periodic sweep keeps
-        // a long-lived pod bounded.
+        // Entries for finished games are never claimed again, so a periodic
+        // sweep keeps a long-lived pod bounded.
         private static readonly TimeSpan SweepInterval = TimeSpan.FromHours(1);
 
         private readonly IDateTimeProvider _dateTimeProvider;
@@ -47,23 +52,33 @@ namespace SportsData.Provider.Infrastructure.Providers.Espn
             _dateTimeProvider = dateTimeProvider;
         }
 
-        public bool IsSeen(string urlHash)
-        {
-            if (!_expiryByKey.TryGetValue(urlHash, out var expiry))
-                return false;
-
-            if (expiry > _dateTimeProvider.UtcNow())
-                return true;
-
-            _expiryByKey.TryRemove(urlHash, out _);
-            return false;
-        }
-
-        public void MarkSeen(string urlHash)
+        public bool TryMarkSeen(string urlHash)
         {
             var now = _dateTimeProvider.UtcNow();
-            _expiryByKey[urlHash] = now.Add(Ttl);
+            var expiry = now.Add(ClaimTtl);
 
+            SweepIfDue(now);
+
+            while (true)
+            {
+                if (_expiryByKey.TryAdd(urlHash, expiry))
+                    return true;
+
+                if (!_expiryByKey.TryGetValue(urlHash, out var existing))
+                    continue; // removed concurrently — retry the add
+
+                if (existing > now)
+                    return false; // live claim held (by a prior cycle or a concurrent consumer)
+
+                // Expired claim: take it over atomically; on a lost race,
+                // loop and re-evaluate against the winner's entry.
+                if (_expiryByKey.TryUpdate(urlHash, expiry, existing))
+                    return true;
+            }
+        }
+
+        private void SweepIfDue(DateTime now)
+        {
             if (now < _nextSweepUtc)
                 return;
 

--- a/src/SportsData.Provider/Infrastructure/Providers/Espn/SeenUriCache.cs
+++ b/src/SportsData.Provider/Infrastructure/Providers/Espn/SeenUriCache.cs
@@ -1,0 +1,78 @@
+using SportsData.Core.Common;
+
+using System;
+using System.Collections.Concurrent;
+
+namespace SportsData.Provider.Infrastructure.Providers.Espn
+{
+    /// <summary>
+    /// Remembers which immutable in-season items the live-index fan-out has
+    /// already handed to Hangfire, so subsequent polling cycles skip them at
+    /// the enqueue site — no Hangfire job, no Mongo read, no re-publish to
+    /// Producer. Without this, every cycle re-enqueues every item the game
+    /// has ever produced (observed 2026-09-06: 1.31M play documents processed
+    /// for ~500 real plays — quadratic cumulative cost per game).
+    ///
+    /// Deliberately per-pod and in-memory (no durable table, unlike
+    /// <see cref="KnownBadUriCache"/>): a cold cache costs exactly one
+    /// full-index cycle — the pre-fix steady state — after which the pod
+    /// converges. "Seen" means "enqueued once"; Hangfire owns delivery from
+    /// there with its own retries, and a permanently failed item remains
+    /// recoverable via the dependency-request leaf path, TTL expiry, or
+    /// manual reenrich. See docs/features/live-sourcing-already-seen-skip.md.
+    /// </summary>
+    public interface ISeenUriCache
+    {
+        bool IsSeen(string urlHash);
+        void MarkSeen(string urlHash);
+    }
+
+    public class SeenUriCache : ISeenUriCache
+    {
+        // Comfortably beyond MaxStreamDuration (5h) so no live stream ever
+        // sees its own entries expire mid-game.
+        private static readonly TimeSpan Ttl = TimeSpan.FromHours(8);
+
+        // Entries for finished games are never read again (the stream stops
+        // asking), so remove-on-read alone would leak; a periodic sweep keeps
+        // a long-lived pod bounded.
+        private static readonly TimeSpan SweepInterval = TimeSpan.FromHours(1);
+
+        private readonly IDateTimeProvider _dateTimeProvider;
+        private readonly ConcurrentDictionary<string, DateTime> _expiryByKey = new();
+        private DateTime _nextSweepUtc = DateTime.MinValue;
+
+        public SeenUriCache(IDateTimeProvider dateTimeProvider)
+        {
+            _dateTimeProvider = dateTimeProvider;
+        }
+
+        public bool IsSeen(string urlHash)
+        {
+            if (!_expiryByKey.TryGetValue(urlHash, out var expiry))
+                return false;
+
+            if (expiry > _dateTimeProvider.UtcNow())
+                return true;
+
+            _expiryByKey.TryRemove(urlHash, out _);
+            return false;
+        }
+
+        public void MarkSeen(string urlHash)
+        {
+            var now = _dateTimeProvider.UtcNow();
+            _expiryByKey[urlHash] = now.Add(Ttl);
+
+            if (now < _nextSweepUtc)
+                return;
+
+            _nextSweepUtc = now.Add(SweepInterval);
+            foreach (var entry in _expiryByKey)
+            {
+                if (entry.Value <= now)
+                    _expiryByKey.TryRemove(entry.Key, out _);
+            }
+        }
+    }
+}

--- a/test/unit/SportsData.Provider.Tests.Unit/Application/Documents/DocumentRequestedHandlerTests.cs
+++ b/test/unit/SportsData.Provider.Tests.Unit/Application/Documents/DocumentRequestedHandlerTests.cs
@@ -975,10 +975,11 @@ public class DocumentRequestedHandlerTests : ProviderTestBase<DocumentRequestedH
     [Theory]
     [InlineData(SkipPlaysBaseUrl, DocumentType.EventCompetitionPlay)]
     [InlineData(SkipProbabilitiesBaseUrl, DocumentType.EventCompetitionProbability)]
-    public async Task PrioritySeenImmutableItems_SkippedAtFanOut_ExceptLiveEdge(
+    public async Task PriorityClaimedImmutableItems_SkippedAtFanOut_ExceptLiveEdge(
         string baseUrl, DocumentType documentType)
     {
-        // arrange — every item already seen; only the live edge may flow.
+        // arrange — every non-edge item holds a live in-flight claim (enqueued
+        // by a prior cycle, jobs presumed pending); only the live edge may flow.
         const int season = 2026;
         UseCurrentSeason(season);
 
@@ -986,8 +987,8 @@ public class DocumentRequestedHandlerTests : ProviderTestBase<DocumentRequestedH
             .Setup(x => x.GetResource(It.IsAny<Uri>(), It.IsAny<bool>(), It.IsAny<bool>()))
             .ReturnsAsync(new Success<string>(ThreeItemIndexJson(baseUrl)));
         Mocker.GetMock<ISeenUriCache>()
-            .Setup(x => x.IsSeen(It.IsAny<string>()))
-            .Returns(true);
+            .Setup(x => x.TryMarkSeen(It.IsAny<string>()))
+            .Returns(false);
 
         var captured = CaptureAllEnqueues();
         var handler = Mocker.CreateInstance<DocumentRequestedHandler>();
@@ -998,18 +999,19 @@ public class DocumentRequestedHandlerTests : ProviderTestBase<DocumentRequestedH
         // act
         await handler.Consume(ctx);
 
-        // assert — non-edge items were already seen; only the live edge flows.
+        // assert — non-edge items are claimed; only the live edge flows.
         var edge = captured.Should().ContainSingle().Subject;
         edge.Uri.ToString().Should().StartWith($"{baseUrl}/3");
         edge.BypassCache.Should().BeTrue("the live edge may still be finalizing and must re-fetch");
     }
 
     [Fact]
-    public async Task PriorityImmutableItems_MarkedSeenAtEnqueue_IncludingLiveEdge()
+    public async Task PriorityImmutableItems_ClaimedAtEnqueue_ExceptLiveEdge()
     {
-        // arrange — nothing seen yet (first cycle): all 3 enqueue, all 3 mark.
-        // The edge is marked too — once a newer play displaces it, it is
-        // complete and the skip applies to it.
+        // arrange — first cycle, nothing persisted, no claims held: all 3
+        // enqueue. The two non-edge items take the in-flight claim; the live
+        // edge is never claimed — it must re-fetch every cycle, and once
+        // displaced its persisted copy is picked up by L2.
         const int season = 2026;
         UseCurrentSeason(season);
 
@@ -1018,6 +1020,8 @@ public class DocumentRequestedHandlerTests : ProviderTestBase<DocumentRequestedH
             .ReturnsAsync(new Success<string>(ThreeItemIndexJson(SkipPlaysBaseUrl)));
 
         var seen = Mocker.GetMock<ISeenUriCache>();
+        seen.Setup(x => x.TryMarkSeen(It.IsAny<string>())).Returns(true);
+
         var captured = CaptureAllEnqueues();
         var handler = Mocker.CreateInstance<DocumentRequestedHandler>();
 
@@ -1029,7 +1033,7 @@ public class DocumentRequestedHandlerTests : ProviderTestBase<DocumentRequestedH
 
         // assert
         captured.Should().HaveCount(3);
-        seen.Verify(x => x.MarkSeen(It.IsAny<string>()), Times.Exactly(3));
+        seen.Verify(x => x.TryMarkSeen(It.IsAny<string>()), Times.Exactly(2));
     }
 
     [Theory]
@@ -1042,14 +1046,15 @@ public class DocumentRequestedHandlerTests : ProviderTestBase<DocumentRequestedH
     public async Task SeenSkip_DoesNotApply_OutsideTheGate(
         bool priority, DocumentType documentType, int? seasonYear)
     {
-        // arrange — cache claims everything is seen; the gate must ignore it.
+        // arrange — the claim cache would refuse every claim; the gate must
+        // never even consult it for ineligible traffic.
         UseCurrentSeason(2026);
 
         Mocker.GetMock<IProvideEspnApiData>()
             .Setup(x => x.GetResource(It.IsAny<Uri>(), It.IsAny<bool>(), It.IsAny<bool>()))
             .ReturnsAsync(new Success<string>(ThreeItemIndexJson(SkipPlaysBaseUrl)));
         var seen = Mocker.GetMock<ISeenUriCache>();
-        seen.Setup(x => x.IsSeen(It.IsAny<string>())).Returns(true);
+        seen.Setup(x => x.TryMarkSeen(It.IsAny<string>())).Returns(false);
 
         var captured = CaptureAllEnqueues();
         var handler = Mocker.CreateInstance<DocumentRequestedHandler>();
@@ -1060,9 +1065,9 @@ public class DocumentRequestedHandlerTests : ProviderTestBase<DocumentRequestedH
         // act
         await handler.Consume(ctx);
 
-        // assert — every item enqueued, nothing marked.
+        // assert — every item enqueued, nothing claimed.
         captured.Should().HaveCount(3);
-        seen.Verify(x => x.MarkSeen(It.IsAny<string>()), Times.Never);
+        seen.Verify(x => x.TryMarkSeen(It.IsAny<string>()), Times.Never);
     }
 
     // ── L2: batched Mongo existence check (cross-pod durable "seen") ────────
@@ -1105,8 +1110,48 @@ public class DocumentRequestedHandlerTests : ProviderTestBase<DocumentRequestedH
         var edge = captured.Should().ContainSingle().Subject;
         edge.Uri.ToString().Should().StartWith($"{SkipPlaysBaseUrl}/3");
 
-        // L2 hits are promoted into L1 (2), and the enqueued edge is marked (1).
-        seen.Verify(x => x.MarkSeen(It.IsAny<string>()), Times.Exactly(3));
+        // Persisted items skip on L2 alone and the edge always flows — the
+        // in-flight claim is never taken for either.
+        seen.Verify(x => x.TryMarkSeen(It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task L2_ConsultedForAllNonEdgeItems_EveryCycle()
+    {
+        // arrange — a held L1 claim must NOT shrink the L2 query: the durable
+        // persistence check is re-consulted every cycle so a claim can never
+        // mask a non-persisted item beyond its short TTL (the failed-job
+        // self-heal). Nothing persisted here, claims already held → non-edge
+        // items skip on the claim, but the batch query still saw them all.
+        const int season = 2026;
+        UseCurrentSeason(season);
+
+        Mocker.GetMock<IProvideEspnApiData>()
+            .Setup(x => x.GetResource(It.IsAny<Uri>(), It.IsAny<bool>(), It.IsAny<bool>()))
+            .ReturnsAsync(new Success<string>(ThreeItemIndexJson(SkipPlaysBaseUrl)));
+        Mocker.GetMock<ISeenUriCache>()
+            .Setup(x => x.TryMarkSeen(It.IsAny<string>()))
+            .Returns(false);
+
+        IReadOnlyCollection<string>? queriedIds = null;
+        var store = Mocker.GetMock<IDocumentStore>();
+        store
+            .Setup(x => x.GetExistingIdsAsync(It.IsAny<string>(), It.IsAny<IReadOnlyCollection<string>>()))
+            .Callback<string, IReadOnlyCollection<string>>((_, ids) => queriedIds = ids)
+            .ReturnsAsync(new HashSet<string>());
+
+        var captured = CaptureAllEnqueues();
+        var handler = Mocker.CreateInstance<DocumentRequestedHandler>();
+
+        var msg = SkipTestRequest(SkipPlaysBaseUrl, DocumentType.EventCompetitionPlay, season, priority: true);
+        var ctx = Mock.Of<ConsumeContext<DocumentRequested>>(x => x.Message == msg);
+
+        // act
+        await handler.Consume(ctx);
+
+        // assert
+        queriedIds.Should().NotBeNull().And.HaveCount(2, "held claims must not be pre-filtered out of the L2 query");
+        captured.Should().ContainSingle("non-edge items skip on their live claims; the edge flows");
     }
 
     [Fact]
@@ -1153,6 +1198,9 @@ public class DocumentRequestedHandlerTests : ProviderTestBase<DocumentRequestedH
         Mocker.GetMock<IDocumentStore>()
             .Setup(x => x.GetExistingIdsAsync(It.IsAny<string>(), It.IsAny<IReadOnlyCollection<string>>()))
             .ThrowsAsync(new TimeoutException("mongo unavailable"));
+        Mocker.GetMock<ISeenUriCache>()
+            .Setup(x => x.TryMarkSeen(It.IsAny<string>()))
+            .Returns(true);
 
         var captured = CaptureAllEnqueues();
         var handler = Mocker.CreateInstance<DocumentRequestedHandler>();

--- a/test/unit/SportsData.Provider.Tests.Unit/Application/Documents/DocumentRequestedHandlerTests.cs
+++ b/test/unit/SportsData.Provider.Tests.Unit/Application/Documents/DocumentRequestedHandlerTests.cs
@@ -1090,7 +1090,7 @@ public class DocumentRequestedHandlerTests : ProviderTestBase<DocumentRequestedH
 
         IReadOnlyCollection<string>? queriedIds = null;
         Mocker.GetMock<IDocumentStore>()
-            .Setup(x => x.GetExistingIdsAsync(
+            .Setup(x => x.GetPublishedIdsAsync(
                 nameof(DocumentType.EventCompetitionPlay), It.IsAny<IReadOnlyCollection<string>>()))
             .Callback<string, IReadOnlyCollection<string>>((_, ids) => queriedIds = ids)
             .ReturnsAsync((string _, IReadOnlyCollection<string> ids) => ids.ToHashSet());
@@ -1136,7 +1136,7 @@ public class DocumentRequestedHandlerTests : ProviderTestBase<DocumentRequestedH
         IReadOnlyCollection<string>? queriedIds = null;
         var store = Mocker.GetMock<IDocumentStore>();
         store
-            .Setup(x => x.GetExistingIdsAsync(It.IsAny<string>(), It.IsAny<IReadOnlyCollection<string>>()))
+            .Setup(x => x.GetPublishedIdsAsync(It.IsAny<string>(), It.IsAny<IReadOnlyCollection<string>>()))
             .Callback<string, IReadOnlyCollection<string>>((_, ids) => queriedIds = ids)
             .ReturnsAsync(new HashSet<string>());
 
@@ -1179,7 +1179,7 @@ public class DocumentRequestedHandlerTests : ProviderTestBase<DocumentRequestedH
         // assert
         captured.Should().HaveCount(3);
         store.Verify(
-            x => x.GetExistingIdsAsync(It.IsAny<string>(), It.IsAny<IReadOnlyCollection<string>>()),
+            x => x.GetPublishedIdsAsync(It.IsAny<string>(), It.IsAny<IReadOnlyCollection<string>>()),
             Times.Never);
     }
 
@@ -1196,7 +1196,7 @@ public class DocumentRequestedHandlerTests : ProviderTestBase<DocumentRequestedH
             .Setup(x => x.GetResource(It.IsAny<Uri>(), It.IsAny<bool>(), It.IsAny<bool>()))
             .ReturnsAsync(new Success<string>(ThreeItemIndexJson(SkipPlaysBaseUrl)));
         Mocker.GetMock<IDocumentStore>()
-            .Setup(x => x.GetExistingIdsAsync(It.IsAny<string>(), It.IsAny<IReadOnlyCollection<string>>()))
+            .Setup(x => x.GetPublishedIdsAsync(It.IsAny<string>(), It.IsAny<IReadOnlyCollection<string>>()))
             .ThrowsAsync(new TimeoutException("mongo unavailable"));
         Mocker.GetMock<ISeenUriCache>()
             .Setup(x => x.TryMarkSeen(It.IsAny<string>()))

--- a/test/unit/SportsData.Provider.Tests.Unit/Application/Documents/DocumentRequestedHandlerTests.cs
+++ b/test/unit/SportsData.Provider.Tests.Unit/Application/Documents/DocumentRequestedHandlerTests.cs
@@ -17,6 +17,7 @@ using SportsData.Core.Infrastructure.DataSources.Espn;
 using SportsData.Core.Processing;
 using SportsData.Provider.Application.Documents;
 using SportsData.Provider.Application.Processors;
+using SportsData.Provider.Infrastructure.Data;
 using SportsData.Provider.Infrastructure.Providers.Espn;
 
 using FluentValidation.Results;
@@ -903,5 +904,267 @@ public class DocumentRequestedHandlerTests : ProviderTestBase<DocumentRequestedH
 
         // assert
         knownBad.Verify(x => x.MarkBadAsync(ProbabilitiesUri, KnownBadReason.NotFound), Times.Once);
+    }
+
+    // ── Already-seen skip (live streamer fan-out) ───────────────────────────
+    // See docs/features/live-sourcing-already-seen-skip.md: streamer-originated
+    // (Priority) cycles re-page the whole index and re-enqueue every item the
+    // game has ever produced. Immutable items this pod already handed to
+    // Hangfire are skipped at the enqueue site — except the live edge, which
+    // may still be finalizing and must keep flowing every cycle.
+
+    private const string SkipPlaysBaseUrl =
+        "http://sports.core.api.espn.com/v2/sports/football/leagues/college-football/events/401628420/competitions/401628420/plays";
+    private const string SkipProbabilitiesBaseUrl =
+        "http://sports.core.api.espn.com/v2/sports/football/leagues/college-football/events/401628420/competitions/401628420/probabilities";
+
+    private static string ThreeItemIndexJson(string baseUrl) =>
+        "{\"count\":3,\"pageIndex\":1,\"pageSize\":25,\"pageCount\":1,\"items\":[" +
+        "{\"$ref\":\"" + baseUrl + "/1?lang=en\"}," +
+        "{\"$ref\":\"" + baseUrl + "/2?lang=en\"}," +
+        "{\"$ref\":\"" + baseUrl + "/3?lang=en\"}]}";
+
+    private void UseCurrentSeason(int season)
+    {
+        var cfg = (CommonConfig)RuntimeHelpers.GetUninitializedObject(typeof(CommonConfig));
+        cfg.CurrentSeason = season;
+        Mocker.Use<IOptions<CommonConfig>>(Options.Create(cfg));
+    }
+
+    /// <summary>
+    /// Captures commands from BOTH Enqueue overloads (plain and named-queue) —
+    /// Priority traffic rides the live queue, so the skip tests must observe it.
+    /// </summary>
+    private List<ProcessResourceIndexItemCommand> CaptureAllEnqueues()
+    {
+        var captured = new List<ProcessResourceIndexItemCommand>();
+        void Capture(Expression<Func<IProcessResourceIndexItems, Task>> expr)
+        {
+            var call = (MethodCallExpression)expr.Body;
+            captured.Add((ProcessResourceIndexItemCommand)Expression
+                .Lambda(call.Arguments[0]).Compile().DynamicInvoke()!);
+        }
+
+        var background = Mocker.GetMock<IProvideBackgroundJobs>();
+        background
+            .Setup(x => x.Enqueue<IProcessResourceIndexItems>(
+                It.IsAny<Expression<Func<IProcessResourceIndexItems, Task>>>()))
+            .Callback<Expression<Func<IProcessResourceIndexItems, Task>>>(Capture)
+            .Returns(string.Empty);
+        background
+            .Setup(x => x.Enqueue<IProcessResourceIndexItems>(
+                It.IsAny<string>(),
+                It.IsAny<Expression<Func<IProcessResourceIndexItems, Task>>>()))
+            .Callback<string, Expression<Func<IProcessResourceIndexItems, Task>>>((_, expr) => Capture(expr))
+            .Returns(string.Empty);
+        return captured;
+    }
+
+    private DocumentRequested SkipTestRequest(
+        string baseUrl, DocumentType documentType, int? seasonYear, bool priority) =>
+        Fixture.Build<DocumentRequested>()
+            .With(x => x.Uri, new Uri($"{baseUrl}?lang=en"))
+            .With(x => x.DocumentType, documentType)
+            .With(x => x.SourceDataProvider, SourceDataProvider.Espn)
+            .With(x => x.Sport, Sport.FootballNcaa)
+            .With(x => x.SeasonYear, seasonYear)
+            .With(x => x.Priority, priority)
+            .OmitAutoProperties()
+            .Create();
+
+    [Theory]
+    [InlineData(SkipPlaysBaseUrl, DocumentType.EventCompetitionPlay)]
+    [InlineData(SkipProbabilitiesBaseUrl, DocumentType.EventCompetitionProbability)]
+    public async Task PrioritySeenImmutableItems_SkippedAtFanOut_ExceptLiveEdge(
+        string baseUrl, DocumentType documentType)
+    {
+        // arrange — every item already seen; only the live edge may flow.
+        const int season = 2026;
+        UseCurrentSeason(season);
+
+        Mocker.GetMock<IProvideEspnApiData>()
+            .Setup(x => x.GetResource(It.IsAny<Uri>(), It.IsAny<bool>(), It.IsAny<bool>()))
+            .ReturnsAsync(new Success<string>(ThreeItemIndexJson(baseUrl)));
+        Mocker.GetMock<ISeenUriCache>()
+            .Setup(x => x.IsSeen(It.IsAny<string>()))
+            .Returns(true);
+
+        var captured = CaptureAllEnqueues();
+        var handler = Mocker.CreateInstance<DocumentRequestedHandler>();
+
+        var msg = SkipTestRequest(baseUrl, documentType, season, priority: true);
+        var ctx = Mock.Of<ConsumeContext<DocumentRequested>>(x => x.Message == msg);
+
+        // act
+        await handler.Consume(ctx);
+
+        // assert — non-edge items were already seen; only the live edge flows.
+        var edge = captured.Should().ContainSingle().Subject;
+        edge.Uri.ToString().Should().StartWith($"{baseUrl}/3");
+        edge.BypassCache.Should().BeTrue("the live edge may still be finalizing and must re-fetch");
+    }
+
+    [Fact]
+    public async Task PriorityImmutableItems_MarkedSeenAtEnqueue_IncludingLiveEdge()
+    {
+        // arrange — nothing seen yet (first cycle): all 3 enqueue, all 3 mark.
+        // The edge is marked too — once a newer play displaces it, it is
+        // complete and the skip applies to it.
+        const int season = 2026;
+        UseCurrentSeason(season);
+
+        Mocker.GetMock<IProvideEspnApiData>()
+            .Setup(x => x.GetResource(It.IsAny<Uri>(), It.IsAny<bool>(), It.IsAny<bool>()))
+            .ReturnsAsync(new Success<string>(ThreeItemIndexJson(SkipPlaysBaseUrl)));
+
+        var seen = Mocker.GetMock<ISeenUriCache>();
+        var captured = CaptureAllEnqueues();
+        var handler = Mocker.CreateInstance<DocumentRequestedHandler>();
+
+        var msg = SkipTestRequest(SkipPlaysBaseUrl, DocumentType.EventCompetitionPlay, season, priority: true);
+        var ctx = Mock.Of<ConsumeContext<DocumentRequested>>(x => x.Message == msg);
+
+        // act
+        await handler.Consume(ctx);
+
+        // assert
+        captured.Should().HaveCount(3);
+        seen.Verify(x => x.MarkSeen(It.IsAny<string>()), Times.Exactly(3));
+    }
+
+    [Theory]
+    // The skip gate: Priority (streamer live traffic) AND immutable type AND
+    // exactly the current season. Outside the gate, seen-ness is irrelevant —
+    // and nothing is marked, so the cache can't grow from non-streamer traffic.
+    [InlineData(false, DocumentType.EventCompetitionPlay, 2026)]   // reenrich/on-final/historical: not Priority
+    [InlineData(true, DocumentType.EventCompetitionStatus, 2026)]  // mutable type must always flow
+    [InlineData(true, DocumentType.EventCompetitionPlay, 2024)]    // not the current season
+    public async Task SeenSkip_DoesNotApply_OutsideTheGate(
+        bool priority, DocumentType documentType, int? seasonYear)
+    {
+        // arrange — cache claims everything is seen; the gate must ignore it.
+        UseCurrentSeason(2026);
+
+        Mocker.GetMock<IProvideEspnApiData>()
+            .Setup(x => x.GetResource(It.IsAny<Uri>(), It.IsAny<bool>(), It.IsAny<bool>()))
+            .ReturnsAsync(new Success<string>(ThreeItemIndexJson(SkipPlaysBaseUrl)));
+        var seen = Mocker.GetMock<ISeenUriCache>();
+        seen.Setup(x => x.IsSeen(It.IsAny<string>())).Returns(true);
+
+        var captured = CaptureAllEnqueues();
+        var handler = Mocker.CreateInstance<DocumentRequestedHandler>();
+
+        var msg = SkipTestRequest(SkipPlaysBaseUrl, documentType, seasonYear, priority);
+        var ctx = Mock.Of<ConsumeContext<DocumentRequested>>(x => x.Message == msg);
+
+        // act
+        await handler.Consume(ctx);
+
+        // assert — every item enqueued, nothing marked.
+        captured.Should().HaveCount(3);
+        seen.Verify(x => x.MarkSeen(It.IsAny<string>()), Times.Never);
+    }
+
+    // ── L2: batched Mongo existence check (cross-pod durable "seen") ────────
+    // "Seen" at L2 means "the document is already persisted" — the store
+    // itself is the signal, so another pod's work (or a pre-restart cycle)
+    // suppresses re-enqueueing with no shared cache.
+
+    [Fact]
+    public async Task L2_PersistedItems_SkippedAcrossPods_ExceptLiveEdge()
+    {
+        // arrange — L1 cold (fresh pod), but every non-edge item is already
+        // in Mongo. The batch query gets exactly the non-edge candidates and
+        // reports all of them persisted.
+        const int season = 2026;
+        UseCurrentSeason(season);
+
+        Mocker.GetMock<IProvideEspnApiData>()
+            .Setup(x => x.GetResource(It.IsAny<Uri>(), It.IsAny<bool>(), It.IsAny<bool>()))
+            .ReturnsAsync(new Success<string>(ThreeItemIndexJson(SkipPlaysBaseUrl)));
+
+        IReadOnlyCollection<string>? queriedIds = null;
+        Mocker.GetMock<IDocumentStore>()
+            .Setup(x => x.GetExistingIdsAsync(
+                nameof(DocumentType.EventCompetitionPlay), It.IsAny<IReadOnlyCollection<string>>()))
+            .Callback<string, IReadOnlyCollection<string>>((_, ids) => queriedIds = ids)
+            .ReturnsAsync((string _, IReadOnlyCollection<string> ids) => ids.ToHashSet());
+
+        var seen = Mocker.GetMock<ISeenUriCache>();
+        var captured = CaptureAllEnqueues();
+        var handler = Mocker.CreateInstance<DocumentRequestedHandler>();
+
+        var msg = SkipTestRequest(SkipPlaysBaseUrl, DocumentType.EventCompetitionPlay, season, priority: true);
+        var ctx = Mock.Of<ConsumeContext<DocumentRequested>>(x => x.Message == msg);
+
+        // act
+        await handler.Consume(ctx);
+
+        // assert — the live edge never enters the batch query and always flows.
+        queriedIds.Should().NotBeNull().And.HaveCount(2, "only non-edge items are L2 candidates");
+        var edge = captured.Should().ContainSingle().Subject;
+        edge.Uri.ToString().Should().StartWith($"{SkipPlaysBaseUrl}/3");
+
+        // L2 hits are promoted into L1 (2), and the enqueued edge is marked (1).
+        seen.Verify(x => x.MarkSeen(It.IsAny<string>()), Times.Exactly(3));
+    }
+
+    [Fact]
+    public async Task L2_NotConsulted_ForIneligibleTraffic()
+    {
+        // arrange — non-Priority (reenrich/on-final/historical): the batch
+        // existence check must not even run.
+        const int season = 2026;
+        UseCurrentSeason(season);
+
+        Mocker.GetMock<IProvideEspnApiData>()
+            .Setup(x => x.GetResource(It.IsAny<Uri>(), It.IsAny<bool>(), It.IsAny<bool>()))
+            .ReturnsAsync(new Success<string>(ThreeItemIndexJson(SkipPlaysBaseUrl)));
+
+        var store = Mocker.GetMock<IDocumentStore>();
+        var captured = CaptureAllEnqueues();
+        var handler = Mocker.CreateInstance<DocumentRequestedHandler>();
+
+        var msg = SkipTestRequest(SkipPlaysBaseUrl, DocumentType.EventCompetitionPlay, season, priority: false);
+        var ctx = Mock.Of<ConsumeContext<DocumentRequested>>(x => x.Message == msg);
+
+        // act
+        await handler.Consume(ctx);
+
+        // assert
+        captured.Should().HaveCount(3);
+        store.Verify(
+            x => x.GetExistingIdsAsync(It.IsAny<string>(), It.IsAny<IReadOnlyCollection<string>>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task L2_FailsOpen_WhenStoreThrows()
+    {
+        // arrange — a Mongo hiccup must never stall live sourcing: on error,
+        // every item enqueues (pre-skip behavior) instead of the consumer
+        // faulting.
+        const int season = 2026;
+        UseCurrentSeason(season);
+
+        Mocker.GetMock<IProvideEspnApiData>()
+            .Setup(x => x.GetResource(It.IsAny<Uri>(), It.IsAny<bool>(), It.IsAny<bool>()))
+            .ReturnsAsync(new Success<string>(ThreeItemIndexJson(SkipPlaysBaseUrl)));
+        Mocker.GetMock<IDocumentStore>()
+            .Setup(x => x.GetExistingIdsAsync(It.IsAny<string>(), It.IsAny<IReadOnlyCollection<string>>()))
+            .ThrowsAsync(new TimeoutException("mongo unavailable"));
+
+        var captured = CaptureAllEnqueues();
+        var handler = Mocker.CreateInstance<DocumentRequestedHandler>();
+
+        var msg = SkipTestRequest(SkipPlaysBaseUrl, DocumentType.EventCompetitionPlay, season, priority: true);
+        var ctx = Mock.Of<ConsumeContext<DocumentRequested>>(x => x.Message == msg);
+
+        // act
+        var ex = await Record.ExceptionAsync(() => handler.Consume(ctx));
+
+        // assert
+        ex.Should().BeNull();
+        captured.Should().HaveCount(3);
     }
 }

--- a/test/unit/SportsData.Provider.Tests.Unit/Application/Processors/InSeasonDocumentPolicyTests.cs
+++ b/test/unit/SportsData.Provider.Tests.Unit/Application/Processors/InSeasonDocumentPolicyTests.cs
@@ -12,6 +12,10 @@ public class InSeasonDocumentPolicyTests
     [Theory]
     // Immutable once created → served from Mongo even in-season (the fix).
     [InlineData(DocumentType.EventCompetitionPlay, true)]
+    // One probability item per play; append-only index, completed entries never
+    // change. Excluding it sent every item to ESPN each 15s live cycle
+    // (611,931 processed 2026-09-06 for ~500 real items).
+    [InlineData(DocumentType.EventCompetitionProbability, true)]
     // Mutable aggregates → must keep bypassing cache in-season to stay fresh.
     [InlineData(DocumentType.EventCompetitionStatus, false)]
     [InlineData(DocumentType.EventCompetitionSituation, false)]

--- a/test/unit/SportsData.Provider.Tests.Unit/Infrastructure/Providers/SeenUriCacheTests.cs
+++ b/test/unit/SportsData.Provider.Tests.Unit/Infrastructure/Providers/SeenUriCacheTests.cs
@@ -1,0 +1,70 @@
+#nullable enable
+
+using FluentAssertions;
+
+using Moq;
+
+using SportsData.Core.Common;
+using SportsData.Provider.Infrastructure.Providers.Espn;
+
+using System;
+
+using Xunit;
+
+namespace SportsData.Provider.Tests.Unit.Infrastructure.Providers;
+
+public class SeenUriCacheTests
+{
+    private static readonly DateTime T0 = new(2026, 9, 7, 18, 0, 0, DateTimeKind.Utc);
+
+    private readonly Mock<IDateTimeProvider> _clock = new();
+    private readonly SeenUriCache _cache;
+
+    public SeenUriCacheTests()
+    {
+        _clock.Setup(x => x.UtcNow()).Returns(T0);
+        _cache = new SeenUriCache(_clock.Object);
+    }
+
+    [Fact]
+    public void NeverMarked_IsNotSeen()
+    {
+        _cache.IsSeen("abc123").Should().BeFalse();
+    }
+
+    [Fact]
+    public void Marked_IsSeen_WithinTtl()
+    {
+        _cache.MarkSeen("abc123");
+
+        // 5h later — the longest possible stream is still inside the 8h TTL.
+        _clock.Setup(x => x.UtcNow()).Returns(T0.AddHours(5));
+
+        _cache.IsSeen("abc123").Should().BeTrue();
+        _cache.IsSeen("other").Should().BeFalse("marking one hash must not mark others");
+    }
+
+    [Fact]
+    public void Marked_ExpiresAfterTtl()
+    {
+        _cache.MarkSeen("abc123");
+
+        _clock.Setup(x => x.UtcNow()).Returns(T0.AddHours(9));
+
+        _cache.IsSeen("abc123").Should().BeFalse("entries expire after the 8h TTL");
+    }
+
+    [Fact]
+    public void ReMarking_RefreshesTtl()
+    {
+        _cache.MarkSeen("abc123");
+
+        // Re-marked at +6h (e.g. the item slipped through on a rewarm cycle);
+        // at +10h the original mark would be expired but the refresh is not.
+        _clock.Setup(x => x.UtcNow()).Returns(T0.AddHours(6));
+        _cache.MarkSeen("abc123");
+
+        _clock.Setup(x => x.UtcNow()).Returns(T0.AddHours(10));
+        _cache.IsSeen("abc123").Should().BeTrue();
+    }
+}

--- a/test/unit/SportsData.Provider.Tests.Unit/Infrastructure/Providers/SeenUriCacheTests.cs
+++ b/test/unit/SportsData.Provider.Tests.Unit/Infrastructure/Providers/SeenUriCacheTests.cs
@@ -27,44 +27,45 @@ public class SeenUriCacheTests
     }
 
     [Fact]
-    public void NeverMarked_IsNotSeen()
+    public void FirstClaim_Succeeds()
     {
-        _cache.IsSeen("abc123").Should().BeFalse();
+        _cache.TryMarkSeen("abc123").Should().BeTrue();
     }
 
     [Fact]
-    public void Marked_IsSeen_WithinTtl()
+    public void SecondClaim_WithinTtl_Fails()
     {
-        _cache.MarkSeen("abc123");
+        _cache.TryMarkSeen("abc123").Should().BeTrue();
 
-        // 5h later — the longest possible stream is still inside the 8h TTL.
-        _clock.Setup(x => x.UtcNow()).Returns(T0.AddHours(5));
+        // 9 minutes later — the 10-minute claim is still live.
+        _clock.Setup(x => x.UtcNow()).Returns(T0.AddMinutes(9));
 
-        _cache.IsSeen("abc123").Should().BeTrue();
-        _cache.IsSeen("other").Should().BeFalse("marking one hash must not mark others");
+        _cache.TryMarkSeen("abc123").Should().BeFalse("an unexpired claim suppresses re-enqueue");
+        _cache.TryMarkSeen("other").Should().BeTrue("claiming one hash must not claim others");
     }
 
     [Fact]
-    public void Marked_ExpiresAfterTtl()
+    public void Claim_ReleasesAfterTtl()
     {
-        _cache.MarkSeen("abc123");
+        _cache.TryMarkSeen("abc123").Should().BeTrue();
 
-        _clock.Setup(x => x.UtcNow()).Returns(T0.AddHours(9));
+        // Past the 10-minute TTL: a job that never persisted must be allowed
+        // to re-enqueue (the self-healing path for cleanly-failed jobs).
+        _clock.Setup(x => x.UtcNow()).Returns(T0.AddMinutes(11));
 
-        _cache.IsSeen("abc123").Should().BeFalse("entries expire after the 8h TTL");
+        _cache.TryMarkSeen("abc123").Should().BeTrue("a lapsed claim is claimable again");
     }
 
     [Fact]
-    public void ReMarking_RefreshesTtl()
+    public void ReClaim_AfterExpiry_RestartsTtl()
     {
-        _cache.MarkSeen("abc123");
+        _cache.TryMarkSeen("abc123").Should().BeTrue();
 
-        // Re-marked at +6h (e.g. the item slipped through on a rewarm cycle);
-        // at +10h the original mark would be expired but the refresh is not.
-        _clock.Setup(x => x.UtcNow()).Returns(T0.AddHours(6));
-        _cache.MarkSeen("abc123");
+        _clock.Setup(x => x.UtcNow()).Returns(T0.AddMinutes(11));
+        _cache.TryMarkSeen("abc123").Should().BeTrue();
 
-        _clock.Setup(x => x.UtcNow()).Returns(T0.AddHours(10));
-        _cache.IsSeen("abc123").Should().BeTrue();
+        // 9 minutes into the SECOND claim: still held.
+        _clock.Setup(x => x.UtcNow()).Returns(T0.AddMinutes(20));
+        _cache.TryMarkSeen("abc123").Should().BeFalse();
     }
 }


### PR DESCRIPTION
## Problem

Live game polling re-enqueued **every item a game had ever produced, every cycle** (plays index every 10s, probabilities every 15s). Per-interval work grows linearly with game time → quadratic cumulative cost per game.

Observed 2026-09-06 evening (2 streamed NCAAFB games, ~500 real plays):
- Producer processed **1,314,943** EventCompetitionPlay documents (**~2,000x** amplification) and **611,931** EventCompetitionProbability
- Grafana per-interval lines (Mongo cache hits AND ESPN live fetches) climbed linearly for each game's full duration
- `00-live` held 45-55k jobs Saturday evening; 93% immutable plays/probs; p50 job age 6.5 min in primetime

## Root cause (three compounding gaps)

1. The `ProcessResourceIndex` fan-out has no memory — all N items become Hangfire jobs every cycle
2. `EventCompetitionProbability` was not in `InSeasonDocumentPolicy` → every item fetched from **ESPN** each 15s cycle
3. Current-season Mongo cache hits always republish `DocumentCreated` → Producer reprocessed every play every ~10s

## Fix

Single decision point at the enqueue site, so skipped work never exists anywhere downstream (no Hangfire job, no Mongo read, no RabbitMQ publish, no Producer hop):

- **Policy**: `EventCompetitionProbability` classified immutable-in-season (one item per play, append-only index, entries never change once complete)
- **L1 — `SeenUriCache`** (new, per-pod, in-memory, 8h TTL): skips items this pod already handed to Hangfire; marked at enqueue because the Hangfire worker may be a different pod
- **L2 — batched Mongo existence check** (`IDocumentStore.GetExistingIdsAsync`, one `$in` on `_id` per index page): "seen" = "persisted" — durable, cross-pod, cannot drift and cannot mask a failed Hangfire job (a document that never landed is not there and re-enqueues next cycle). **Fails open** on store errors. L2 hits promote into L1 so subsequent batch queries shrink to genuinely new items. Cosmos implementation included for interface parity.
- **Gates**: skip applies ONLY to `Priority` streamer traffic + immutable type + exactly the current season, and **never the live edge** (last item, last page — may still be finalizing). Reenrich, on-final contest refresh, and historical sourcing are untouched by construction.
- **Observability**: new counter `provider.documents.skipped_seen` (DocumentType/Sport tags); enqueue summary log now includes `SkippedAlreadySeen`
- Rename `seenPages` → `visitedPageUrls` (pagination cycle guard, unrelated to the item-level skip)

Design doc with pipeline mermaid diagrams and considered alternatives (Redis, `ResourceIndexItem`): `docs/features/live-sourcing-already-seen-skip.md`

## Testing

- 108 unit tests pass (Provider suite): 8 new — skip-except-live-edge for plays and probabilities, mark-at-enqueue including the edge, gate theory (non-Priority / mutable type / wrong season never skipped and never marked), L2 cross-pod skip with cold L1 + promotion, L2 never consulted for non-Priority traffic, L2 fail-open, SeenUriCache TTL semantics
- Deploy verification plan (single NCAAFB game tonight 19:30, zero NFL): both per-interval Grafana lines flat instead of climbing; `provider.documents.skipped_seen` growing; Producer plays/probs totals within ~2-3x of real event counts; `00-live` age percentiles flat

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XPkLHDqNKDA4krjqknFmSq

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Reduced duplicate processing of already-seen, immutable in-season live-sourcing items.
  - Added support for recognizing immutable event probability updates during in-season processing.
  - Added safeguards to prevent repeated page processing and duplicate enqueuing across polling cycles.

- **Bug Fixes**
  - Preserved live-edge updates while skipping previously persisted or queued items.
  - Added resilient existence checks that continue processing if the lookup service is unavailable.

- **Tests**
  - Added coverage for deduplication, expiration, eligibility rules, persistence checks, and failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->