### PR TITLE
chore(tests): real InMemory isolation, parallel Producer suite, cached mappers

### DIFF
--- a/test/SportsData.Tests.Shared/UnitTestBase.cs
+++ b/test/SportsData.Tests.Shared/UnitTestBase.cs
@@ -34,10 +34,17 @@ public abstract class UnitTestBase<T>
 
         Logger = CreateLogger(LoggerTypes.List) as ListLogger;
 
-        var mapperConfig = new MapperConfiguration(c => c.AddProfile(new DynamicMappingProfile()));
-        var mapper = mapperConfig.CreateMapper();
-        Mocker.Use(typeof(IMapper), mapper);
+        Mocker.Use(typeof(IMapper), SharedMapper.Value);
     }
+
+    // AutoMapper configuration compilation is expensive and xunit constructs
+    // the test class PER TEST — building it in the ctor charged every test in
+    // every suite a fresh compile. IMapper is stateless and thread-safe, so
+    // one shared instance serves parallel test runs. Derived bases that need
+    // extra profiles (e.g. ProducerTestBase) overwrite the registration with
+    // their own cached instance.
+    private static readonly Lazy<IMapper> SharedMapper = new(() =>
+        new MapperConfiguration(c => c.AddProfile(new DynamicMappingProfile())).CreateMapper());
 
     public static ILogger CreateLogger(LoggerTypes type = LoggerTypes.Null)
     {

--- a/test/SportsData.Tests.Shared/UnitTestBase.cs
+++ b/test/SportsData.Tests.Shared/UnitTestBase.cs
@@ -34,17 +34,8 @@ public abstract class UnitTestBase<T>
 
         Logger = CreateLogger(LoggerTypes.List) as ListLogger;
 
-        Mocker.Use(typeof(IMapper), SharedMapper.Value);
+        Mocker.Use(typeof(IMapper), SharedTestMappers.Default.Value);
     }
-
-    // AutoMapper configuration compilation is expensive and xunit constructs
-    // the test class PER TEST — building it in the ctor charged every test in
-    // every suite a fresh compile. IMapper is stateless and thread-safe, so
-    // one shared instance serves parallel test runs. Derived bases that need
-    // extra profiles (e.g. ProducerTestBase) overwrite the registration with
-    // their own cached instance.
-    private static readonly Lazy<IMapper> SharedMapper = new(() =>
-        new MapperConfiguration(c => c.AddProfile(new DynamicMappingProfile())).CreateMapper());
 
     public static ILogger CreateLogger(LoggerTypes type = LoggerTypes.Null)
     {
@@ -57,4 +48,21 @@ public abstract class UnitTestBase<T>
     {
         return await File.ReadAllTextAsync($"../../../Data/{filename}");
     }
+}
+
+/// <summary>
+/// Non-generic holder for the shared test mapper. AutoMapper configuration
+/// compilation is expensive and xunit constructs the test class PER TEST —
+/// building it in the UnitTestBase ctor charged every test in every suite a
+/// fresh compile. A static on UnitTestBase&lt;T&gt; itself (or any type
+/// nested in it) would be re-created once per closed T (~one per test
+/// class), so the cache lives here: exactly one compile per profile set.
+/// IMapper is stateless and thread-safe, so one instance serves parallel
+/// runs. Derived bases that need extra profiles (e.g. ProducerTestBase)
+/// overwrite the registration with their own non-generic-held instance.
+/// </summary>
+internal static class SharedTestMappers
+{
+    internal static readonly Lazy<IMapper> Default = new(() =>
+        new MapperConfiguration(c => c.AddProfile(new DynamicMappingProfile())).CreateMapper());
 }

