### PR TITLE
feat(mobile): By Week pane - consensus rail, pre-lock readiness, shared league selection

### DIFF
--- a/src/UI/sd-mobile/__tests__/hooks/useSeasonLeagueSelection.test.ts
+++ b/src/UI/sd-mobile/__tests__/hooks/useSeasonLeagueSelection.test.ts
@@ -93,4 +93,44 @@ describe('useSeasonLeagueSelection', () => {
     expect(result.current.seasonLeagues.map((l) => l.id)).toEqual(['past']);
     expect(result.current.selectedLeagueId).toBe('past');
   });
+
+  describe('preferredLeagueId adoption (app-wide league store)', () => {
+    const leagues = [
+      league({ id: 'a-2026', seasonYear: 2026 }),
+      league({ id: 'b-2026', seasonYear: 2026 }),
+      league({ id: 'old-2025', seasonYear: 2025 }),
+      league({ id: 'ended-2026', seasonYear: 2026, deactivatedUtc: '2026-01-01T00:00:00Z' }),
+    ];
+
+    it('adopts the preferred league and flips the season along', () => {
+      const { result } = renderHook(() => useSeasonLeagueSelection(leagues, 'old-2025'));
+
+      expect(result.current.selectedLeagueId).toBe('old-2025');
+      expect(result.current.selectedSeason).toBe(2025);
+    });
+
+    it('adopts an ended current-season league by revealing ended leagues', () => {
+      const { result } = renderHook(() => useSeasonLeagueSelection(leagues, 'ended-2026'));
+
+      expect(result.current.selectedLeagueId).toBe('ended-2026');
+      expect(result.current.showEnded).toBe(true);
+    });
+
+    it('adopts each preferred value at most once — local browsing is never yanked back', () => {
+      const { result } = renderHook(() => useSeasonLeagueSelection(leagues, 'old-2025'));
+      expect(result.current.selectedLeagueId).toBe('old-2025');
+
+      // The user browses back to 2026; reconciliation snaps to the first
+      // visible league. The still-set preferred id must NOT re-adopt.
+      act(() => result.current.setSelectedSeason(2026));
+      expect(result.current.selectedSeason).toBe(2026);
+      expect(result.current.selectedLeagueId).not.toBe('old-2025');
+    });
+
+    it('ignores a preferred id that is not one of the user leagues', () => {
+      const { result } = renderHook(() => useSeasonLeagueSelection(leagues, 'foreign'));
+
+      expect(result.current.selectedLeagueId).toBe('a-2026');
+    });
+  });
 });

