### PR TITLE
feat(api): per-member submitted-pick counts on league week overview

### DIFF
--- a/src/SportsData.Api/Application/UI/Leagues/Dtos/LeagueWeekOverviewDto.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Dtos/LeagueWeekOverviewDto.cs
@@ -26,6 +26,15 @@ namespace SportsData.Api.Application.UI.Leagues.Dtos
         public string DisplayName { get; set; } = string.Empty;
 
         public bool IsSynthetic { get; set; }
+
+        /// <summary>
+        /// How many of the week's games this member has submitted a pick for
+        /// — locked or not. A COUNT is deliberately the only thing revealed
+        /// about un-locked picks (reveal enforcement withholds the picks
+        /// themselves): it powers the pre-lock "Who's Ready" readiness list
+        /// without leaking what anyone picked.
+        /// </summary>
+        public int SubmittedPickCount { get; set; }
     }
 
     public class LeagueWeekMatchupResultDto : ContestResultDto

--- a/src/SportsData.Api/Application/UI/Leagues/Queries/GetLeagueWeekOverview/GetLeagueWeekOverviewQueryHandler.cs
+++ b/src/SportsData.Api/Application/UI/Leagues/Queries/GetLeagueWeekOverview/GetLeagueWeekOverviewQueryHandler.cs
@@ -141,6 +141,25 @@ public class GetLeagueWeekOverviewQueryHandler : IGetLeagueWeekOverviewQueryHand
                 LeagueWinnerFranchiseSeasonId = x.SpreadWinnerFranchiseSeasonId ?? x.WinnerFranchiseSeasonId
             }).ToList();
 
+        var memberIds = league.Members.Select(m => m.UserId).ToList();
+
+        // Readiness counts: how many of the week's games each member has
+        // picked, INCLUDING picks on un-locked contests — a count is safe
+        // metadata (it says nothing about what was picked) and is the only
+        // pre-lock signal the "Who's Ready" list needs. Scoped to the
+        // canonical contest list so stale picks can't inflate an X/Y readout
+        // past Y.
+        var submittedCounts = await _dbContext.UserPicks
+            .AsNoTracking()
+            .Where(p =>
+                p.PickemGroupId == query.LeagueId &&
+                p.Week == query.Week &&
+                memberIds.Contains(p.UserId) &&
+                canonicalContestIds.Contains(p.ContestId))
+            .GroupBy(p => p.UserId)
+            .Select(g => new { UserId = g.Key, Count = g.Count() })
+            .ToDictionaryAsync(x => x.UserId, x => x.Count, cancellationToken);
+
         // The member roster rides on the DTO so renderers can derive matrix
         // columns from it — a picks-derived column set would drop members
         // whose picks are all withheld (un-locked) mid-week.
@@ -150,7 +169,8 @@ public class GetLeagueWeekOverviewQueryHandler : IGetLeagueWeekOverviewQueryHand
             {
                 UserId = m.UserId,
                 DisplayName = m.User.DisplayName,
-                IsSynthetic = m.User.IsSynthetic
+                IsSynthetic = m.User.IsSynthetic,
+                SubmittedPickCount = submittedCounts.GetValueOrDefault(m.UserId)
             })
             .ToList();
 
@@ -167,8 +187,6 @@ public class GetLeagueWeekOverviewQueryHandler : IGetLeagueWeekOverviewQueryHand
         // One set-based query for the whole league also replaces the
         // previous per-member handler loop (3 queries per member — the N+1
         // called out in docs/audit/launch-readiness-2026-07.md).
-        var memberIds = league.Members.Select(m => m.UserId).ToList();
-
         result.UserPicks = await _dbContext.UserPicks
             .AsNoTracking()
             .Where(p =>

--- a/test/unit/SportsData.Api.Tests.Unit/Application/UI/Leagues/Queries/GetLeagueWeekOverview/GetLeagueWeekOverviewQueryHandlerTests.cs
+++ b/test/unit/SportsData.Api.Tests.Unit/Application/UI/Leagues/Queries/GetLeagueWeekOverview/GetLeagueWeekOverviewQueryHandlerTests.cs
@@ -269,6 +269,8 @@ public class GetLeagueWeekOverviewQueryHandlerTests : ApiTestBase<GetLeagueWeekO
         // caller who has no picks this week.
         result.Value.Members.Select(m => m.DisplayName).Should()
             .ContainInOrder("Alpha User", "Beta User", "Caller User");
+        result.Value.Members.Single(m => m.UserId == user1.Id).SubmittedPickCount.Should().Be(1);
+        result.Value.Members.Single(m => m.UserId == caller.Id).SubmittedPickCount.Should().Be(0);
     }
 
     [Fact]
@@ -340,6 +342,14 @@ public class GetLeagueWeekOverviewQueryHandlerTests : ApiTestBase<GetLeagueWeekO
         result.Value.UserPicks.Should()
             .NotContain(p => p.ContestId == staleContestId,
                 "a pick outside the week's canonical contest list is withheld even for the caller");
+
+        // Readiness counts are safe metadata: the rival's count includes the
+        // un-locked pick whose CONTENT is withheld above, and the caller's
+        // stale pick doesn't inflate their count past the week's slate.
+        result.Value.Members.Single(m => m.UserId == rival.Id)
+            .SubmittedPickCount.Should().Be(2, "counts include picks on un-locked contests");
+        result.Value.Members.Single(m => m.UserId == caller.Id)
+            .SubmittedPickCount.Should().Be(2, "stale picks are excluded from the count");
     }
 
     [Fact]


### PR DESCRIPTION
## What

Adds `SubmittedPickCount` to `LeagueWeekMemberDto` on `GET /ui/leagues/{id}/overview/{week}` — how many of the week's games each member has submitted a pick for, **including picks on un-locked contests**.

## Why

PR 1 of the mobile By Week build-out (design handoff option A3, "pre-lock readiness"): before any game locks, the pane shows a "Who's Ready" list — per-member counts only, never the team, never the points. Since #736's reveal enforcement deliberately withholds un-locked picks from the payload, the client can no longer derive these counts itself; a count is safe metadata that reveals nothing about *what* was picked.

## How

- Single grouped aggregate query for the whole league (no per-member round-trips)
- Scoped to the week's canonical contest list so stale picks can't inflate an X/Y readout past the slate size
- Additive DTO change — web untouched, mobile consumes it in the upcoming By Week PR

## Testing

820 passed, 0 failed (full Api suite). New assertions: the count includes a pick whose content is simultaneously withheld as un-locked (the A3 contract in one test); stale picks excluded; zero for members without picks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XPkLHDqNKDA4krjqknFmSq

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * League week overviews now show how many picks each member has submitted.
  * Members’ own picks remain visible, while other members’ picks appear after contests lock.

* **Bug Fixes**
  * Submission totals now exclude picks from contests outside the requested week’s official contest slate.
  * Members with no submitted picks correctly display a count of zero.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->