--- a/test/unit/SportsData.Api.Tests.Unit/ApiTestBase.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/ApiTestBase.cs
@@ -44,7 +44,7 @@ namespace SportsData.Api.Tests.Unit
 
         private static DbContextOptions<AppDataContext> GetAppDataContextOptions()
         {
-            var dbName = Guid.NewGuid().ToString()[..5];
+            var dbName = Guid.NewGuid().ToString(); // full Guid: truncated names collide and InMemory shares same-named stores
             return new DbContextOptionsBuilder<AppDataContext>()
                 .UseInMemoryDatabase(dbName)
                 .ConfigureWarnings(w => w.Ignore(Microsoft.EntityFrameworkCore.Diagnostics.InMemoryEventId.TransactionIgnoredWarning))

--- a/test/unit/SportsData.Notification.Tests.Unit/NotificationTestBase.cs
+++ b/test/unit/SportsData.Notification.Tests.Unit/NotificationTestBase.cs
@@ -18,7 +18,7 @@ namespace SportsData.Notification.Tests.Unit
 
         private static DbContextOptions<AppDataContext> GetAppDataContextOptions()
         {
-            var dbName = Guid.NewGuid().ToString()[..5];
+            var dbName = Guid.NewGuid().ToString(); // full Guid: truncated names collide and InMemory shares same-named stores
             return new DbContextOptionsBuilder<AppDataContext>()
                 .UseInMemoryDatabase(dbName)
                 .ConfigureWarnings(w => w.Ignore(Microsoft.EntityFrameworkCore.Diagnostics.InMemoryEventId.TransactionIgnoredWarning))

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Competitions/CalculateCompetitionMetricsCommandHandlerTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Competitions/CalculateCompetitionMetricsCommandHandlerTests.cs
@@ -26,7 +26,6 @@ namespace SportsData.Producer.Tests.Unit.Application.Competitions
     /// Tests for CalculateCompetitionMetricsCommandHandler using real game data.
     /// Optimized to reduce test setup overhead by consolidating related tests.
     /// </summary>
-    [Collection("Sequential")] // Force sequential to avoid DB contention
     public class CalculateCompetitionMetricsCommandHandlerTests : ProducerTestBase<CalculateCompetitionMetricsCommandHandler>, IAsyncLifetime
     {
         private readonly ITestOutputHelper _output;

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Competitions/FootballCompetitionStreamerTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Competitions/FootballCompetitionStreamerTests.cs
@@ -30,7 +30,6 @@ namespace SportsData.Producer.Tests.Unit.Application.Competitions;
 /// Tests for FootballCompetitionStreamer to validate live game streaming functionality.
 /// Tests cover cancellation, status tracking, worker management, and error handling.
 /// </summary>
-[Collection("Sequential")]
 public class FootballCompetitionStreamerTests : ProducerTestBase<FootballCompetitionStreamer>
 {
     #region Helper Methods

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Competitions/FootballCompetitionStreamer_LiveGameTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Competitions/FootballCompetitionStreamer_LiveGameTests.cs
@@ -18,7 +18,6 @@ namespace SportsData.Producer.Tests.Unit.Application.Competitions;
 /// Unit tests for FootballCompetitionStreamer focusing on isolated behavior.
 /// For integration tests using real Postman collection data, see SportsData.Producer.Tests.Integration.
 /// </summary>
-[Collection("Sequential")]
 public class FootballCompetitionStreamer_LiveGameTests : ProducerTestBase<FootballCompetitionStreamer>
 {
     /// <summary>

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Competitions/Reconcile/FinalizationReconcileJobTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Competitions/Reconcile/FinalizationReconcileJobTests.cs
@@ -25,7 +25,6 @@ using Xunit;
 
 namespace SportsData.Producer.Tests.Unit.Application.Competitions.Reconcile;
 
-[Collection("Sequential")]
 public class FinalizationReconcileJobTests : ProducerTestBase<FinalizationReconcileJob<FootballDataContext>>
 {
     private static readonly DateTime FixedNow = new(2026, 6, 14, 12, 0, 0, DateTimeKind.Utc);

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Contests/ContestEnrichmentAuditJobTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Contests/ContestEnrichmentAuditJobTests.cs
@@ -14,7 +14,6 @@ using Xunit;
 
 namespace SportsData.Producer.Tests.Unit.Application.Contests;
 
-[Collection("Sequential")]
 public class ContestEnrichmentAuditJobTests : ProducerTestBase<ContestEnrichmentAuditJob<FootballDataContext>>
 {
     private static readonly DateTime FixedNow =

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Contests/ContestEnrichmentAuditProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Contests/ContestEnrichmentAuditProcessorTests.cs
@@ -17,7 +17,6 @@ using Xunit;
 
 namespace SportsData.Producer.Tests.Unit.Application.Contests;
 
-[Collection("Sequential")]
 public class ContestEnrichmentAuditProcessorTests
     : ProducerTestBase<ContestEnrichmentAuditProcessor<FootballDataContext>>
 {

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Contests/ContestEnrichmentJobTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Contests/ContestEnrichmentJobTests.cs
@@ -14,7 +14,6 @@ using Xunit;
 
 namespace SportsData.Producer.Tests.Unit.Application.Contests;
 
-[Collection("Sequential")]
 public class ContestEnrichmentJobTests : ProducerTestBase<ContestEnrichmentJob<FootballDataContext>>
 {
     private static readonly DateTime FixedNow =

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionCompetitorDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionCompetitorDocumentProcessorTests.cs
@@ -39,7 +39,6 @@ namespace SportsData.Producer.Tests.Unit.Application.Documents.Processors.Provid
 ///
 /// See docs/competition-competitor-probables.md.
 /// </summary>
-[Collection("Sequential")]
 public class BaseballEventCompetitionCompetitorDocumentProcessorTests
     : ProducerTestBase<BaseballEventCompetitionCompetitorDocumentProcessor<BaseballDataContext>>
 {

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionDocumentProcessorTests.cs
@@ -38,7 +38,6 @@ namespace SportsData.Producer.Tests.Unit.Application.Documents.Processors.Provid
 ///
 /// See docs/series-snapshot-redesign.md.
 /// </summary>
-[Collection("Sequential")]
 public class BaseballEventCompetitionDocumentProcessorTests
     : ProducerTestBase<BaseballEventCompetitionDocumentProcessor<BaseballDataContext>>
 {

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionOddsDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionOddsDocumentProcessorTests.cs
@@ -34,7 +34,6 @@ namespace SportsData.Producer.Tests.Unit.Application.Documents.Processors.Provid
 /// processor tests follow the same pragmatic pattern until a dedicated
 /// BaseballDataContext test scaffold lands.
 /// </summary>
-[Collection("Sequential")]
 public class BaseballEventCompetitionOddsDocumentProcessorTests
     : ProducerTestBase<BaseballEventCompetitionOddsDocumentProcessor<FootballDataContext>>
 {

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionPlayDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionPlayDocumentProcessorTests.cs
@@ -40,7 +40,6 @@ namespace SportsData.Producer.Tests.Unit.Application.Documents.Processors.Provid
 ///   • ApplyUpdateAsync: re-resolves athletes, refreshes rich fields,
 ///     and replaces the participants set wholesale.
 /// </summary>
-[Collection("Sequential")]
 public class BaseballEventCompetitionPlayDocumentProcessorTests
     : ProducerTestBase<BaseballEventCompetitionPlayDocumentProcessor<BaseballDataContext>>
 {

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionSituationDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionSituationDocumentProcessorTests.cs
@@ -24,7 +24,6 @@ using Xunit;
 
 namespace SportsData.Producer.Tests.Unit.Application.Documents.Processors.Providers.Espn.Baseball;
 
-[Collection("Sequential")]
 public class BaseballEventCompetitionSituationDocumentProcessorTests
     : ProducerTestBase<BaseballEventCompetitionSituationDocumentProcessor<BaseballDataContext>>
 {

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionStatusDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Baseball/BaseballEventCompetitionStatusDocumentProcessorTests.cs
@@ -37,7 +37,6 @@ namespace SportsData.Producer.Tests.Unit.Application.Documents.Processors.Provid
 /// <c>BaseballCompetitionStatusFeaturedAthlete</c> are in the model
 /// and the persistence path under test is real, not stubbed.
 /// </summary>
-[Collection("Sequential")]
 public class BaseballEventCompetitionStatusDocumentProcessorTests
     : ProducerTestBase<BaseballEventCompetitionStatusDocumentProcessor<BaseballDataContext>>
 {

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Common/EventCompetitionCompetitorDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Common/EventCompetitionCompetitorDocumentProcessorTests.cs
@@ -19,7 +19,6 @@ using Xunit;
 
 namespace SportsData.Producer.Tests.Unit.Application.Documents.Processors.Providers.Espn.Common
 {
-    [Collection("Sequential")]
     public class EventCompetitionCompetitorDocumentProcessorTests
         : ProducerTestBase<FootballEventCompetitionCompetitorDocumentProcessor<FootballDataContext>>
     {

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Common/EventDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Common/EventDocumentProcessorTests.cs
@@ -32,7 +32,6 @@ namespace SportsData.Producer.Tests.Unit.Application.Documents.Processors.Provid
 /// Tests for FootballEventDocumentProcessor.
 /// Optimized to eliminate AutoFixture overhead.
 /// </summary>
-[Collection("Sequential")]
 public class FootballEventDocumentProcessorTests : ProducerTestBase<FootballDataContext>
 {
     // Deterministic seed timestamp for entity CreatedUtc — never asserted against,

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Common/SeasonTypeLeadersDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Common/SeasonTypeLeadersDocumentProcessorTests.cs
@@ -23,7 +23,6 @@ namespace SportsData.Producer.Tests.Unit.Application.Documents.Processors.Provid
 /// leaders, season-scoped athlete/team refs intact so identity hashing
 /// resolves exactly as it does in production.
 /// </summary>
-[Collection("Sequential")]
 public class SeasonTypeLeadersDocumentProcessorTests
     : ProducerTestBase<SeasonTypeLeadersDocumentProcessor<FootballDataContext>>
 {

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Common/SeasonTypeWeekRankingsDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Common/SeasonTypeWeekRankingsDocumentProcessorTests.cs
@@ -23,7 +23,6 @@ namespace SportsData.Producer.Tests.Unit.Application.Documents.Processors.Provid
     /// Tests for SeasonTypeWeekRankingsDocumentProcessor.
     /// Optimized to eliminate AutoFixture overhead.
     /// </summary>
-    [Collection("Sequential")]
     public class SeasonTypeWeekRankingsDocumentProcessorTests
     : ProducerTestBase<SeasonTypeWeekRankingsDocumentProcessor<FootballDataContext>>
     {

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/AthleteCareerStatisticsDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/AthleteCareerStatisticsDocumentProcessorTests.cs
@@ -19,7 +19,6 @@ using Xunit;
 
 namespace SportsData.Producer.Tests.Unit.Application.Documents.Processors.Providers.Espn.Football;
 
-[Collection("Sequential")]
 public class AthleteCareerStatisticsDocumentProcessorTests :
     ProducerTestBase<AthleteCareerStatisticsDocumentProcessor<FootballDataContext>>
 {

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/AthleteSeasonDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/AthleteSeasonDocumentProcessorTests.cs
@@ -28,7 +28,6 @@ namespace SportsData.Producer.Tests.Unit.Application.Documents.Processors.Provid
 /// Tests for AthleteSeasonDocumentProcessor covering create, update, dependency resolution, and image processing.
 /// Optimized to eliminate AutoFixture overhead.
 /// </summary>
-[Collection("Sequential")]
 public class AthleteSeasonDocumentProcessorTests :
     ProducerTestBase<AthleteSeasonDocumentProcessor<FootballDataContext>>
 {

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/AthleteSeasonStatisticsDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/AthleteSeasonStatisticsDocumentProcessorTests.cs
@@ -24,7 +24,6 @@ namespace SportsData.Producer.Tests.Unit.Application.Documents.Processors.Provid
 /// <summary>
 /// Tests for AthleteSeasonStatisticsDocumentProcessor covering create and replace scenarios.
 /// </summary>
-[Collection("Sequential")]
 public class AthleteSeasonStatisticsDocumentProcessorTests :
     ProducerTestBase<AthleteSeasonStatisticsDocumentProcessor<FootballDataContext>>
 {

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/DraftDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/DraftDocumentProcessorTests.cs
@@ -23,7 +23,6 @@ using Xunit;
 
 namespace SportsData.Producer.Tests.Unit.Application.Documents.Processors.Providers.Espn.Football;
 
-[Collection("Sequential")]
 public class DraftDocumentProcessorTests :
     ProducerTestBase<DraftDocumentProcessor<FootballDataContext>>
 {

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/DraftRoundsDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/DraftRoundsDocumentProcessorTests.cs
@@ -18,7 +18,6 @@ using Xunit;
 
 namespace SportsData.Producer.Tests.Unit.Application.Documents.Processors.Providers.Espn.Football;
 
-[Collection("Sequential")]
 public class DraftRoundsDocumentProcessorTests :
     ProducerTestBase<DraftRoundsDocumentProcessor<FootballDataContext>>
 {

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/EventCompetitionAthleteStatisticsDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/EventCompetitionAthleteStatisticsDocumentProcessorTests.cs
@@ -22,7 +22,6 @@ namespace SportsData.Producer.Tests.Unit.Application.Documents.Processors.Provid
 /// <summary>
 /// Tests for EventCompetitionAthleteStatisticsDocumentProcessor covering create and replace scenarios.
 /// </summary>
-[Collection("Sequential")]
 public class EventCompetitionAthleteStatisticsDocumentProcessorTests
     : ProducerTestBase<EventCompetitionAthleteStatisticsDocumentProcessor<FootballDataContext>>
 {

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/EventCompetitionCompetitorLineScoreDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/EventCompetitionCompetitorLineScoreDocumentProcessorTests.cs
@@ -21,7 +21,6 @@ namespace SportsData.Producer.Tests.Unit.Application.Documents.Processors.Provid
 /// Tests for EventCompetitionCompetitorLineScoreDocumentProcessor.
 /// Optimized to minimize AutoFixture overhead and test execution time.
 /// </summary>
-[Collection("Sequential")]
 public class EventCompetitionCompetitorLineScoreDocumentProcessorTests : ProducerTestBase<FootballDataContext>
 {
     private const string TestUrl = "http://sports.core.api.espn.com/v2/sports/football/leagues/college-football/events/401628334/competitions/401628334/competitors/99/linescores/1/1?lang=en&region=us";

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/EventCompetitionCompetitorScoreDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/EventCompetitionCompetitorScoreDocumentProcessorTests.cs
@@ -21,7 +21,6 @@ namespace SportsData.Producer.Tests.Unit.Application.Documents.Processors.Provid
 /// Tests for EventCompetitionCompetitorScoreDocumentProcessor.
 /// Optimized to eliminate AutoFixture overhead for massive performance gains.
 /// </summary>
-[Collection("Sequential")]
 public class EventCompetitionCompetitorScoreDocumentProcessorTests : ProducerTestBase<FootballDataContext>
 {
     // Fixed seed time: the repo rule bans DateTime.UtcNow, and deterministic

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/EventCompetitionCompetitorStatisticsDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/EventCompetitionCompetitorStatisticsDocumentProcessorTests.cs
@@ -26,7 +26,6 @@ namespace SportsData.Producer.Tests.Unit.Application.Documents.Processors.Provid
     /// Tests for EventCompetitionCompetitorStatisticsDocumentProcessor.
     /// Optimized to eliminate AutoFixture overhead.
     /// </summary>
-    [Collection("Sequential")]
     public class EventCompetitionCompetitorStatisticsDocumentProcessorTests
         : ProducerTestBase<EventCompetitionCompetitorStatisticsDocumentProcessor<TeamSportDataContext>>
     {

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/EventCompetitionDriveDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/EventCompetitionDriveDocumentProcessorTests.cs
@@ -22,7 +22,6 @@ namespace SportsData.Producer.Tests.Unit.Application.Documents.Processors.Provid
 /// Tests for EventCompetitionDriveDocumentProcessor.
 /// Optimized to eliminate AutoFixture overhead for massive performance gains.
 /// </summary>
-[Collection("Sequential")]
 public class EventCompetitionDriveDocumentProcessorTests : ProducerTestBase<FootballDataContext>
 {
     private const string DriveUrl = "http://sports.core.api.espn.com/v2/sports/football/leagues/college-football/events/401628334/competitions/401628334/drives/4016283341?lang=en";

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/EventCompetitionLeadersDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/EventCompetitionLeadersDocumentProcessorTests.cs
@@ -34,7 +34,6 @@ namespace SportsData.Producer.Tests.Unit.Application.Documents.Processors.Provid
 /// Tests for EventCompetitionLeadersDocumentProcessor.
 /// Optimized to eliminate AutoFixture overhead.
 /// </summary>
-[Collection("Sequential")]
 public class EventCompetitionLeadersDocumentProcessorTests : 
     ProducerTestBase<EventCompetitionLeadersDocumentProcessor<TeamSportDataContext>>
 {

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/EventCompetitionOddsDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/EventCompetitionOddsDocumentProcessorTests.cs
@@ -30,7 +30,6 @@ namespace SportsData.Producer.Tests.Unit.Application.Documents.Processors.Provid
     /// Tests for EventCompetitionOddsDocumentProcessor.
     /// Optimized to eliminate AutoFixture overhead.
     /// </summary>
-    [Collection("Sequential")]
     public class EventCompetitionOddsDocumentProcessorTests
         : ProducerTestBase<EventCompetitionOddsDocumentProcessor<FootballDataContext>>
     {

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/EventCompetitionPowerIndexDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/EventCompetitionPowerIndexDocumentProcessorTests.cs
@@ -24,7 +24,6 @@ namespace SportsData.Producer.Tests.Unit.Application.Documents.Processors.Provid
     /// Tests for EventCompetitionPowerIndexDocumentProcessor.
     /// Optimized to eliminate AutoFixture overhead.
     /// </summary>
-    [Collection("Sequential")]
     public class EventCompetitionPowerIndexDocumentProcessorTests :
         ProducerTestBase<EventCompetitionPowerIndexDocumentProcessor<FootballDataContext>>
     {

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/EventCompetitionPredictorDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/EventCompetitionPredictorDocumentProcessorTests.cs
@@ -20,7 +20,6 @@ namespace SportsData.Producer.Tests.Unit.Application.Documents.Processors.Provid
 /// Tests for EventCompetitionPredictionDocumentProcessor.
 /// Optimized to eliminate AutoFixture overhead.
 /// </summary>
-[Collection("Sequential")]
 public class EventCompetitionPredictionDocumentProcessorTests :
     ProducerTestBase<EventCompetitionPredictionDocumentProcessor<FootballDataContext>>
 {

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/EventCompetitionProbabilityDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/EventCompetitionProbabilityDocumentProcessorTests.cs
@@ -20,7 +20,6 @@ namespace SportsData.Producer.Tests.Unit.Application.Documents.Processors.Provid
     /// Tests for EventCompetitionProbabilityDocumentProcessor.
     /// Optimized to eliminate AutoFixture overhead.
     /// </summary>
-    [Collection("Sequential")]
     public class EventCompetitionProbabilityDocumentProcessorTests :
         ProducerTestBase<EventCompetitionProbabilityDocumentProcessor<FootballDataContext>>
     {

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/FootballEventCompetitionDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/FootballEventCompetitionDocumentProcessorTests.cs
@@ -23,7 +23,6 @@ using Xunit;
 
 namespace SportsData.Producer.Tests.Unit.Application.Documents.Processors.Providers.Espn.Football
 {
-    [Collection("Sequential")]
     public class FootballEventCompetitionDocumentProcessorTests :
         ProducerTestBase<FootballEventCompetitionDocumentProcessor<FootballDataContext>>
     {

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/FootballEventCompetitionPlayDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/FootballEventCompetitionPlayDocumentProcessorTests.cs
@@ -30,7 +30,6 @@ namespace SportsData.Producer.Tests.Unit.Application.Documents.Processors.Provid
 /// Tests for FootballEventCompetitionPlayDocumentProcessor.
 /// Optimized to eliminate AutoFixture overhead.
 /// </summary>
-[Collection("Sequential")]
 public class FootballEventCompetitionPlayDocumentProcessorTests : ProducerTestBase<FootballDataContext>
 {
     private const string PlayUrl = "http://sports.core.api.espn.com/v2/sports/football/leagues/college-football/events/401628334/competitions/401628334/plays/401628334123";

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/FootballEventCompetitionStatusDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/FootballEventCompetitionStatusDocumentProcessorTests.cs
@@ -25,7 +25,6 @@ namespace SportsData.Producer.Tests.Unit.Application.Documents.Processors.Provid
     /// Tests for FootballEventCompetitionStatusDocumentProcessor.
     /// Optimized to eliminate AutoFixture overhead.
     /// </summary>
-    [Collection("Sequential")]
     public class FootballEventCompetitionStatusDocumentProcessorTests :
         ProducerTestBase<FootballEventCompetitionStatusDocumentProcessor<FootballDataContext>>
     {

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/SeasonPollDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/Football/SeasonPollDocumentProcessorTests.cs
@@ -17,7 +17,6 @@ using Xunit;
 
 namespace SportsData.Producer.Tests.Unit.Application.Documents.Processors.Providers.Espn.Football;
 
-[Collection("Sequential")]
 public class SeasonPollDocumentProcessorTests : ProducerTestBase<SeasonPollDocumentProcessor<FootballDataContext>>
 {
     [Fact]

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/TeamSports/AthleteSeasonNoteDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/TeamSports/AthleteSeasonNoteDocumentProcessorTests.cs
@@ -19,7 +19,6 @@ using Xunit;
 
 namespace SportsData.Producer.Tests.Unit.Application.Documents.Processors.Providers.Espn.TeamSports;
 
-[Collection("Sequential")]
 public class AthleteSeasonNoteDocumentProcessorTests : ProducerTestBase<AthleteSeasonNoteDocumentProcessor<TeamSportDataContext>>
 {
     [Fact]

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/TeamSports/CoachSeasonDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/TeamSports/CoachSeasonDocumentProcessorTests.cs
@@ -21,7 +21,6 @@ using Xunit;
 
 namespace SportsData.Producer.Tests.Unit.Application.Documents.Processors.Providers.Espn.TeamSports;
 
-[Collection("Sequential")]
 public class CoachSeasonDocumentProcessorTests : ProducerTestBase<CoachSeasonDocumentProcessor<FootballDataContext>>
 {
     private const string TestDataFile = "EspnFootballNcaa/EspnFootballNcaaTeamSeasonCoach.json";

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/TeamSports/TeamSeasonAwardDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/TeamSports/TeamSeasonAwardDocumentProcessorTests.cs
@@ -18,7 +18,6 @@ using Xunit;
 
 namespace SportsData.Producer.Tests.Unit.Application.Documents.Processors.Providers.Espn.TeamSports;
 
-[Collection("Sequential")]
 public class TeamSeasonAwardDocumentProcessorTests : ProducerTestBase<TeamSeasonAwardDocumentProcessor<TeamSportDataContext>>
 {
     [Fact]

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/TeamSports/TeamSeasonInjuriesDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/TeamSports/TeamSeasonInjuriesDocumentProcessorTests.cs
@@ -18,7 +18,6 @@ using Xunit;
 
 namespace SportsData.Producer.Tests.Unit.Application.Documents.Processors.Providers.Espn.TeamSports;
 
-[Collection("Sequential")]
 public class TeamSeasonInjuriesDocumentProcessorTests : ProducerTestBase<TeamSeasonInjuriesDocumentProcessor<TeamSportDataContext>>
 {
     [Fact]

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/TeamSports/TeamSeasonLeadersDocumentProcessorTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Documents/Processors/Providers/Espn/TeamSports/TeamSeasonLeadersDocumentProcessorTests.cs
@@ -31,7 +31,6 @@ using Xunit;
 
 namespace SportsData.Producer.Tests.Unit.Application.Documents.Processors.Providers.Espn.TeamSports;
 
-[Collection("Sequential")]
 public class TeamSeasonLeadersDocumentProcessorTests : ProducerTestBase<TeamSeasonLeadersDocumentProcessor<TeamSportDataContext>>
 {
     private EspnLeadersDto _dto;

--- a/test/unit/SportsData.Producer.Tests.Unit/Application/Franchises/Commands/EnrichFranchiseSeasonHandlerTests.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/Application/Franchises/Commands/EnrichFranchiseSeasonHandlerTests.cs
@@ -21,7 +21,6 @@ namespace SportsData.Producer.Tests.Unit.Application.Franchises.Commands;
 /// <summary>
 /// Unit tests for EnrichFranchiseSeasonHandler to verify win/loss calculations and scoring margins
 /// </summary>
-[Collection("Sequential")]
 public class EnrichFranchiseSeasonHandlerTests :
     ProducerTestBase<EnrichFranchiseSeasonHandler<FootballDataContext>>
 {

--- a/test/unit/SportsData.Producer.Tests.Unit/ProducerTestBase.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/ProducerTestBase.cs
@@ -55,19 +55,8 @@ public abstract class ProducerTestBase<T> : UnitTestBase<T>
         Fixture.Customizations.Add(new ProcessDocumentCommandFlagsOffByDefault());
 
         // Override mapper with Producer-specific mapping profile
-        Mocker.Use(typeof(IMapper), ProducerMapper.Value);
+        Mocker.Use(typeof(IMapper), ProducerTestMappers.Default.Value);
     }
-
-    // AutoMapper configuration compilation is expensive and xunit constructs
-    // the test class PER TEST — building this in the ctor cost every test a
-    // fresh two-profile compile (~658 per run). IMapper is stateless and
-    // thread-safe, so one shared instance serves the whole parallel suite.
-    private static readonly Lazy<IMapper> ProducerMapper = new(() =>
-        new MapperConfiguration(c =>
-        {
-            c.AddProfile(new DynamicMappingProfile());
-            c.AddProfile(new MappingProfile());
-        }).CreateMapper());
 
     private sealed class ProcessDocumentCommandFlagsOffByDefault : ISpecimenBuilder
     {
@@ -104,4 +93,21 @@ public abstract class ProducerTestBase<T> : UnitTestBase<T>
             .UseInMemoryDatabase(dbName)
             .Options;
     }
+}
+
+/// <summary>
+/// Non-generic holder for the Producer test mapper: a static on
+/// ProducerTestBase&lt;T&gt; would be re-created once per closed T (~one per
+/// test class). Here it compiles exactly once per run — the ctor previously
+/// cost every test a fresh two-profile compile (~658 per run). IMapper is
+/// stateless and thread-safe.
+/// </summary>
+internal static class ProducerTestMappers
+{
+    internal static readonly Lazy<IMapper> Default = new(() =>
+        new MapperConfiguration(c =>
+        {
+            c.AddProfile(new DynamicMappingProfile());
+            c.AddProfile(new MappingProfile());
+        }).CreateMapper());
 }

--- a/test/unit/SportsData.Producer.Tests.Unit/ProducerTestBase.cs
+++ b/test/unit/SportsData.Producer.Tests.Unit/ProducerTestBase.cs
@@ -55,14 +55,19 @@ public abstract class ProducerTestBase<T> : UnitTestBase<T>
         Fixture.Customizations.Add(new ProcessDocumentCommandFlagsOffByDefault());
 
         // Override mapper with Producer-specific mapping profile
-        var mapperConfig = new MapperConfiguration(c =>
+        Mocker.Use(typeof(IMapper), ProducerMapper.Value);
+    }
+
+    // AutoMapper configuration compilation is expensive and xunit constructs
+    // the test class PER TEST — building this in the ctor cost every test a
+    // fresh two-profile compile (~658 per run). IMapper is stateless and
+    // thread-safe, so one shared instance serves the whole parallel suite.
+    private static readonly Lazy<IMapper> ProducerMapper = new(() =>
+        new MapperConfiguration(c =>
         {
             c.AddProfile(new DynamicMappingProfile());
             c.AddProfile(new MappingProfile());
-        });
-        var mapper = mapperConfig.CreateMapper();
-        Mocker.Use(typeof(IMapper), mapper);
-    }
+        }).CreateMapper());
 
     private sealed class ProcessDocumentCommandFlagsOffByDefault : ISpecimenBuilder
     {
@@ -88,8 +93,13 @@ public abstract class ProducerTestBase<T> : UnitTestBase<T>
 
     private static DbContextOptions<FootballDataContext> GetFootballDataContextOptions()
     {
-        // https://stackoverflow.com/questions/52810039/moq-and-setting-up-db-context
-        var dbName = Guid.NewGuid().ToString()[..5];
+        // Full Guid, NOT a truncated one: InMemory databases with the same
+        // name SHARE a store, and 5 hex chars across ~650 tests gave ~20%
+        // odds per run of two tests silently sharing (and polluting) a DB —
+        // the "DB contention" the Dec-2025 sequential collection was added
+        // to paper over. Full-Guid names make every test's store truly
+        // isolated, which is what lets the suite run parallel.
+        var dbName = Guid.NewGuid().ToString();
         return new DbContextOptionsBuilder<FootballDataContext>()
             .UseInMemoryDatabase(dbName)
             .Options;

--- a/test/unit/SportsData.Provider.Tests.Unit/ProviderTestBase.cs
+++ b/test/unit/SportsData.Provider.Tests.Unit/ProviderTestBase.cs
@@ -67,7 +67,7 @@ namespace SportsData.Provider.Tests.Unit
 
         private static DbContextOptions<AppDataContext> GetAppDataContextOptions()
         {
-            var dbName = Guid.NewGuid().ToString()[..5];
+            var dbName = Guid.NewGuid().ToString(); // full Guid: truncated names collide and InMemory shares same-named stores
             return new DbContextOptionsBuilder<AppDataContext>()
                 .UseInMemoryDatabase(dbName)
                 .Options;


### PR DESCRIPTION
## What this fixes

Profiled the Producer unit suite (trx, 676 tests, 381s aggregate) before touching anything. Three related test-infrastructure issues:

### 1. InMemory DB isolation was broken (correctness fix, all four service test bases)

Every test base named its InMemory database `Guid.NewGuid().ToString()[..5]` — **5 hex chars**. Same-named InMemory databases *share a store*, and at ~650 Producer tests per run that's ~20% odds (birthday math) of two tests silently sharing and polluting a database. This was the real "DB contention" behind the Dec-2025 `[Collection("Sequential")]` additions — which never fixed the sharing (a colliding name reuses leftover data regardless of scheduling), only serialized the suite. Full-Guid names make every test's store truly isolated. Fixed in Api, Notification, Producer, and Provider bases.

### 2. Sequential collections removed (42 Producer classes)

With isolation real, the serialization is unnecessary — xunit collection parallelism is restored.

### 3. Cached mappers (UnitTestBase + ProducerTestBase)

xunit constructs the test class per test, and both ctors built fresh `MapperConfiguration`s — two AutoMapper config compilations per Producer test, ~1,300 throwaway compiles per run. Now a static `Lazy<IMapper>` in each base; `IMapper` is stateless and thread-safe.

## Measured results

- Producer wall: 5m29s baseline → 5m12s / 5m15s / 4m59s across three consecutive green parallel runs (658 passed each — stability evidence for the Sequential removal)
- All suites green: Producer 658, Api 818, Core 265, Notification 150, Provider 109 (Contest/Franchise/Player/Season/Venue contain no tests)

## Why the gain is modest, and where the real leverage is (follow-up)

The trx profile shows three test families own ~224s of the 381s aggregate, and time inside a class is serial in xunit:

| Class | Time | Tests |
|---|---|---|
| CalculateCompetitionMetricsCommandHandlerTests | 137.5s | 22 (re-seeds full real-game play data per test) |
| RefreshCompetitionMetricsCommandHandlerTests | 46.9s | 5 (one test = 26s) |
| RefreshAllCompetitionMediaCommandHandlerTests | 39.3s | 2 (22s for a two-competition unit test — worth its own investigation) |

Class-fixture sharing (seed once per class) for the metrics families is the follow-up with real leverage (~2 minutes of aggregate). This PR ships the correctness fix and the structural enablers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XPkLHDqNKDA4krjqknFmSq

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved test isolation with unique in-memory database names, reducing cross-test collisions.
  - Reused shared mapper setup across tests for more consistent execution.
  - Removed sequential test grouping from numerous test suites, enabling greater parallelism while preserving existing coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->