--- a/src/UI/sd-mobile/__tests__/hooks/useSeasonLeagueSelection.test.ts
+++ b/src/UI/sd-mobile/__tests__/hooks/useSeasonLeagueSelection.test.ts
@@ -103,21 +103,21 @@ describe('useSeasonLeagueSelection', () => {
     ];
 
     it('adopts the preferred league and flips the season along', () => {
-      const { result } = renderHook(() => useSeasonLeagueSelection(leagues, 'old-2025'));
+      const { result } = renderHook(() => useSeasonLeagueSelection(leagues, 'old-2025', 1));
 
       expect(result.current.selectedLeagueId).toBe('old-2025');
       expect(result.current.selectedSeason).toBe(2025);
     });
 
     it('adopts an ended current-season league by revealing ended leagues', () => {
-      const { result } = renderHook(() => useSeasonLeagueSelection(leagues, 'ended-2026'));
+      const { result } = renderHook(() => useSeasonLeagueSelection(leagues, 'ended-2026', 1));
 
       expect(result.current.selectedLeagueId).toBe('ended-2026');
       expect(result.current.showEnded).toBe(true);
     });
 
-    it('adopts each preferred value at most once — local browsing is never yanked back', () => {
-      const { result } = renderHook(() => useSeasonLeagueSelection(leagues, 'old-2025'));
+    it('consumes each nonce once — local browsing is never yanked back', () => {
+      const { result } = renderHook(() => useSeasonLeagueSelection(leagues, 'old-2025', 1));
       expect(result.current.selectedLeagueId).toBe('old-2025');
 
       // The user browses back to 2026; reconciliation snaps to the first
@@ -127,8 +127,44 @@ describe('useSeasonLeagueSelection', () => {
       expect(result.current.selectedLeagueId).not.toBe('old-2025');
     });
 
+    it('a preference equal to the current selection still consumes its nonce', () => {
+      // CR-738: pref arrives naming the league we already defaulted to; if
+      // the nonce is not recorded on that path, a later season browse makes
+      // pref differ from the selection and the STALE choice re-adopts.
+      const { result, rerender } = renderHook(
+        ({ pref, nonce }: { pref: string | null; nonce: number }) =>
+          useSeasonLeagueSelection(leagues, pref, nonce),
+        { initialProps: { pref: null as string | null, nonce: 0 } },
+      );
+      expect(result.current.selectedLeagueId).toBe('a-2026'); // default
+
+      rerender({ pref: 'a-2026', nonce: 1 }); // matches current selection
+
+      act(() => result.current.setSelectedSeason(2025));
+      expect(result.current.selectedLeagueId).toBe('old-2025'); // snap
+      // The consumed nonce must not drag the selection back to a-2026.
+      expect(result.current.selectedSeason).toBe(2025);
+    });
+
+    it('re-choosing the SAME league elsewhere (new nonce) converges again', () => {
+      // Vortex-738: after local browsing diverges, a fresh explicit tap of
+      // the same league on another surface must still propagate.
+      const { result, rerender } = renderHook(
+        ({ nonce }: { nonce: number }) => useSeasonLeagueSelection(leagues, 'old-2025', nonce),
+        { initialProps: { nonce: 1 } },
+      );
+      expect(result.current.selectedLeagueId).toBe('old-2025');
+
+      act(() => result.current.setSelectedSeason(2026)); // browse away, snap
+      expect(result.current.selectedLeagueId).not.toBe('old-2025');
+
+      rerender({ nonce: 2 }); // same league, fresh explicit choice
+      expect(result.current.selectedLeagueId).toBe('old-2025');
+      expect(result.current.selectedSeason).toBe(2025);
+    });
+
     it('ignores a preferred id that is not one of the user leagues', () => {
-      const { result } = renderHook(() => useSeasonLeagueSelection(leagues, 'foreign'));
+      const { result } = renderHook(() => useSeasonLeagueSelection(leagues, 'foreign', 1));
 
       expect(result.current.selectedLeagueId).toBe('a-2026');
     });

--- a/src/UI/sd-mobile/__tests__/lib/weekOverview.test.ts
+++ b/src/UI/sd-mobile/__tests__/lib/weekOverview.test.ts
@@ -1,0 +1,167 @@
+import {
+  contestPhase,
+  indexPicks,
+  memberRowsForContest,
+  readinessRows,
+  sideSplit,
+  summarizeWeek,
+} from '@/src/lib/weekOverview';
+import type {
+  LeagueWeekContest,
+  LeagueWeekMember,
+  LeagueWeekOverview,
+  UserPick,
+} from '@/src/types/models';
+
+const NOW = Date.parse('2026-09-07T18:00:00Z');
+
+function contest(overrides: Partial<LeagueWeekContest> = {}): LeagueWeekContest {
+  return {
+    startDateUtc: '2026-09-07T17:00:00Z',
+    contestId: 'c1',
+    isLocked: true,
+    awayShort: 'SJSU',
+    awayFranchiseSeasonId: 'fs-away',
+    awaySlug: 'sjsu',
+    homeShort: 'USC',
+    homeFranchiseSeasonId: 'fs-home',
+    homeSlug: 'usc',
+    ...overrides,
+  };
+}
+
+function member(userId: string, displayName: string, submitted = 0): LeagueWeekMember {
+  return { userId, displayName, isSynthetic: false, submittedPickCount: submitted };
+}
+
+function pick(userId: string, contestId: string, overrides: Partial<UserPick> = {}): UserPick {
+  return {
+    id: `${userId}-${contestId}`,
+    userId,
+    contestId,
+    franchiseSeasonId: 'fs-home',
+    pickType: 'StraightUp',
+    ...overrides,
+  };
+}
+
+describe('contestPhase', () => {
+  it('unlocked when the server says so, regardless of clock', () => {
+    expect(contestPhase(contest({ isLocked: false }), NOW)).toBe('unlocked');
+  });
+
+  it('locked before kickoff, live after, final once completed', () => {
+    const preKick = contest({ startDateUtc: '2026-09-07T18:03:00Z' });
+    expect(contestPhase(preKick, NOW)).toBe('locked');
+
+    const kicked = contest({ startDateUtc: '2026-09-07T17:00:00Z' });
+    expect(contestPhase(kicked, NOW)).toBe('live');
+
+    const done = contest({ completedUtc: '2026-09-07T17:50:00Z' });
+    expect(contestPhase(done, NOW)).toBe('final');
+  });
+
+  it('finalizedUtc alone is final too', () => {
+    expect(contestPhase(contest({ finalizedUtc: '2026-09-07T17:59:00Z' }), NOW)).toBe('final');
+  });
+});
+
+describe('sideSplit', () => {
+  it('counts revealed picks per side; foreign franchise ids count nowhere', () => {
+    const c = contest();
+    const split = sideSplit(c, [
+      pick('u1', 'c1', { franchiseSeasonId: 'fs-home' }),
+      pick('u2', 'c1', { franchiseSeasonId: 'fs-home' }),
+      pick('u3', 'c1', { franchiseSeasonId: 'fs-away' }),
+      pick('u4', 'c1', { franchiseSeasonId: 'fs-elsewhere' }),
+    ]);
+    expect(split.homeCount).toBe(2);
+    expect(split.awayCount).toBe(1);
+    expect(split.awayShare).toBeCloseTo(1 / 3);
+  });
+
+  it('splits 50/50 with nothing revealed', () => {
+    expect(sideSplit(contest(), []).awayShare).toBe(0.5);
+  });
+});
+
+describe('memberRowsForContest', () => {
+  it('sorts revealed picks by confidence desc, no-pick rows trail alphabetically', () => {
+    const members = [
+      member('u-low', 'Zed'),
+      member('u-high', 'Aesop'),
+      member('u-none-b', 'Beta'),
+      member('u-none-a', 'Alpha'),
+    ];
+    const picks = indexPicks([
+      pick('u-low', 'c1', { confidencePoints: 3 }),
+      pick('u-high', 'c1', { confidencePoints: 30 }),
+    ]);
+    const rows = memberRowsForContest(contest(), members, picks);
+    expect(rows.map((r) => r.member.userId)).toEqual(['u-high', 'u-low', 'u-none-a', 'u-none-b']);
+  });
+
+  it('derives the picked team via franchiseSeasonId match', () => {
+    const rows = memberRowsForContest(
+      contest(),
+      [member('u1', 'A'), member('u2', 'B')],
+      indexPicks([
+        pick('u1', 'c1', { franchiseSeasonId: 'fs-home' }),
+        pick('u2', 'c1', { franchiseSeasonId: 'fs-away' }),
+      ]),
+    );
+    expect(rows.find((r) => r.member.userId === 'u1')?.teamShort).toBe('USC');
+    expect(rows.find((r) => r.member.userId === 'u2')?.teamShort).toBe('SJSU');
+  });
+});
+
+describe('summarizeWeek', () => {
+  const overview = (contests: LeagueWeekContest[]): LeagueWeekOverview => ({
+    contests,
+    userPicks: [],
+    members: [],
+  });
+
+  it('pre-lock when every game is unlocked, with the earliest lock instant', () => {
+    const s = summarizeWeek(
+      overview([
+        contest({ contestId: 'c1', isLocked: false, startDateUtc: '2026-09-12T16:00:00Z' }),
+        contest({ contestId: 'c2', isLocked: false, startDateUtc: '2026-09-12T20:00:00Z' }),
+      ]),
+      NOW,
+    );
+    expect(s.preLock).toBe(true);
+    expect(s.revealed).toHaveLength(0);
+    expect(s.unlockedCount).toBe(2);
+    // kickoff − 5 min of the EARLIEST game
+    expect(s.firstLockMs).toBe(Date.parse('2026-09-12T15:55:00Z'));
+  });
+
+  it('mid-week: revealed strips plus a count of still-hidden games', () => {
+    const s = summarizeWeek(
+      overview([
+        contest({ contestId: 'c1' }),
+        contest({ contestId: 'c2', isLocked: false, startDateUtc: '2026-09-12T16:00:00Z' }),
+      ]),
+      NOW,
+    );
+    expect(s.preLock).toBe(false);
+    expect(s.revealed.map((c) => c.contestId)).toEqual(['c1']);
+    expect(s.unlockedCount).toBe(1);
+  });
+
+  it('an empty week is not pre-lock (renders empty, not the reveal card)', () => {
+    expect(summarizeWeek(overview([]), NOW).preLock).toBe(false);
+  });
+});
+
+describe('readinessRows', () => {
+  it('sorts most-ready first, ties alphabetical, counts capped at the slate', () => {
+    const rows = readinessRows(
+      [member('u1', 'Zed', 12), member('u2', 'Aesop', 12), member('u3', 'Ranman', 8), member('u4', 'New', 99)],
+      12,
+    );
+    expect(rows.map((r) => r.member.displayName)).toEqual(['Aesop', 'New', 'Zed', 'Ranman']);
+    expect(rows[1].submitted).toBe(12); // capped
+  });
+});

--- a/src/UI/sd-mobile/app/(tabs)/picks.tsx
+++ b/src/UI/sd-mobile/app/(tabs)/picks.tsx
@@ -26,6 +26,7 @@ import { ImportPicksModal } from '@/src/components/features/picks/ImportPicksMod
 import { ConfidencePickerModal } from '@/src/components/features/picks/ConfidencePickerModal';
 import { getLeagues } from '@/src/lib/leagues';
 import { resolveSportLeague } from '@/src/utils/sportLinks';
+import { useLeagueSelectionStore } from '@/src/stores/leagueSelectionStore';
 import { useQuery } from '@tanstack/react-query';
 import { leaguesApi, leaguesKeys } from '@/src/services/api/leaguesApi';
 import type { League, UserPick } from '@/src/types/models';
@@ -119,19 +120,28 @@ export default function PicksScreen() {
   const [importOpen, setImportOpen] = useState(false);
 
 
+  // App-wide current league (leagueSelectionStore): a deep-link or explicit
+  // tap here writes it; a choice made on another surface (Standings, Home) is
+  // adopted below.
+  const storeLeagueId = useLeagueSelectionStore((s) => s.selectedLeagueId);
+  const setStoreLeague = useLeagueSelectionStore((s) => s.setSelectedLeague);
+
   // eslint-disable-next-line react-hooks/exhaustive-deps — intentionally excluding leagueId to only initialize/target, not rerun on user selection
   useEffect(() => {
     // Deep-link param wins: an active league, or the on-demand past league.
+    // A deep link is explicit intent, so it writes the app-wide selection too.
     if (leagueIdParam) {
       const active = leagues.find((l) => l.id === leagueIdParam);
       if (active) {
         setLeagueId(active.id);
         setSelectedWeek(defaultWeek(active));
+        setStoreLeague(active.id);
         return;
       }
       if (pastLeagueAsLeague && pastLeagueAsLeague.id === leagueIdParam) {
         setLeagueId(pastLeagueAsLeague.id);
         setSelectedWeek(defaultWeek(pastLeagueAsLeague));
+        setStoreLeague(pastLeagueAsLeague.id);
         return;
       }
       // Param is a past league still being fetched → wait rather than default to
@@ -140,12 +150,27 @@ export default function PicksScreen() {
       // Otherwise it's not one of the user's leagues → fall through to default.
     }
 
-    // Initialize once to the first active league.
+    // Initialize once: the app-wide selection when it's one of ours, else the
+    // first active league. Fallbacks do NOT write the store (see its contract).
     if (!leagueId && leagues.length > 0) {
-      setLeagueId(leagues[0].id);
-      setSelectedWeek(defaultWeek(leagues[0]));
+      const preferred = storeLeagueId ? leagues.find((l) => l.id === storeLeagueId) : undefined;
+      const initial = preferred ?? leagues[0];
+      setLeagueId(initial.id);
+      setSelectedWeek(defaultWeek(initial));
     }
   }, [leagues, leagueIdParam, pastLeagueAsLeague, candidatePastId, allLeaguesFetched]);
+
+  // Adopt a league chosen on ANOTHER surface while this tab stays mounted
+  // (tab navigators keep screens alive). Our own picks write the store first,
+  // so store === local means nothing to do; validation against
+  // selectableLeagues keeps a foreign id from clearing the screen.
+  useEffect(() => {
+    if (!storeLeagueId || storeLeagueId === leagueId) return;
+    const target = selectableLeagues.find((l) => l.id === storeLeagueId);
+    if (!target) return;
+    setLeagueId(target.id);
+    setSelectedWeek(defaultWeek(target));
+  }, [storeLeagueId, selectableLeagues, leagueId]);
 
   const selectedLeague = selectableLeagues.find((l) => l.id === leagueId) ?? null;
   const seasonWeeks = selectedLeague?.seasonWeeks ?? [];
@@ -186,8 +211,10 @@ export default function PicksScreen() {
       // league resolves its weeks instead of transiently clearing selectedWeek.
       const league = selectableLeagues.find((l) => l.id === id);
       setSelectedWeek(defaultWeek(league));
+      // Explicit tap → app-wide selection (leagueSelectionStore contract).
+      setStoreLeague(id);
     },
-    [selectableLeagues],
+    [selectableLeagues, setStoreLeague],
   );
 
   const {

--- a/src/UI/sd-mobile/app/(tabs)/picks.tsx
+++ b/src/UI/sd-mobile/app/(tabs)/picks.tsx
@@ -73,17 +73,24 @@ export default function PicksScreen() {
   // /(tabs)/picks?leagueId=<id> so the screen opens on that league directly.
   const { leagueId: leagueIdParam } = useLocalSearchParams<{ leagueId?: string }>();
 
-  // Viewing a PAST (deactivated) league: /user/me is active-only, so a deep-link
-  // param that isn't in the active set is fetched on demand (getUserLeagues
-  // includes deactivated) and rendered read-only. Reuses the My Leagues query
-  // key so arriving from that screen costs no extra request.
-  const candidatePastId = useMemo(
-    () =>
-      leagueIdParam && !leagues.some((l) => l.id === leagueIdParam)
-        ? leagueIdParam
-        : null,
-    [leagueIdParam, leagues],
-  );
+  // App-wide current league (leagueSelectionStore): a deep-link or explicit
+  // tap here writes it; a choice made on another surface (Standings, Home) is
+  // adopted below. The nonce subscription matters: re-choosing the SAME
+  // league elsewhere bumps only the nonce.
+  const storeLeagueId = useLeagueSelectionStore((s) => s.selectedLeagueId);
+  const storeNonce = useLeagueSelectionStore((s) => s.selectionNonce);
+  const setStoreLeague = useLeagueSelectionStore((s) => s.setSelectedLeague);
+
+  // Viewing a PAST (deactivated) league: /user/me is active-only, so a
+  // deep-link param — or an app-wide selection made on Standings, whose list
+  // includes past seasons — that isn't in the active set is fetched on demand
+  // (getUserLeagues includes deactivated) and rendered read-only. Reuses the
+  // My Leagues query key so arriving from that screen costs no extra request.
+  const candidatePastId = useMemo(() => {
+    if (leagueIdParam && !leagues.some((l) => l.id === leagueIdParam)) return leagueIdParam;
+    if (storeLeagueId && !leagues.some((l) => l.id === storeLeagueId)) return storeLeagueId;
+    return null;
+  }, [leagueIdParam, storeLeagueId, leagues]);
   const { data: allLeagues, isFetched: allLeaguesFetched } = useQuery({
     queryKey: leaguesKeys.mine,
     queryFn: () =>
@@ -120,32 +127,34 @@ export default function PicksScreen() {
   const [importOpen, setImportOpen] = useState(false);
 
 
-  // App-wide current league (leagueSelectionStore): a deep-link or explicit
-  // tap here writes it; a choice made on another surface (Standings, Home) is
-  // adopted below.
-  const storeLeagueId = useLeagueSelectionStore((s) => s.selectedLeagueId);
-  const setStoreLeague = useLeagueSelectionStore((s) => s.setSelectedLeague);
+  // A deep-link selection is applied ONCE per param value: the param sticks
+  // in the route, and re-applying it whenever leagues refetch would overwrite
+  // a newer choice made on another surface with the stale param.
+  const appliedParamRef = useRef<string | null>(null);
 
   // eslint-disable-next-line react-hooks/exhaustive-deps — intentionally excluding leagueId to only initialize/target, not rerun on user selection
   useEffect(() => {
     // Deep-link param wins: an active league, or the on-demand past league.
     // A deep link is explicit intent, so it writes the app-wide selection too.
-    if (leagueIdParam) {
+    if (leagueIdParam && appliedParamRef.current !== leagueIdParam) {
       const active = leagues.find((l) => l.id === leagueIdParam);
       if (active) {
+        appliedParamRef.current = leagueIdParam;
         setLeagueId(active.id);
         setSelectedWeek(defaultWeek(active));
         setStoreLeague(active.id);
         return;
       }
       if (pastLeagueAsLeague && pastLeagueAsLeague.id === leagueIdParam) {
+        appliedParamRef.current = leagueIdParam;
         setLeagueId(pastLeagueAsLeague.id);
         setSelectedWeek(defaultWeek(pastLeagueAsLeague));
         setStoreLeague(pastLeagueAsLeague.id);
         return;
       }
       // Param is a past league still being fetched → wait rather than default to
-      // the first active league (that was the bug).
+      // the first active league (that was the bug). NOT marked applied, so it
+      // stays retryable until the fetch lands.
       if (candidatePastId === leagueIdParam && !allLeaguesFetched) return;
       // Otherwise it's not one of the user's leagues → fall through to default.
     }
@@ -161,16 +170,21 @@ export default function PicksScreen() {
   }, [leagues, leagueIdParam, pastLeagueAsLeague, candidatePastId, allLeaguesFetched]);
 
   // Adopt a league chosen on ANOTHER surface while this tab stays mounted
-  // (tab navigators keep screens alive). Our own picks write the store first,
-  // so store === local means nothing to do; validation against
-  // selectableLeagues keeps a foreign id from clearing the screen.
+  // (tab navigators keep screens alive). Keyed on the selection NONCE and
+  // consumed once, so our own writes (which bump it) no-op via the same-id
+  // guard without resetting the week, and a stale store value can't re-fire;
+  // validation against selectableLeagues keeps a foreign id from clearing
+  // the screen (past leagues become selectable via candidatePastId above).
+  const adoptedNonceRef = useRef<number | null>(null);
   useEffect(() => {
-    if (!storeLeagueId || storeLeagueId === leagueId) return;
+    if (!storeLeagueId || adoptedNonceRef.current === storeNonce) return;
     const target = selectableLeagues.find((l) => l.id === storeLeagueId);
     if (!target) return;
+    adoptedNonceRef.current = storeNonce;
+    if (target.id === leagueId) return; // consumed; already here — keep the week
     setLeagueId(target.id);
     setSelectedWeek(defaultWeek(target));
-  }, [storeLeagueId, selectableLeagues, leagueId]);
+  }, [storeLeagueId, storeNonce, selectableLeagues, leagueId]);
 
   const selectedLeague = selectableLeagues.find((l) => l.id === leagueId) ?? null;
   const seasonWeeks = selectedLeague?.seasonWeeks ?? [];

--- a/src/UI/sd-mobile/app/(tabs)/picks.tsx
+++ b/src/UI/sd-mobile/app/(tabs)/picks.tsx
@@ -167,7 +167,15 @@ export default function PicksScreen() {
       // the first active league (that was the bug). NOT marked applied, so it
       // stays retryable until the fetch lands.
       if (candidatePastId === leagueIdParam && !allLeaguesFetched) return;
-      // Otherwise it's not one of the user's leagues → fall through to default.
+      // The fetch settled and the param matched nothing the user belongs to
+      // (a left/deleted league, a stale notification link). CONSUME it —
+      // an unresolvable param left unapplied would pin candidatePastId for
+      // the whole session and starve the store branch, so a newer
+      // deactivated selection from Standings could never materialize here.
+      // (If the fetch errored on a genuinely valid param, the store branch
+      // recovers it: Home/deep-link sources write the store too.)
+      setAppliedParam(leagueIdParam);
+      // Fall through to default.
     }
 
     // Initialize once: the app-wide selection when it's one of ours, else the

--- a/src/UI/sd-mobile/app/(tabs)/picks.tsx
+++ b/src/UI/sd-mobile/app/(tabs)/picks.tsx
@@ -81,16 +81,32 @@ export default function PicksScreen() {
   const storeNonce = useLeagueSelectionStore((s) => s.selectionNonce);
   const setStoreLeague = useLeagueSelectionStore((s) => s.setSelectedLeague);
 
+  // A deep-link selection is applied ONCE per param value: the param sticks
+  // in the route, and re-applying it whenever leagues refetch would overwrite
+  // a newer choice made on another surface with the stale param. State (not a
+  // ref) because candidatePastId's memo must recompute when it flips.
+  const [appliedParam, setAppliedParam] = useState<string | null>(null);
+
   // Viewing a PAST (deactivated) league: /user/me is active-only, so a
   // deep-link param — or an app-wide selection made on Standings, whose list
   // includes past seasons — that isn't in the active set is fetched on demand
   // (getUserLeagues includes deactivated) and rendered read-only. Reuses the
   // My Leagues query key so arriving from that screen costs no extra request.
+  // The route param claims the candidate slot only while UNRESOLVED: it
+  // sticks in the route after being applied, and letting it keep outranking
+  // the store would pin the on-demand fetch to the stale param — a NEWER
+  // deactivated selection from Standings could then never materialize here.
   const candidatePastId = useMemo(() => {
-    if (leagueIdParam && !leagues.some((l) => l.id === leagueIdParam)) return leagueIdParam;
+    if (
+      leagueIdParam &&
+      appliedParam !== leagueIdParam &&
+      !leagues.some((l) => l.id === leagueIdParam)
+    ) {
+      return leagueIdParam;
+    }
     if (storeLeagueId && !leagues.some((l) => l.id === storeLeagueId)) return storeLeagueId;
     return null;
-  }, [leagueIdParam, storeLeagueId, leagues]);
+  }, [leagueIdParam, appliedParam, storeLeagueId, leagues]);
   const { data: allLeagues, isFetched: allLeaguesFetched } = useQuery({
     queryKey: leaguesKeys.mine,
     queryFn: () =>
@@ -127,26 +143,21 @@ export default function PicksScreen() {
   const [importOpen, setImportOpen] = useState(false);
 
 
-  // A deep-link selection is applied ONCE per param value: the param sticks
-  // in the route, and re-applying it whenever leagues refetch would overwrite
-  // a newer choice made on another surface with the stale param.
-  const appliedParamRef = useRef<string | null>(null);
-
   // eslint-disable-next-line react-hooks/exhaustive-deps — intentionally excluding leagueId to only initialize/target, not rerun on user selection
   useEffect(() => {
     // Deep-link param wins: an active league, or the on-demand past league.
     // A deep link is explicit intent, so it writes the app-wide selection too.
-    if (leagueIdParam && appliedParamRef.current !== leagueIdParam) {
+    if (leagueIdParam && appliedParam !== leagueIdParam) {
       const active = leagues.find((l) => l.id === leagueIdParam);
       if (active) {
-        appliedParamRef.current = leagueIdParam;
+        setAppliedParam(leagueIdParam);
         setLeagueId(active.id);
         setSelectedWeek(defaultWeek(active));
         setStoreLeague(active.id);
         return;
       }
       if (pastLeagueAsLeague && pastLeagueAsLeague.id === leagueIdParam) {
-        appliedParamRef.current = leagueIdParam;
+        setAppliedParam(leagueIdParam);
         setLeagueId(pastLeagueAsLeague.id);
         setSelectedWeek(defaultWeek(pastLeagueAsLeague));
         setStoreLeague(pastLeagueAsLeague.id);
@@ -167,7 +178,7 @@ export default function PicksScreen() {
       setLeagueId(initial.id);
       setSelectedWeek(defaultWeek(initial));
     }
-  }, [leagues, leagueIdParam, pastLeagueAsLeague, candidatePastId, allLeaguesFetched]);
+  }, [leagues, leagueIdParam, appliedParam, pastLeagueAsLeague, candidatePastId, allLeaguesFetched]);
 
   // Adopt a league chosen on ANOTHER surface while this tab stays mounted
   // (tab navigators keep screens alive). Keyed on the selection NONCE and

--- a/src/UI/sd-mobile/app/(tabs)/picks.tsx
+++ b/src/UI/sd-mobile/app/(tabs)/picks.tsx
@@ -143,11 +143,28 @@ export default function PicksScreen() {
   const [importOpen, setImportOpen] = useState(false);
 
 
+  // The param's priority is TEMPORAL, not positional: it represents intent at
+  // navigation time. Snapshot the store nonce when a param first goes pending;
+  // if the nonce advances past the snapshot (an explicit choice made anywhere
+  // while a slow includeDeactivated fetch resolves), the newer intent wins and
+  // the param is consumed unapplied — a stale deep link must never win merely
+  // because its resolution landed last.
+  const paramArrivalRef = useRef<{ param: string; nonce: number } | null>(null);
+
   // eslint-disable-next-line react-hooks/exhaustive-deps — intentionally excluding leagueId to only initialize/target, not rerun on user selection
   useEffect(() => {
     // Deep-link param wins: an active league, or the on-demand past league.
     // A deep link is explicit intent, so it writes the app-wide selection too.
     if (leagueIdParam && appliedParam !== leagueIdParam) {
+      if (paramArrivalRef.current?.param !== leagueIdParam) {
+        paramArrivalRef.current = { param: leagueIdParam, nonce: storeNonce };
+      }
+      if (storeNonce > paramArrivalRef.current.nonce) {
+        // A newer explicit choice happened while this param was pending —
+        // consume it unapplied; the store branch owns the selection now.
+        setAppliedParam(leagueIdParam);
+        return;
+      }
       const active = leagues.find((l) => l.id === leagueIdParam);
       if (active) {
         setAppliedParam(leagueIdParam);
@@ -186,7 +203,7 @@ export default function PicksScreen() {
       setLeagueId(initial.id);
       setSelectedWeek(defaultWeek(initial));
     }
-  }, [leagues, leagueIdParam, appliedParam, pastLeagueAsLeague, candidatePastId, allLeaguesFetched]);
+  }, [leagues, leagueIdParam, appliedParam, storeNonce, pastLeagueAsLeague, candidatePastId, allLeaguesFetched]);
 
   // Adopt a league chosen on ANOTHER surface while this tab stays mounted
   // (tab navigators keep screens alive). Keyed on the selection NONCE and

--- a/src/UI/sd-mobile/app/(tabs)/standings.tsx
+++ b/src/UI/sd-mobile/app/(tabs)/standings.tsx
@@ -13,10 +13,15 @@ import { LoadingSpinner } from '@/src/components/ui/LoadingSpinner';
 import { EmptyState } from '@/src/components/ui/EmptyState';
 import { Button } from '@/src/components/ui/Button';
 import { StandingsControls } from '@/src/components/features/selectors/StandingsControls';
+import { SegmentedControl } from '@/src/components/ui/SegmentedControl';
+import { ByWeekPane } from '@/src/components/features/standings/ByWeekPane';
 import { useStandings, useUserLeagues } from '@/src/hooks/useStandings';
 import { useSeasonLeagueSelection } from '@/src/hooks/useSeasonLeagueSelection';
 import { useAuthStore } from '@/src/stores/authStore';
+import { useLeagueSelectionStore } from '@/src/stores/leagueSelectionStore';
 import type { Standing } from '@/src/types/models';
+
+type StandingsPane = 'standings' | 'byWeek';
 
 // ─── Row ──────────────────────────────────────────────────────────────────────
 
@@ -87,6 +92,11 @@ export default function StandingsScreen() {
   // season and recently-ended leagues are reachable — /user/me is active-only.
   const { data: allLeagues = [], isLoading: leaguesLoading } = useUserLeagues();
 
+  // App-wide current league: adopt what another surface (Picks, Home) chose,
+  // and record explicit choices made here.
+  const storeLeagueId = useLeagueSelectionStore((s) => s.selectedLeagueId);
+  const setStoreLeague = useLeagueSelectionStore((s) => s.setSelectedLeague);
+
   // Season/league selection state machine (derivation + reconciliation).
   const {
     seasons,
@@ -98,9 +108,31 @@ export default function StandingsScreen() {
     canFilterEnded,
     showEnded,
     setShowEnded,
-  } = useSeasonLeagueSelection(allLeagues);
+  } = useSeasonLeagueSelection(allLeagues, storeLeagueId);
+
+  // Explicit league taps write the app-wide selection; reconciliation snaps
+  // and defaults never do (see leagueSelectionStore contract).
+  const handleLeagueChange = (id: string) => {
+    setSelectedLeagueId(id);
+    setStoreLeague(id);
+  };
 
   const [showBots, setShowBots] = useState(true);
+  const [pane, setPane] = useState<StandingsPane>('standings');
+
+  const selectedLeague = seasonLeagues.find((l) => l.id === selectedLeagueId) ?? null;
+
+  // By Week's selected week, keyed to the league so switching leagues
+  // re-defaults to that league's latest week (web-standings parity —
+  // LeagueSummary carries no currentSeasonWeek).
+  const [weekByLeague, setWeekByLeague] = useState<Record<string, number>>({});
+  const seasonWeeks = selectedLeague?.seasonWeeks ?? [];
+  const selectedWeek =
+    (selectedLeagueId ? weekByLeague[selectedLeagueId] : undefined) ??
+    (seasonWeeks.length ? seasonWeeks[seasonWeeks.length - 1] : null);
+  const setSelectedWeek = (w: number) => {
+    if (selectedLeagueId) setWeekByLeague((prev) => ({ ...prev, [selectedLeagueId]: w }));
+  };
 
   const {
     data: standings = [],
@@ -139,7 +171,7 @@ export default function StandingsScreen() {
         onSeasonChange={setSelectedSeason}
         leagues={seasonLeagues}
         selectedLeagueId={selectedLeagueId}
-        onLeagueChange={setSelectedLeagueId}
+        onLeagueChange={handleLeagueChange}
         canFilterEnded={canFilterEnded}
         showEnded={showEnded}
         onToggleEnded={() => setShowEnded((v) => !v)}
@@ -147,7 +179,29 @@ export default function StandingsScreen() {
         onToggleBots={() => setShowBots((v) => !v)}
       />
 
-      {standingsLoading ? (
+      <View style={styles.paneSwitch}>
+        <SegmentedControl<StandingsPane>
+          value={pane}
+          options={[
+            { value: 'standings', label: 'Standings' },
+            { value: 'byWeek', label: 'By Week' },
+          ]}
+          onChange={setPane}
+          accessibilityLabel="Standings view"
+        />
+      </View>
+
+      {pane === 'byWeek' && selectedLeagueId ? (
+        <ByWeekPane
+          leagueId={selectedLeagueId}
+          week={selectedWeek}
+          seasonWeeks={seasonWeeks}
+          onWeekChange={setSelectedWeek}
+          showBots={showBots}
+          currentUserId={user?.uid}
+          pickType={selectedLeague?.leagueType ?? null}
+        />
+      ) : standingsLoading ? (
         <LoadingSpinner message="Loading standings…" />
       ) : isError ? (
         // Genuine fetch failure (distinct from the not-started empty state,
@@ -212,6 +266,7 @@ export default function StandingsScreen() {
 
 const styles = StyleSheet.create({
   container: { flex: 1 },
+  paneSwitch: { paddingHorizontal: 14, paddingTop: 8 },
   list: { padding: 14, paddingBottom: 24 },
   // flexGrow fills the viewport so the error centers and pull-to-refresh works.
   errorContent: { flexGrow: 1, alignItems: 'center', justifyContent: 'center', padding: 40, gap: 10 },

--- a/src/UI/sd-mobile/app/(tabs)/standings.tsx
+++ b/src/UI/sd-mobile/app/(tabs)/standings.tsx
@@ -93,8 +93,10 @@ export default function StandingsScreen() {
   const { data: allLeagues = [], isLoading: leaguesLoading } = useUserLeagues();
 
   // App-wide current league: adopt what another surface (Picks, Home) chose,
-  // and record explicit choices made here.
+  // and record explicit choices made here. The nonce subscription matters:
+  // re-choosing the SAME league elsewhere bumps only the nonce.
   const storeLeagueId = useLeagueSelectionStore((s) => s.selectedLeagueId);
+  const storeNonce = useLeagueSelectionStore((s) => s.selectionNonce);
   const setStoreLeague = useLeagueSelectionStore((s) => s.setSelectedLeague);
 
   // Season/league selection state machine (derivation + reconciliation).
@@ -108,7 +110,7 @@ export default function StandingsScreen() {
     canFilterEnded,
     showEnded,
     setShowEnded,
-  } = useSeasonLeagueSelection(allLeagues, storeLeagueId);
+  } = useSeasonLeagueSelection(allLeagues, storeLeagueId, storeNonce);
 
   // Explicit league taps write the app-wide selection; reconciliation snaps
   // and defaults never do (see leagueSelectionStore contract).

--- a/src/UI/sd-mobile/app/(tabs)/standings.tsx
+++ b/src/UI/sd-mobile/app/(tabs)/standings.tsx
@@ -90,7 +90,12 @@ export default function StandingsScreen() {
 
   // Source the league list from getUserLeagues (includes deactivated) so past-
   // season and recently-ended leagues are reachable — /user/me is active-only.
-  const { data: allLeagues = [], isLoading: leaguesLoading } = useUserLeagues();
+  const {
+    data: allLeagues = [],
+    isLoading: leaguesLoading,
+    refetch: refetchLeagues,
+    isRefetching: leaguesRefetching,
+  } = useUserLeagues();
 
   // App-wide current league: adopt what another surface (Picks, Home) chose,
   // and record explicit choices made here. The nonce subscription matters:
@@ -202,6 +207,8 @@ export default function StandingsScreen() {
           showBots={showBots}
           currentUserId={user?.uid}
           pickType={selectedLeague?.leagueType ?? null}
+          onRefreshLeagues={refetchLeagues}
+          refreshingLeagues={leaguesRefetching}
         />
       ) : standingsLoading ? (
         <LoadingSpinner message="Loading standings…" />

--- a/src/UI/sd-mobile/src/components/features/home/YourLeaguesCard.tsx
+++ b/src/UI/sd-mobile/src/components/features/home/YourLeaguesCard.tsx
@@ -34,10 +34,11 @@ export function YourLeaguesCard({ leagues }: Props) {
   const scheme = useColorScheme();
   const theme = getTheme(scheme);
   const router = useRouter();
+  // Above the early return — a conditional hook call would change the hook
+  // count when `leagues` goes empty→non-empty and crash the renderer.
+  const setStoreLeague = useLeagueSelectionStore((s) => s.setSelectedLeague);
 
   if (leagues.length === 0) return null;
-
-  const setStoreLeague = useLeagueSelectionStore((s) => s.setSelectedLeague);
 
   const openLeague = (leagueId: string) => {
     // Explicit tap → app-wide selection, so Standings (and anything else)

--- a/src/UI/sd-mobile/src/components/features/home/YourLeaguesCard.tsx
+++ b/src/UI/sd-mobile/src/components/features/home/YourLeaguesCard.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { View, StyleSheet, TouchableOpacity } from 'react-native';
 import { useRouter } from 'expo-router';
+import { useLeagueSelectionStore } from '@/src/stores/leagueSelectionStore';
 import { Text } from '@/src/components/ui/AppText';
 import { useColorScheme } from '@/src/lib/theme/ThemeContext';
 import { getTheme } from '@/constants/Colors';
@@ -36,7 +37,12 @@ export function YourLeaguesCard({ leagues }: Props) {
 
   if (leagues.length === 0) return null;
 
+  const setStoreLeague = useLeagueSelectionStore((s) => s.setSelectedLeague);
+
   const openLeague = (leagueId: string) => {
+    // Explicit tap → app-wide selection, so Standings (and anything else)
+    // lands on this league too; the param keeps the Picks deep-link exact.
+    setStoreLeague(leagueId);
     router.push({
       pathname: '/(tabs)/picks',
       params: { leagueId },

--- a/src/UI/sd-mobile/src/components/features/selectors/StandingsControls.tsx
+++ b/src/UI/sd-mobile/src/components/features/selectors/StandingsControls.tsx
@@ -62,22 +62,45 @@ export function StandingsControls({
   // otherwise open so the user can pick.
   const [collapsed, setCollapsed] = useState(() => selectedLeagueId != null);
 
-  // Auto-close whenever a selection is in hand:
-  //  - on tab focus (navigating Picks → Standings must land content-first,
-  //    not on an open picker shoving everything down), and
-  //  - when the selection changes while focused — the async reconciliation
-  //    landing after mount, an adoption from the app-wide league store, or
-  //    the user tapping a league in the open panel (task complete → close).
-  // Browsing with the panel open (season taps, pills) doesn't change
-  // selectedLeagueId, so it never slams shut mid-exploration.
+  // Auto-close ONLY on:
+  //  - tab focus with a selection in hand (navigating Picks → Standings must
+  //    land content-first, not on an open picker shoving everything down) —
+  //    the selection is read through a ref so the focus callback identity
+  //    never changes: keying it on selectedLeagueId made useFocusEffect
+  //    re-run mid-focus, and a season tap whose reconciliation SNAP changed
+  //    the selection slammed the panel shut mid-exploration; and
+  //  - an explicit league tap in the open panel (task complete → close),
+  //    wired at the chip press below — snap-driven selection changes don't
+  //    come through there.
+  // The mount race (selection landing async after focus) is covered by the
+  // collapse in the league-tap path plus initial `collapsed` state; a user
+  // who arrives selection-less keeps the panel open to pick.
+  const selectedLeagueIdRef = React.useRef(selectedLeagueId);
+  selectedLeagueIdRef.current = selectedLeagueId;
+  const focusArmedRef = React.useRef(false);
   useFocusEffect(
     React.useCallback(() => {
-      if (selectedLeagueId != null) {
-        LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
+      if (selectedLeagueIdRef.current != null) {
         setCollapsed(true);
+      } else {
+        // Selection hasn't landed yet (async reconciliation) — collapse once
+        // it does, then disarm so later selection changes don't re-collapse.
+        focusArmedRef.current = true;
       }
-    }, [selectedLeagueId]),
+    }, []),
   );
+  React.useEffect(() => {
+    if (focusArmedRef.current && selectedLeagueId != null) {
+      focusArmedRef.current = false;
+      setCollapsed(true);
+    }
+  }, [selectedLeagueId]);
+
+  const pickLeague = (id: string) => {
+    onLeagueChange(id);
+    LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
+    setCollapsed(true);
+  };
 
   const toggle = () => {
     LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
@@ -133,7 +156,7 @@ export function StandingsControls({
     leagues.length > 1 ? (
       <View style={styles.wrapRow}>
         {leagues.map((l) =>
-          chip(l.id, l.name, l.id === selectedLeagueId, () => onLeagueChange(l.id), styles.leagueChip),
+          chip(l.id, l.name, l.id === selectedLeagueId, () => pickLeague(l.id), styles.leagueChip),
         )}
       </View>
     ) : null,

--- a/src/UI/sd-mobile/src/components/features/selectors/StandingsControls.tsx
+++ b/src/UI/sd-mobile/src/components/features/selectors/StandingsControls.tsx
@@ -7,6 +7,7 @@ import {
   Platform,
   UIManager,
 } from 'react-native';
+import { useFocusEffect } from 'expo-router';
 import { Text } from '@/src/components/ui/AppText';
 import { useColorScheme } from '@/src/lib/theme/ThemeContext';
 import { getTheme } from '@/constants/Colors';
@@ -60,6 +61,23 @@ export function StandingsControls({
   // Start collapsed if a league is already selected (e.g. returning to the tab);
   // otherwise open so the user can pick.
   const [collapsed, setCollapsed] = useState(() => selectedLeagueId != null);
+
+  // Auto-close whenever a selection is in hand:
+  //  - on tab focus (navigating Picks → Standings must land content-first,
+  //    not on an open picker shoving everything down), and
+  //  - when the selection changes while focused — the async reconciliation
+  //    landing after mount, an adoption from the app-wide league store, or
+  //    the user tapping a league in the open panel (task complete → close).
+  // Browsing with the panel open (season taps, pills) doesn't change
+  // selectedLeagueId, so it never slams shut mid-exploration.
+  useFocusEffect(
+    React.useCallback(() => {
+      if (selectedLeagueId != null) {
+        LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
+        setCollapsed(true);
+      }
+    }, [selectedLeagueId]),
+  );
 
   const toggle = () => {
     LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);

--- a/src/UI/sd-mobile/src/components/features/standings/ByWeekPane.tsx
+++ b/src/UI/sd-mobile/src/components/features/standings/ByWeekPane.tsx
@@ -53,6 +53,11 @@ interface ByWeekPaneProps {
   showBots: boolean;
   currentUserId: string | undefined;
   pickType: PickType | null;
+  /** Refetches the league summaries — the only way the "No weeks yet"
+   *  state can learn the slate now exists (nothing invalidates that cache
+   *  from inside this pane, and refetchOnWindowFocus is off app-wide). */
+  onRefreshLeagues: () => void;
+  refreshingLeagues: boolean;
 }
 
 export function ByWeekPane({
@@ -63,6 +68,8 @@ export function ByWeekPane({
   showBots,
   currentUserId,
   pickType,
+  onRefreshLeagues,
+  refreshingLeagues,
 }: ByWeekPaneProps) {
   const scheme = useColorScheme();
   const theme = getTheme(scheme);
@@ -146,14 +153,28 @@ export function ByWeekPane({
   // disabled, so isLoading never resolves and isError never fires — without
   // this branch the pane would spin forever with no escape.
   if (week == null) {
+    // Refreshable, unlike a bare EmptyState: the league-summary cache is
+    // 5-min stale, stays mounted, and nothing invalidates it from here — so
+    // without pull-to-refresh/Retry this state would outlive the slate's
+    // creation for the whole session.
     return (
-      <View style={styles.fill}>
+      <ScrollView
+        contentContainerStyle={styles.emptyScroll}
+        refreshControl={
+          <RefreshControl
+            refreshing={refreshingLeagues}
+            onRefresh={onRefreshLeagues}
+            tintColor={theme.tint}
+          />
+        }
+      >
         <EmptyState
           icon="📅"
           title="No weeks yet"
-          subtitle="This league's schedule hasn't been generated yet — check back soon."
+          subtitle="This league's schedule hasn't been generated yet. Pull to refresh or tap retry."
         />
-      </View>
+        <Button title="Retry" variant="secondary" size="sm" onPress={onRefreshLeagues} />
+      </ScrollView>
     );
   }
 
@@ -514,6 +535,7 @@ function formatLockTime(lockMs: number): string {
 
 const styles = StyleSheet.create({
   fill: { flex: 1 },
+  emptyScroll: { flexGrow: 1, alignItems: 'center', justifyContent: 'center', gap: 10, padding: 30 },
   list: { padding: 14, paddingBottom: 24 },
   weekRow: { paddingTop: 8 },
   weekRowContent: { paddingHorizontal: 14, gap: 6 },

--- a/src/UI/sd-mobile/src/components/features/standings/ByWeekPane.tsx
+++ b/src/UI/sd-mobile/src/components/features/standings/ByWeekPane.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import {
   View,
   FlatList,
@@ -10,6 +10,7 @@ import {
   UIManager,
   ScrollView,
 } from 'react-native';
+import { useIsFocused } from '@react-navigation/native';
 import { Text } from '@/src/components/ui/AppText';
 import { useColorScheme } from '@/src/lib/theme/ThemeContext';
 import { getTheme } from '@/constants/Colors';
@@ -69,8 +70,11 @@ export function ByWeekPane({
   const { data: userOptions } = useUserOptions();
   const showGambling = shouldShowGambling(pickType, userOptions);
 
+  // Poll only while FOCUSED (tab screens stay mounted) — the hook stops on
+  // its own once every game is final.
+  const isFocused = useIsFocused();
   const { data: overview, isLoading, isError, refetch, isRefetching } =
-    useLeagueWeekOverview(leagueId, week);
+    useLeagueWeekOverview(leagueId, week, isFocused);
 
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
   const toggleExpanded = (contestId: string) => {
@@ -83,7 +87,16 @@ export function ByWeekPane({
     });
   };
 
-  const nowMs = Date.now();
+  // 15s clock tick while focused (picks.tsx precedent): time-only derivations
+  // — the LOCKED→LIVE flip at kickoff, the pre-lock countdown — advance
+  // between refetches instead of freezing at the last render's timestamp.
+  const [nowMs, setNowMs] = useState(() => Date.now());
+  useEffect(() => {
+    if (!isFocused) return undefined;
+    setNowMs(Date.now());
+    const id = setInterval(() => setNowMs(Date.now()), 15_000);
+    return () => clearInterval(id);
+  }, [isFocused]);
 
   const derived = useMemo(() => {
     if (!overview) return null;
@@ -97,8 +110,7 @@ export function ByWeekPane({
       picksByUser: indexPicks(picks),
       summary: summarizeWeek(overview, nowMs),
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [overview, showBots]);
+  }, [overview, showBots, nowMs]);
 
   const weekChips = (
     <View style={styles.weekRow}>
@@ -128,6 +140,22 @@ export function ByWeekPane({
       </ScrollView>
     </View>
   );
+
+  // A week-less league (slate not generated yet, or a future season whose
+  // weeks aren't sourced) reaches here with week == null: the query is
+  // disabled, so isLoading never resolves and isError never fires — without
+  // this branch the pane would spin forever with no escape.
+  if (week == null) {
+    return (
+      <View style={styles.fill}>
+        <EmptyState
+          icon="📅"
+          title="No weeks yet"
+          subtitle="This league's schedule hasn't been generated yet — check back soon."
+        />
+      </View>
+    );
+  }
 
   if (isLoading || !derived) {
     return (
@@ -247,7 +275,7 @@ export function ByWeekPane({
           summary.unlockedCount > 0 ? (
             <Text style={[styles.footerNote, { color: theme.textMuted }]}>
               🔒 {summary.unlockedCount} more {summary.unlockedCount === 1 ? 'game' : 'games'} —
-              picks reveal at kickoff
+              picks reveal 5 min before kickoff
             </Text>
           ) : null
         }

--- a/src/UI/sd-mobile/src/components/features/standings/ByWeekPane.tsx
+++ b/src/UI/sd-mobile/src/components/features/standings/ByWeekPane.tsx
@@ -1,0 +1,592 @@
+import React, { useMemo, useState } from 'react';
+import {
+  View,
+  FlatList,
+  TouchableOpacity,
+  StyleSheet,
+  RefreshControl,
+  LayoutAnimation,
+  Platform,
+  UIManager,
+  ScrollView,
+} from 'react-native';
+import { Text } from '@/src/components/ui/AppText';
+import { useColorScheme } from '@/src/lib/theme/ThemeContext';
+import { getTheme } from '@/constants/Colors';
+import { LoadingSpinner } from '@/src/components/ui/LoadingSpinner';
+import { EmptyState } from '@/src/components/ui/EmptyState';
+import { Button } from '@/src/components/ui/Button';
+import { useLeagueWeekOverview } from '@/src/hooks/useLeagueWeekOverview';
+import { useUserOptions } from '@/src/hooks/useUserOptions';
+import { shouldShowGambling } from '@/src/lib/gamblingContent';
+import {
+  contestPhase,
+  indexPicks,
+  memberRowsForContest,
+  readinessRows,
+  sideSplit,
+  summarizeWeek,
+  type ContestPhase,
+  type MemberPickRow,
+} from '@/src/lib/weekOverview';
+import type { PickType } from '@/src/types/models';
+import type { LeagueWeekContest, LeagueWeekMember, UserPick } from '@/src/types/models';
+
+// The "By Week" pane (design handoff: D consensus rail as the pane, A's
+// member rows as each strip's expanded state, A3 pre-lock readiness, A4
+// spreads-off). One FlatList; expansion is per-item state — no nested
+// scrolling.
+
+if (Platform.OS === 'android') {
+  UIManager.setLayoutAnimationEnabledExperimental?.(true);
+}
+
+const CORRECT = '#34d399';
+const INCORRECT = '#f87171';
+
+interface ByWeekPaneProps {
+  leagueId: string;
+  week: number | null;
+  seasonWeeks: number[];
+  onWeekChange: (week: number) => void;
+  showBots: boolean;
+  currentUserId: string | undefined;
+  pickType: PickType | null;
+}
+
+export function ByWeekPane({
+  leagueId,
+  week,
+  seasonWeeks,
+  onWeekChange,
+  showBots,
+  currentUserId,
+  pickType,
+}: ByWeekPaneProps) {
+  const scheme = useColorScheme();
+  const theme = getTheme(scheme);
+
+  const { data: userOptions } = useUserOptions();
+  const showGambling = shouldShowGambling(pickType, userOptions);
+
+  const { data: overview, isLoading, isError, refetch, isRefetching } =
+    useLeagueWeekOverview(leagueId, week);
+
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const toggleExpanded = (contestId: string) => {
+    LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(contestId)) next.delete(contestId);
+      else next.add(contestId);
+      return next;
+    });
+  };
+
+  const nowMs = Date.now();
+
+  const derived = useMemo(() => {
+    if (!overview) return null;
+    const members = showBots
+      ? overview.members
+      : overview.members.filter((m) => !m.isSynthetic);
+    const memberIds = new Set(members.map((m) => m.userId));
+    const picks = overview.userPicks.filter((p) => memberIds.has(p.userId));
+    return {
+      members,
+      picksByUser: indexPicks(picks),
+      summary: summarizeWeek(overview, nowMs),
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [overview, showBots]);
+
+  const weekChips = (
+    <View style={styles.weekRow}>
+      <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={styles.weekRowContent}>
+        {seasonWeeks.map((w) => {
+          const active = w === week;
+          return (
+            <TouchableOpacity
+              key={w}
+              style={[
+                styles.weekChip,
+                active
+                  ? { backgroundColor: theme.tint, borderColor: theme.tint }
+                  : { borderColor: theme.border },
+              ]}
+              onPress={() => onWeekChange(w)}
+              accessibilityRole="button"
+              accessibilityState={{ selected: active }}
+              activeOpacity={0.7}
+            >
+              <Text style={[styles.weekChipText, { color: active ? theme.textOnAccent : theme.textMuted }]}>
+                Wk {w}
+              </Text>
+            </TouchableOpacity>
+          );
+        })}
+      </ScrollView>
+    </View>
+  );
+
+  if (isLoading || !derived) {
+    return (
+      <View style={styles.fill}>
+        {weekChips}
+        {isError ? (
+          <View style={styles.errorBox}>
+            <Text style={[styles.errorTitle, { color: theme.text }]}>Couldn't load the week</Text>
+            <Button title="Retry" variant="secondary" size="sm" onPress={() => refetch()} />
+          </View>
+        ) : (
+          <LoadingSpinner message="Loading week…" />
+        )}
+      </View>
+    );
+  }
+
+  const { members, picksByUser, summary } = derived;
+
+  // ── A3: nothing revealed yet ──────────────────────────────────────────────
+  if (summary.preLock) {
+    const rows = readinessRows(members, overview!.contests.length);
+    return (
+      <View style={styles.fill}>
+        {weekChips}
+        <FlatList
+          data={rows}
+          keyExtractor={(r) => r.member.userId}
+          contentContainerStyle={styles.list}
+          refreshControl={
+            <RefreshControl refreshing={isRefetching} onRefresh={refetch} tintColor={theme.tint} />
+          }
+          ListHeaderComponent={
+            <View style={[styles.revealCard, { backgroundColor: theme.card, borderColor: theme.border }]}>
+              <Text style={styles.revealLock}>🔒</Text>
+              <Text style={[styles.revealTitle, { color: theme.text }]}>Picks reveal at kickoff</Text>
+              <Text style={[styles.revealSub, { color: theme.textMuted }]}>
+                Nobody sees anybody's picks until a game locks — 5 minutes before kick.
+              </Text>
+              {summary.firstLockMs != null && (
+                <View style={[styles.revealWhen, { borderColor: theme.tint }]}>
+                  <Text style={[styles.revealWhenText, { color: theme.tint }]}>
+                    First lock {formatLockTime(summary.firstLockMs)}
+                  </Text>
+                </View>
+              )}
+              <Text style={[styles.readyHeader, { color: theme.textMuted }]}>
+                WHO'S READY · {overview!.contests.length} GAMES
+              </Text>
+            </View>
+          }
+          renderItem={({ item }) => {
+            const isMe = item.member.userId === currentUserId;
+            const share = item.total === 0 ? 0 : item.submitted / item.total;
+            return (
+              <View
+                style={[
+                  styles.readyRow,
+                  { backgroundColor: theme.card, borderColor: theme.border },
+                  isMe && { borderLeftColor: theme.tint, borderLeftWidth: 3 },
+                ]}
+              >
+                <Text style={[styles.readyName, { color: theme.text }]} numberOfLines={1}>
+                  {item.member.displayName}
+                  {isMe ? ' (you)' : ''}
+                </Text>
+                <View style={[styles.readyBar, { backgroundColor: theme.border }]}>
+                  <View
+                    style={[
+                      styles.readyBarFill,
+                      { backgroundColor: share >= 1 ? CORRECT : theme.tint, flex: Math.max(share, 0.02) },
+                    ]}
+                  />
+                  <View style={{ flex: Math.max(1 - share, 0.001) }} />
+                </View>
+                <Text style={[styles.readyCount, { color: share >= 1 ? CORRECT : theme.tint }]}>
+                  {item.submitted}/{item.total}
+                </Text>
+              </View>
+            );
+          }}
+          ItemSeparatorComponent={() => <View style={{ height: 6 }} />}
+        />
+      </View>
+    );
+  }
+
+  // ── D: consensus rail over revealed games ────────────────────────────────
+  return (
+    <View style={styles.fill}>
+      {weekChips}
+      <FlatList
+        data={summary.revealed}
+        keyExtractor={(c) => c.contestId}
+        contentContainerStyle={styles.list}
+        showsVerticalScrollIndicator={false}
+        refreshControl={
+          <RefreshControl refreshing={isRefetching} onRefresh={refetch} tintColor={theme.tint} />
+        }
+        renderItem={({ item }) => (
+          <GameStrip
+            contest={item}
+            phase={contestPhase(item, nowMs)}
+            members={members}
+            picksByUser={picksByUser}
+            currentUserId={currentUserId}
+            showGambling={showGambling}
+            expanded={expanded.has(item.contestId)}
+            onToggle={() => toggleExpanded(item.contestId)}
+          />
+        )}
+        ItemSeparatorComponent={() => <View style={{ height: 8 }} />}
+        ListEmptyComponent={
+          <EmptyState title="No games this week" subtitle="This week has no matchups." />
+        }
+        ListFooterComponent={
+          summary.unlockedCount > 0 ? (
+            <Text style={[styles.footerNote, { color: theme.textMuted }]}>
+              🔒 {summary.unlockedCount} more {summary.unlockedCount === 1 ? 'game' : 'games'} —
+              picks reveal at kickoff
+            </Text>
+          ) : null
+        }
+      />
+    </View>
+  );
+}
+
+// ─── One rail strip (collapsed = D, expanded = A's member rows) ──────────────
+
+function GameStrip({
+  contest,
+  phase,
+  members,
+  picksByUser,
+  currentUserId,
+  showGambling,
+  expanded,
+  onToggle,
+}: {
+  contest: LeagueWeekContest;
+  phase: ContestPhase;
+  members: LeagueWeekMember[];
+  picksByUser: Map<string, Map<string, UserPick>>;
+  currentUserId: string | undefined;
+  showGambling: boolean;
+  expanded: boolean;
+  onToggle: () => void;
+}) {
+  const scheme = useColorScheme();
+  const theme = getTheme(scheme);
+
+  const rows = useMemo(
+    () => memberRowsForContest(contest, members, picksByUser),
+    [contest, members, picksByUser],
+  );
+  const revealedPicks = rows.filter((r): r is Required<MemberPickRow> => !!r.pick).map((r) => r.pick);
+  const split = sideSplit(contest, revealedPicks);
+  const noPickCount = rows.length - revealedPicks.length;
+
+  const hasScore = contest.awayScore != null && contest.homeScore != null;
+  const scoreText = hasScore ? `${contest.awayScore}–${contest.homeScore}` : kickTime(contest.startDateUtc);
+
+  return (
+    <TouchableOpacity
+      style={[styles.strip, { backgroundColor: theme.card, borderColor: theme.border }]}
+      onPress={onToggle}
+      activeOpacity={0.85}
+      accessibilityRole="button"
+      accessibilityState={{ expanded }}
+    >
+      {/* Header: matchup · score/kick · status */}
+      <View style={styles.stripHeader}>
+        <Text style={[styles.matchup, { color: theme.text }]} numberOfLines={1}>
+          {rankPrefix(contest.awayRank)}
+          {contest.awayShort} @ {rankPrefix(contest.homeRank)}
+          {contest.homeShort}
+        </Text>
+        <Text style={[styles.score, { color: phase === 'live' ? CORRECT : theme.text }]}>{scoreText}</Text>
+        <StatusPill phase={phase} />
+      </View>
+
+      {showGambling && contest.homeSpread != null && contest.homeSpread !== 0 && (
+        <Text style={[styles.spread, { color: theme.textMuted }]}>
+          {contest.homeShort} {contest.homeSpread > 0 ? '+' : ''}
+          {contest.homeSpread}
+        </Text>
+      )}
+
+      {/* Majority split bar */}
+      <View style={styles.splitRow}>
+        <Text style={[styles.splitLabel, { color: theme.tint }]}>
+          {split.awayCount} {contest.awayShort}
+        </Text>
+        <View style={[styles.splitBar, { backgroundColor: theme.border }]}>
+          <View style={{ flex: Math.max(split.awayShare, 0.03), backgroundColor: theme.tint }} />
+          <View style={{ flex: Math.max(1 - split.awayShare, 0.03) }} />
+        </View>
+        <Text style={[styles.splitLabel, { color: theme.textMuted }]}>
+          {contest.homeShort} {split.homeCount}
+        </Text>
+      </View>
+
+      {/* Collapsed: name pills. Expanded: full member rows. */}
+      {expanded ? (
+        <View style={styles.memberRows}>
+          {rows.map((row) => (
+            <MemberRow key={row.member.userId} row={row} isMe={row.member.userId === currentUserId} />
+          ))}
+        </View>
+      ) : (
+        <View style={styles.pillWrap}>
+          {rows
+            .filter((r) => r.pick)
+            .map((row) => (
+              <NamePill key={row.member.userId} row={row} isMe={row.member.userId === currentUserId} />
+            ))}
+          {noPickCount > 0 && (
+            <Text style={[styles.noPickTail, { color: theme.textMuted }]}>
+              {noPickCount} no pick 🔒
+            </Text>
+          )}
+        </View>
+      )}
+    </TouchableOpacity>
+  );
+}
+
+function StatusPill({ phase }: { phase: ContestPhase }) {
+  const scheme = useColorScheme();
+  const theme = getTheme(scheme);
+  const label = phase === 'final' ? 'FINAL' : phase === 'live' ? 'LIVE' : 'LOCKED';
+  const color = phase === 'live' ? CORRECT : theme.textMuted;
+  return (
+    <View style={[styles.statusPill, { borderColor: color }]}>
+      <Text style={[styles.statusPillText, { color }]}>{label}</Text>
+    </View>
+  );
+}
+
+function ConfidenceBadge({ pick }: { pick: UserPick }) {
+  const scheme = useColorScheme();
+  const theme = getTheme(scheme);
+  if (pick.confidencePoints == null) return null;
+  const color =
+    pick.isCorrect === true ? CORRECT : pick.isCorrect === false ? INCORRECT : theme.tint;
+  return (
+    <View style={[styles.confBadge, { borderColor: color }]}>
+      <Text style={[styles.confBadgeText, { color }]}>{pick.confidencePoints}</Text>
+    </View>
+  );
+}
+
+function ResultMark({ pick }: { pick: UserPick }) {
+  if (typeof pick.isCorrect !== 'boolean') return null;
+  return (
+    <Text style={[styles.mark, { color: pick.isCorrect ? CORRECT : INCORRECT }]}>
+      {pick.isCorrect ? '✓' : '✗'}
+    </Text>
+  );
+}
+
+function NamePill({ row, isMe }: { row: MemberPickRow; isMe: boolean }) {
+  const scheme = useColorScheme();
+  const theme = getTheme(scheme);
+  const firstName = isMe ? 'You' : row.member.displayName.split(' ')[0];
+  return (
+    <View
+      style={[
+        styles.pill,
+        { borderColor: isMe ? theme.tint : theme.border, backgroundColor: theme.background },
+      ]}
+    >
+      {row.pick && <ConfidenceBadge pick={row.pick} />}
+      <Text style={[styles.pillName, { color: theme.text, fontWeight: isMe ? '700' : '500' }]} numberOfLines={1}>
+        {firstName}
+      </Text>
+      {row.pick && <ResultMark pick={row.pick} />}
+    </View>
+  );
+}
+
+function MemberRow({ row, isMe }: { row: MemberPickRow; isMe: boolean }) {
+  const scheme = useColorScheme();
+  const theme = getTheme(scheme);
+  return (
+    <View
+      style={[
+        styles.memberRow,
+        isMe && { backgroundColor: `${theme.tint}14`, borderLeftColor: theme.tint, borderLeftWidth: 3 },
+      ]}
+    >
+      <Text
+        style={[
+          styles.memberName,
+          { color: row.pick ? theme.text : theme.textMuted, fontWeight: isMe ? '700' : '500' },
+        ]}
+        numberOfLines={1}
+      >
+        {row.member.displayName}
+        {isMe ? ' (you)' : ''}
+      </Text>
+      {row.pick ? (
+        <>
+          <View
+            style={[
+              styles.teamChip,
+              {
+                borderColor:
+                  row.pick.isCorrect === true
+                    ? CORRECT
+                    : row.pick.isCorrect === false
+                      ? INCORRECT
+                      : theme.border,
+              },
+            ]}
+          >
+            <Text style={[styles.teamChipText, { color: theme.text }]}>{row.teamShort ?? '—'}</Text>
+          </View>
+          <ConfidenceBadge pick={row.pick} />
+          <ResultMark pick={row.pick} />
+        </>
+      ) : (
+        <View style={[styles.teamChip, styles.noPickChip, { borderColor: theme.border }]}>
+          <Text>🔒</Text>
+        </View>
+      )}
+    </View>
+  );
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function rankPrefix(rank: number | null | undefined): string {
+  return rank != null ? `#${rank} ` : '';
+}
+
+function kickTime(startDateUtc: string): string {
+  const d = new Date(startDateUtc);
+  return d.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' });
+}
+
+function formatLockTime(lockMs: number): string {
+  const d = new Date(lockMs);
+  const day = d.toLocaleDateString(undefined, { weekday: 'short' });
+  const time = d.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' });
+  const deltaMs = lockMs - Date.now();
+  if (deltaMs <= 0) return `${day} ${time}`;
+  const hours = Math.floor(deltaMs / 3_600_000);
+  const days = Math.floor(hours / 24);
+  const remainder = days > 0 ? `${days}d ${hours % 24}h` : `${hours}h ${Math.floor((deltaMs % 3_600_000) / 60_000)}m`;
+  return `${day} ${time} · ${remainder}`;
+}
+
+// ─── Styles ──────────────────────────────────────────────────────────────────
+
+const styles = StyleSheet.create({
+  fill: { flex: 1 },
+  list: { padding: 14, paddingBottom: 24 },
+  weekRow: { paddingTop: 8 },
+  weekRowContent: { paddingHorizontal: 14, gap: 6 },
+  weekChip: {
+    borderWidth: 1,
+    borderRadius: 999,
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+  },
+  weekChipText: { fontSize: 12, fontWeight: '600' },
+  errorBox: { flex: 1, alignItems: 'center', justifyContent: 'center', gap: 10, padding: 30 },
+  errorTitle: { fontSize: 16, fontWeight: '700' },
+
+  // A3 pre-lock
+  revealCard: {
+    borderRadius: 14,
+    borderWidth: StyleSheet.hairlineWidth,
+    padding: 20,
+    alignItems: 'center',
+    gap: 8,
+    marginBottom: 12,
+  },
+  revealLock: { fontSize: 34 },
+  revealTitle: { fontSize: 17, fontWeight: '800', textTransform: 'uppercase', letterSpacing: 0.5 },
+  revealSub: { fontSize: 13, textAlign: 'center', lineHeight: 19 },
+  revealWhen: { borderWidth: 1, borderRadius: 8, paddingHorizontal: 12, paddingVertical: 6, marginTop: 4 },
+  revealWhenText: { fontSize: 13, fontWeight: '600', fontVariant: ['tabular-nums'] },
+  readyHeader: { fontSize: 11, fontWeight: '700', letterSpacing: 1, marginTop: 10, alignSelf: 'flex-start' },
+  readyRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    borderRadius: 10,
+    borderWidth: StyleSheet.hairlineWidth,
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    gap: 10,
+  },
+  readyName: { flex: 1, fontSize: 14, fontWeight: '600' },
+  readyBar: { flexDirection: 'row', width: 90, height: 6, borderRadius: 3, overflow: 'hidden' },
+  readyBarFill: { borderRadius: 3 },
+  readyCount: { fontSize: 13, fontWeight: '700', fontVariant: ['tabular-nums'], minWidth: 42, textAlign: 'right' },
+
+  // D strip
+  strip: {
+    borderRadius: 13,
+    borderWidth: StyleSheet.hairlineWidth,
+    padding: 12,
+    gap: 8,
+  },
+  stripHeader: { flexDirection: 'row', alignItems: 'center', gap: 8 },
+  matchup: { flex: 1, fontSize: 15, fontWeight: '800' },
+  score: { fontSize: 15, fontWeight: '700', fontVariant: ['tabular-nums'] },
+  statusPill: { borderWidth: 1, borderRadius: 5, paddingHorizontal: 6, paddingVertical: 2 },
+  statusPillText: { fontSize: 10, fontWeight: '700', letterSpacing: 0.5 },
+  spread: { fontSize: 12, fontVariant: ['tabular-nums'], marginTop: -4 },
+  splitRow: { flexDirection: 'row', alignItems: 'center', gap: 8 },
+  splitLabel: { fontSize: 12, fontWeight: '700', minWidth: 52 },
+  splitBar: { flex: 1, flexDirection: 'row', height: 6, borderRadius: 3, overflow: 'hidden' },
+  pillWrap: { flexDirection: 'row', flexWrap: 'wrap', gap: 6, alignItems: 'center' },
+  pill: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 5,
+    borderWidth: 1,
+    borderRadius: 999,
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+  },
+  pillName: { fontSize: 12, maxWidth: 90 },
+  noPickTail: { fontSize: 12, marginLeft: 4 },
+  footerNote: { fontSize: 12, textAlign: 'center', paddingVertical: 14 },
+
+  // A expanded rows
+  memberRows: { gap: 2 },
+  memberRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    paddingVertical: 8,
+    paddingHorizontal: 6,
+    borderRadius: 9,
+    minHeight: 38,
+  },
+  memberName: { flex: 1, fontSize: 14 },
+  teamChip: {
+    width: 56,
+    alignItems: 'center',
+    borderWidth: 1,
+    borderRadius: 6,
+    paddingVertical: 4,
+  },
+  noPickChip: { borderStyle: 'dashed' },
+  teamChipText: { fontSize: 12, fontWeight: '800' },
+  confBadge: {
+    width: 20,
+    height: 20,
+    borderRadius: 10,
+    borderWidth: 1.5,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  confBadgeText: { fontSize: 11, fontWeight: '700' },
+  mark: { fontSize: 14, fontWeight: '700' },
+});

--- a/src/UI/sd-mobile/src/hooks/useLeagueWeekOverview.ts
+++ b/src/UI/sd-mobile/src/hooks/useLeagueWeekOverview.ts
@@ -1,0 +1,22 @@
+import { useQuery } from '@tanstack/react-query';
+import { leaguesApi, leaguesKeys } from '@/src/services/api/leaguesApi';
+import type { LeagueWeekOverview } from '@/src/types/models';
+
+/**
+ * The By Week pane's payload: contests + member roster (with readiness
+ * counts) + revealed picks. Reveal enforcement is server-side (#736): the
+ * payload already excludes other members' picks on un-locked contests, so
+ * the client renders what it gets and never filters for secrecy itself.
+ */
+export function useLeagueWeekOverview(
+  leagueId: string | null | undefined,
+  week: number | null | undefined,
+) {
+  return useQuery<LeagueWeekOverview>({
+    queryKey: leaguesKeys.weekOverview(leagueId ?? '', week ?? 0),
+    queryFn: () => leaguesApi.getLeagueWeekOverview(leagueId!, week!).then((r) => r.data),
+    enabled: !!leagueId && week != null,
+    // Live games move; keep the pane reasonably fresh without hammering.
+    staleTime: 1000 * 30,
+  });
+}

--- a/src/UI/sd-mobile/src/hooks/useLeagueWeekOverview.ts
+++ b/src/UI/sd-mobile/src/hooks/useLeagueWeekOverview.ts
@@ -7,10 +7,18 @@ import type { LeagueWeekOverview } from '@/src/types/models';
  * counts) + revealed picks. Reveal enforcement is server-side (#736): the
  * payload already excludes other members' picks on un-locked contests, so
  * the client renders what it gets and never filters for secrecy itself.
+ *
+ * When `poll` is true (the pane is FOCUSED — tab screens stay mounted, so
+ * callers must gate on focus or every backgrounded tab would poll), the
+ * query refetches on an interval WHILE the week still has unresolved games:
+ * the reveal moment, LOCKED→LIVE→FINAL flips, scores, and readiness counts
+ * all arrive without a manual pull-to-refresh. A fully-final week stops
+ * polling entirely — nothing left to change.
  */
 export function useLeagueWeekOverview(
   leagueId: string | null | undefined,
   week: number | null | undefined,
+  poll = false,
 ) {
   return useQuery<LeagueWeekOverview>({
     queryKey: leaguesKeys.weekOverview(leagueId ?? '', week ?? 0),
@@ -18,5 +26,12 @@ export function useLeagueWeekOverview(
     enabled: !!leagueId && week != null,
     // Live games move; keep the pane reasonably fresh without hammering.
     staleTime: 1000 * 30,
+    refetchInterval: (query) => {
+      if (!poll) return false;
+      const data = query.state.data;
+      if (!data || data.contests.length === 0) return false;
+      const unresolved = data.contests.some((c) => !c.completedUtc && !c.finalizedUtc);
+      return unresolved ? 30_000 : false;
+    },
   });
 }

--- a/src/UI/sd-mobile/src/hooks/useSeasonLeagueSelection.ts
+++ b/src/UI/sd-mobile/src/hooks/useSeasonLeagueSelection.ts
@@ -1,4 +1,4 @@
-import { Dispatch, SetStateAction, useEffect, useMemo, useState } from 'react';
+import { Dispatch, SetStateAction, useEffect, useMemo, useRef, useState } from 'react';
 import type { LeagueSummary } from '@/src/services/api/leaguesApi';
 
 export interface SeasonLeagueSelection {
@@ -34,7 +34,18 @@ export interface SeasonLeagueSelection {
  *  - selectedLeagueId snaps to the first visible league whenever it drops out of
  *    the current season/filter.
  */
-export function useSeasonLeagueSelection(allLeagues: LeagueSummary[]): SeasonLeagueSelection {
+export function useSeasonLeagueSelection(
+  allLeagues: LeagueSummary[],
+  /**
+   * The app-wide current league (leagueSelectionStore). Adopted — season
+   * flipped along, ended-filter opened if needed — when it names one of the
+   * user's leagues. Each distinct value is adopted at most ONCE, so local
+   * browsing afterwards (switching seasons snaps the selection) is never
+   * yanked back; and because every explicit local pick writes the store, the
+   * store and local selection only diverge when ANOTHER surface chose.
+   */
+  preferredLeagueId?: string | null,
+): SeasonLeagueSelection {
   const [selectedLeagueId, setSelectedLeagueId] = useState<string | null>(null);
   const [selectedSeason, setSelectedSeason] = useState<number | null>(null);
   // Active-only by default to keep the league row short; the pill reveals ended.
@@ -90,6 +101,26 @@ export function useSeasonLeagueSelection(allLeagues: LeagueSummary[]): SeasonLea
       setSelectedLeagueId(seasonLeagues[0].id);
     }
   }, [selectedSeason, seasonLeagues, selectedLeagueId]);
+
+  // Adoption of the app-wide preferred league. Declared AFTER the two
+  // reconciliation effects deliberately: effects run in declaration order,
+  // and within one commit the reconcilers read pre-adoption state — declared
+  // first, the season-validity effect would overwrite the adopted season and
+  // the snap effect would then yank the adopted league. Last-writer here,
+  // validated by the reconcilers on the following pass.
+  const adoptedRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!preferredLeagueId || preferredLeagueId === selectedLeagueId) return;
+    if (adoptedRef.current === preferredLeagueId) return;
+    const target = allLeagues.find((l) => l.id === preferredLeagueId);
+    if (!target) return;
+    adoptedRef.current = preferredLeagueId;
+    setSelectedSeason(target.seasonYear);
+    // A current-season ended league would be filtered out and snapped away —
+    // reveal ended leagues so the adoption sticks.
+    if (target.deactivatedUtc) setShowEnded(true);
+    setSelectedLeagueId(target.id);
+  }, [preferredLeagueId, allLeagues, selectedLeagueId]);
 
   return {
     seasons,

--- a/src/UI/sd-mobile/src/hooks/useSeasonLeagueSelection.ts
+++ b/src/UI/sd-mobile/src/hooks/useSeasonLeagueSelection.ts
@@ -39,12 +39,14 @@ export function useSeasonLeagueSelection(
   /**
    * The app-wide current league (leagueSelectionStore). Adopted — season
    * flipped along, ended-filter opened if needed — when it names one of the
-   * user's leagues. Each distinct value is adopted at most ONCE, so local
+   * user's leagues. Each selection NONCE is consumed at most once, so local
    * browsing afterwards (switching seasons snaps the selection) is never
-   * yanked back; and because every explicit local pick writes the store, the
-   * store and local selection only diverge when ANOTHER surface chose.
+   * yanked back by the same stale choice — while a fresh explicit re-choice
+   * of the SAME league elsewhere (new nonce) still converges here.
    */
   preferredLeagueId?: string | null,
+  /** leagueSelectionStore.selectionNonce — bumps on every explicit choice. */
+  preferredNonce?: number,
 ): SeasonLeagueSelection {
   const [selectedLeagueId, setSelectedLeagueId] = useState<string | null>(null);
   const [selectedSeason, setSelectedSeason] = useState<number | null>(null);
@@ -108,19 +110,26 @@ export function useSeasonLeagueSelection(
   // first, the season-validity effect would overwrite the adopted season and
   // the snap effect would then yank the adopted league. Last-writer here,
   // validated by the reconcilers on the following pass.
-  const adoptedRef = useRef<string | null>(null);
+  //
+  // Consumption is keyed on the NONCE, not the id: each explicit choice is
+  // adopted once (recorded even when it matches the current selection, so a
+  // later reconciliation snap can't resurrect a stale preference), while a
+  // fresh re-choice of the same league elsewhere arrives as a new nonce and
+  // converges the local selection again.
+  const adoptedNonceRef = useRef<number | null>(null);
   useEffect(() => {
-    if (!preferredLeagueId || preferredLeagueId === selectedLeagueId) return;
-    if (adoptedRef.current === preferredLeagueId) return;
+    if (!preferredLeagueId || preferredNonce == null) return;
+    if (adoptedNonceRef.current === preferredNonce) return;
     const target = allLeagues.find((l) => l.id === preferredLeagueId);
     if (!target) return;
-    adoptedRef.current = preferredLeagueId;
+    adoptedNonceRef.current = preferredNonce;
+    if (preferredLeagueId === selectedLeagueId) return; // consumed; nothing to move
     setSelectedSeason(target.seasonYear);
     // A current-season ended league would be filtered out and snapped away —
     // reveal ended leagues so the adoption sticks.
     if (target.deactivatedUtc) setShowEnded(true);
     setSelectedLeagueId(target.id);
-  }, [preferredLeagueId, allLeagues, selectedLeagueId]);
+  }, [preferredLeagueId, preferredNonce, allLeagues, selectedLeagueId]);
 
   return {
     seasons,

--- a/src/UI/sd-mobile/src/lib/weekOverview.ts
+++ b/src/UI/sd-mobile/src/lib/weekOverview.ts
@@ -1,0 +1,160 @@
+import type {
+  LeagueWeekContest,
+  LeagueWeekMember,
+  LeagueWeekOverview,
+  UserPick,
+} from '@/src/types/models';
+
+// Pure derivations for the By Week pane (design handoff: D consensus rail,
+// A expanded card, A3 pre-lock readiness). Kept free of React/RN so the
+// pane's logic is unit-testable; the component only renders these shapes.
+
+export type ContestPhase = 'unlocked' | 'locked' | 'live' | 'final';
+
+/**
+ * Phase off the contest's own fields. `isLocked` is server-stamped (kickoff
+ * − 5 min, the reveal boundary — never re-derive it client-side); final is
+ * completion/finalization; live is locked + kicked off + not final.
+ */
+export function contestPhase(contest: LeagueWeekContest, nowMs: number): ContestPhase {
+  if (!contest.isLocked) return 'unlocked';
+  if (contest.completedUtc || contest.finalizedUtc) return 'final';
+  return nowMs >= Date.parse(contest.startDateUtc) ? 'live' : 'locked';
+}
+
+export interface SideSplit {
+  awayCount: number;
+  homeCount: number;
+  /** 0..1 share of revealed picks on the away side (0.5 when none revealed). */
+  awayShare: number;
+}
+
+/** Revealed-pick counts per side for the strip's majority split bar. */
+export function sideSplit(contest: LeagueWeekContest, picks: UserPick[]): SideSplit {
+  let awayCount = 0;
+  let homeCount = 0;
+  for (const p of picks) {
+    if (p.franchiseSeasonId === contest.awayFranchiseSeasonId) awayCount += 1;
+    else if (p.franchiseSeasonId === contest.homeFranchiseSeasonId) homeCount += 1;
+  }
+  const total = awayCount + homeCount;
+  return { awayCount, homeCount, awayShare: total === 0 ? 0.5 : awayCount / total };
+}
+
+export interface MemberPickRow {
+  member: LeagueWeekMember;
+  /** Undefined = no revealed pick for this contest (no pick, or withheld). */
+  pick?: UserPick;
+  /** Short name of the picked team, derived by franchiseSeasonId match. */
+  teamShort?: string;
+  pickedHome?: boolean;
+}
+
+/**
+ * One row per member for a contest, sorted: revealed picks by confidence
+ * desc (the big bets on top — handoff A), then alphabetical; no-pick rows
+ * trail in name order. The caller decides how many to show (A2 collapses to
+ * the top 5 for 10+ member leagues).
+ */
+export function memberRowsForContest(
+  contest: LeagueWeekContest,
+  members: LeagueWeekMember[],
+  picksByUser: Map<string, Map<string, UserPick>>,
+): MemberPickRow[] {
+  const rows: MemberPickRow[] = members.map((member) => {
+    const pick = picksByUser.get(member.userId)?.get(contest.contestId);
+    if (!pick) return { member };
+    const pickedHome = pick.franchiseSeasonId === contest.homeFranchiseSeasonId;
+    const teamShort = pickedHome
+      ? contest.homeShort
+      : pick.franchiseSeasonId === contest.awayFranchiseSeasonId
+        ? contest.awayShort
+        : undefined;
+    return { member, pick, teamShort, pickedHome };
+  });
+
+  return rows.sort((a, b) => {
+    if (!!a.pick !== !!b.pick) return a.pick ? -1 : 1;
+    const conf = (b.pick?.confidencePoints ?? 0) - (a.pick?.confidencePoints ?? 0);
+    if (conf !== 0) return conf;
+    return a.member.displayName.localeCompare(b.member.displayName);
+  });
+}
+
+/** picksByUser[userId][contestId] — one pass over the payload. */
+export function indexPicks(picks: UserPick[]): Map<string, Map<string, UserPick>> {
+  const byUser = new Map<string, Map<string, UserPick>>();
+  for (const p of picks) {
+    let inner = byUser.get(p.userId);
+    if (!inner) {
+      inner = new Map();
+      byUser.set(p.userId, inner);
+    }
+    inner.set(p.contestId, p);
+  }
+  return byUser;
+}
+
+export interface WeekPhaseSummary {
+  /** Contests to render as rail strips, in start order (locked/live/final). */
+  revealed: LeagueWeekContest[];
+  /** Count of games whose picks are still hidden. */
+  unlockedCount: number;
+  /** First lock instant (kickoff − 5 min) across unlocked games, ms epoch. */
+  firstLockMs: number | null;
+  /** True = nothing revealed yet: render the A3 pre-lock readiness state. */
+  preLock: boolean;
+}
+
+const LOCK_LEAD_MS = 5 * 60 * 1000;
+
+export function summarizeWeek(overview: LeagueWeekOverview, nowMs: number): WeekPhaseSummary {
+  const revealed: LeagueWeekContest[] = [];
+  let unlockedCount = 0;
+  let firstLockMs: number | null = null;
+
+  for (const contest of overview.contests) {
+    if (contestPhase(contest, nowMs) === 'unlocked') {
+      unlockedCount += 1;
+      const lockMs = Date.parse(contest.startDateUtc) - LOCK_LEAD_MS;
+      if (firstLockMs === null || lockMs < firstLockMs) firstLockMs = lockMs;
+    } else {
+      revealed.push(contest);
+    }
+  }
+
+  return {
+    revealed,
+    unlockedCount,
+    firstLockMs,
+    preLock: revealed.length === 0 && overview.contests.length > 0,
+  };
+}
+
+export interface ReadinessRow {
+  member: LeagueWeekMember;
+  submitted: number;
+  total: number;
+}
+
+/**
+ * The A3 "Who's Ready" list: submitted-count per member (safe metadata from
+ * the server — reveal enforcement withholds the picks themselves), most
+ * ready first, ties alphabetical.
+ */
+export function readinessRows(
+  members: LeagueWeekMember[],
+  totalGames: number,
+): ReadinessRow[] {
+  return members
+    .map((member) => ({
+      member,
+      submitted: Math.min(member.submittedPickCount, totalGames),
+      total: totalGames,
+    }))
+    .sort(
+      (a, b) =>
+        b.submitted - a.submitted ||
+        a.member.displayName.localeCompare(b.member.displayName),
+    );
+}

--- a/src/UI/sd-mobile/src/services/api/leaguesApi.ts
+++ b/src/UI/sd-mobile/src/services/api/leaguesApi.ts
@@ -1,4 +1,5 @@
 import { apiClient } from './client';
+import type { LeagueWeekOverview } from '@/src/types/models';
 
 // Matches SportsData.Api.Application.Common.Enums.PickType (by name).
 export type PickType = 'StraightUp' | 'AgainstTheSpread' | 'OverUnder';
@@ -83,6 +84,7 @@ export const leaguesKeys = {
   public: ['leagues', 'public'] as const,
   invitations: ['leagues', 'invitations'] as const,
   seasonWeeks: (sport: string) => ['leagues', 'season-weeks', sport] as const,
+  weekOverview: (id: string, week: number) => ['league', id, 'overview', week] as const,
 };
 
 /**
@@ -330,6 +332,13 @@ export const leaguesApi = {
     apiClient.get<LeagueSummary[]>('/ui/leagues', {
       params: includeDeactivated ? { includeDeactivated: true } : undefined,
     }),
+
+  // GET /ui/leagues/{id}/overview/{week} — the By Week pane's payload:
+  // contests, the member roster (with readiness counts), and REVEALED picks
+  // only (own always; others' once their contest locks — reveal enforcement
+  // is server-side, #736; do not re-derive it client-side).
+  getLeagueWeekOverview: (id: string, week: number) =>
+    apiClient.get<LeagueWeekOverview>(`/ui/leagues/${id}/overview/${week}`),
 
   // POST /ui/leagues/{id}/clone — duplicate a league the user belongs to.
   // Copies config and regenerates the slate server-side; picks are NOT copied.

--- a/src/UI/sd-mobile/src/stores/leagueSelectionStore.ts
+++ b/src/UI/sd-mobile/src/stores/leagueSelectionStore.ts
@@ -1,0 +1,24 @@
+import { create } from 'zustand';
+
+/**
+ * The app-wide "current league" — the league the user most recently chose by
+ * an EXPLICIT action (a league chip on Picks/Standings, a Home league card).
+ *
+ * Contract (see the By Week PR discussion):
+ *  - Only explicit user actions write. Surfaces that auto-select a fallback
+ *    (reconciliation snaps, first-league defaults) must NOT write it back —
+ *    two tabs with different league lists would ping-pong the store.
+ *  - Consumers read-and-validate: adopt the id only when it exists in their
+ *    own league list; otherwise keep their local default and leave the store
+ *    untouched.
+ *  - Session-scoped (in-memory): an app restart re-defaults every surface.
+ */
+interface LeagueSelectionState {
+  selectedLeagueId: string | null;
+  setSelectedLeague: (id: string) => void;
+}
+
+export const useLeagueSelectionStore = create<LeagueSelectionState>((set) => ({
+  selectedLeagueId: null,
+  setSelectedLeague: (id) => set({ selectedLeagueId: id }),
+}));

--- a/src/UI/sd-mobile/src/stores/leagueSelectionStore.ts
+++ b/src/UI/sd-mobile/src/stores/leagueSelectionStore.ts
@@ -2,7 +2,8 @@ import { create } from 'zustand';
 
 /**
  * The app-wide "current league" — the league the user most recently chose by
- * an EXPLICIT action (a league chip on Picks/Standings, a Home league card).
+ * an EXPLICIT action (a league chip on Picks/Standings, a Home league card,
+ * a deep link).
  *
  * Contract (see the By Week PR discussion):
  *  - Only explicit user actions write. Surfaces that auto-select a fallback
@@ -11,14 +12,23 @@ import { create } from 'zustand';
  *  - Consumers read-and-validate: adopt the id only when it exists in their
  *    own league list; otherwise keep their local default and leave the store
  *    untouched.
+ *  - Every explicit choice bumps selectionNonce, INCLUDING re-choosing the
+ *    id already stored. Zustand skips notifying on same-value sets, so
+ *    without the nonce a user who locally browsed away on one surface and
+ *    then re-tapped the same league on another would produce no signal at
+ *    all. Consumers key adoption on the nonce and consume each one once.
  *  - Session-scoped (in-memory): an app restart re-defaults every surface.
  */
 interface LeagueSelectionState {
   selectedLeagueId: string | null;
+  /** Monotonic; bumps on every explicit choice, same-id re-choices included. */
+  selectionNonce: number;
   setSelectedLeague: (id: string) => void;
 }
 
 export const useLeagueSelectionStore = create<LeagueSelectionState>((set) => ({
   selectedLeagueId: null,
-  setSelectedLeague: (id) => set({ selectedLeagueId: id }),
+  selectionNonce: 0,
+  setSelectedLeague: (id) =>
+    set((s) => ({ selectedLeagueId: id, selectionNonce: s.selectionNonce + 1 })),
 }));

--- a/src/UI/sd-mobile/src/types/models.ts
+++ b/src/UI/sd-mobile/src/types/models.ts
@@ -266,6 +266,9 @@ export interface UserPicksResult {
 export interface UserPick {
   id: string;
   userId: string;
+  /** The member's display name (UserPickDto.User) — populated on the
+   *  league week overview payload; absent on own-picks endpoints. */
+  user?: string;
   contestId: string;
   franchiseSeasonId: string;
   pickType: PickType;
@@ -274,6 +277,60 @@ export interface UserPick {
   isCorrect?: boolean | null;
   pointsAwarded?: number | null;
   isSynthetic?: boolean;
+}
+
+// ─── League week overview (By Week pane) ─────────────────────────────────────
+
+/** Matches LeagueWeekMemberDto from GET /ui/leagues/{id}/overview/{week}. */
+export interface LeagueWeekMember {
+  userId: string;
+  displayName: string;
+  isSynthetic: boolean;
+  /**
+   * How many of the week's games this member has picked — INCLUDING picks on
+   * un-locked contests, whose content the server withholds. Safe metadata;
+   * powers the pre-lock "Who's Ready" list.
+   */
+  submittedPickCount: number;
+}
+
+/** Matches LeagueWeekMatchupResultDto (ContestResultDto + league winner). */
+export interface LeagueWeekContest {
+  startDateUtc: string;
+  contestId: string;
+  isLocked: boolean;
+  awayShort: string;
+  awayFranchiseSeasonId: string;
+  awaySlug: string;
+  awayRank?: number | null;
+  homeShort: string;
+  homeFranchiseSeasonId: string;
+  homeSlug: string;
+  homeRank?: number | null;
+  awaySpread?: number | null;
+  homeSpread?: number | null;
+  overUnder?: number | null;
+  finalizedUtc?: string | null;
+  awayScore?: number | null;
+  homeScore?: number | null;
+  winnerFranchiseSeasonId?: string | null;
+  spreadWinnerFranchiseSeasonId?: string | null;
+  overUnderResult?: string | null;
+  completedUtc?: string | null;
+  /** Spread winner when the league has a spread, else outright winner. */
+  leagueWinnerFranchiseSeasonId?: string | null;
+}
+
+/**
+ * Matches LeagueWeekOverviewDto from GET /ui/leagues/{id}/overview/{week}.
+ * userPicks carries ONLY revealed picks: the caller's own, plus other
+ * members' picks on locked contests (server-side reveal enforcement, #736).
+ * Derive columns/rows from members, never from userPicks.
+ */
+export interface LeagueWeekOverview {
+  contests: LeagueWeekContest[];
+  userPicks: UserPick[];
+  members: LeagueWeekMember[];
 }
 
 // ─── Standings ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What

The mobile half of the picks-reveal parity work (`docs/features/league-picks-reveal-mobile-parity.md`) — PR 3 of 3, on top of #736 (server-side reveal enforcement + member roster) and #737 (readiness counts). Implements the chosen direction from the design handoff: **D consensus rail** as the pane, **A's card** as its expanded state, **A3** pre-lock readiness, **A4** spreads-off.

## By Week pane (Standings tab, `Standings | By Week` segmented control)

- **Consensus rail**: one strip per revealed game — matchup (+rank prefixes), score/kick time, FINAL/LIVE/LOCKED pill, majority split bar with side counts, name pills (confidence badge + first name + ✓/✗, "You" outlined), "N no pick 🔒" tail. Tap → in-place expansion to full member rows sorted confidence-desc; scroll position preserved. Single FlatList, per-item expansion state.
- **Pre-lock**: reveal card (first-lock time + countdown) over the "Who's Ready" list driven by `submittedPickCount` — counts only, never picks.
- **Gambling preference**: the spread line renders only through `shouldShowGambling(pickType, options)`.
- Reveal enforcement stays server-side; the client renders what it receives and never filters for secrecy itself.
- Pure derivations extracted to `src/lib/weekOverview.ts` and unit-tested (phase, splits, member-row sorting, readiness, week summary).

## Shared league selection (found during device validation)

Selecting a league on one tab didn't carry to the other — three surfaces each kept their own idea of "current league." New `leagueSelectionStore` (zustand, session-scoped) with a deliberate contract:

- **Only explicit actions write** (league chips on Picks/Standings, Home league cards, deep links); reconciliation snaps and defaults never write — differing per-tab league lists can't ping-pong the store.
- **Consumers validate-then-adopt** against their own list. `useSeasonLeagueSelection` adopts each preferred value at most once (season flipped along, ended leagues revealed when needed) so local browsing is never yanked back. The adoption effect is declared **after** the reconciliation effects — declared first it loses a same-commit race where the season-validity effect overwrites the adopted season from stale state (regression-tested).
- Picks adopts foreign selections while mounted (tab screens stay alive) and re-defaults the week.

## StandingsControls auto-collapse

Collapses via `useFocusEffect` whenever the tab gains focus with a selection in hand, and when the selection changes while open — navigating Picks → Standings lands content-first instead of on an open picker.

## Testing

- 201 passed (22 suites; 15 new), tsc clean
- Device-validated by the operator: home → league → picks → standings loop, league switching in both directions, By Week states

## Notes

- Week default is the league's latest week (LeagueSummary carries no `currentSeasonWeek`) — matches web Standings behavior; plumbing `currentSeasonWeek` onto the summary DTO is a possible follow-up.
- Follow-ups per the scoping doc: C drill-in (member week detail) as its own PR; B matrix stays shelved pending friend feedback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XPkLHDqNKDA4krjqknFmSq

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a **By Week** standings view with week selection, bot filtering, refresh, loading/error recovery, readiness progress, and revealed-game pick details.
  - Added weekly contest overviews showing member picks, confidence, results, scores, consensus, and locked no-pick states.
  - League selections now stay synchronized across Picks, Standings, and Home, including valid deep links and previously ended leagues.
- **Usability**
  - Standings league selectors collapse automatically after selection, while season and view browsing remain available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->