### PR TITLE
fix(provider): classify EventCompetitionDrive immutable-in-season

### DIFF
--- a/docs/features/live-sourcing-already-seen-skip.md
+++ b/docs/features/live-sourcing-already-seen-skip.md
@@ -245,9 +245,10 @@ Consequences accepted:
 
 ## Deliberately out of scope (follow-ups)
 
-- **Drives**: 118K/evening. Completed drives are immutable but the *active* drive
-  mutates as plays append; the "all but the last drive" positional rule would work
-  but expands classification risk. Revisit after plays/probs prove out.
+- ~~**Drives**~~ DONE 2026-09-08 after plays/probs verified in prod (233x/900x
+  reductions; drives left as the #1 amplifier at 36,276/game): the active
+  drive IS the live edge (newest item), so the existing carve-out covers its
+  mutation window; completed drives share plays' accepted correction gap.
 - **Index-page paging**: the plays index is re-paged in full from ESPN every cycle
   and grows with the game (uncounted on current panels). A "last page only after
   first full walk" optimization or a larger `limit` on the streamer's index

--- a/src/SportsData.Producer/Application/Contests/FootballContestEnrichmentProcessor.cs
+++ b/src/SportsData.Producer/Application/Contests/FootballContestEnrichmentProcessor.cs
@@ -4,7 +4,6 @@ using SportsData.Core.Common;
 using SportsData.Core.Eventing;
 using SportsData.Core.Eventing.Events.Contests;
 using SportsData.Producer.Enums;
-using SportsData.Producer.Extensions;
 using SportsData.Producer.Infrastructure.Data.Football;
 
 namespace SportsData.Producer.Application.Contests

--- a/src/SportsData.Producer/Application/Documents/Processors/DocumentProcessorBase.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/DocumentProcessorBase.cs
@@ -1,6 +1,4 @@
-﻿using System.Diagnostics.Metrics;
-
-using Microsoft.EntityFrameworkCore;
+﻿using Microsoft.EntityFrameworkCore;
 
 using SportsData.Core.Common;
 using SportsData.Core.Common.Hashing;
@@ -11,7 +9,8 @@ using SportsData.Core.Infrastructure.Refs;
 using SportsData.Producer.Application.Documents.Processors.Commands;
 using SportsData.Producer.Exceptions;
 using SportsData.Producer.Infrastructure.Data.Common;
-using SportsData.Producer.Infrastructure.Data.Entities;
+
+using System.Diagnostics.Metrics;
 
 namespace SportsData.Producer.Application.Documents.Processors;
 

--- a/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Football/FootballEventCompetitionCompetitorDocumentProcessor.cs
+++ b/src/SportsData.Producer/Application/Documents/Processors/Providers/Espn/Football/FootballEventCompetitionCompetitorDocumentProcessor.cs
@@ -7,7 +7,6 @@ using SportsData.Producer.Application.Documents.Processors.Providers.Espn.Common
 using SportsData.Producer.Infrastructure.Data.Entities;
 using SportsData.Producer.Infrastructure.Data.Entities.Extensions;
 using SportsData.Producer.Infrastructure.Data.Football;
-using SportsData.Producer.Infrastructure.Data.Football.Entities;
 
 namespace SportsData.Producer.Application.Documents.Processors.Providers.Espn.Football;
 

--- a/src/SportsData.Provider/Application/Jobs/SourcingJobOrchestrator.cs
+++ b/src/SportsData.Provider/Application/Jobs/SourcingJobOrchestrator.cs
@@ -64,7 +64,7 @@ namespace SportsData.Provider.Application.Jobs
                     job => job.ExecuteAsync(def),
                     resource.CronExpression);
 
-                _logger.LogInformation("Registered recurring job {JobId} for {Name} with cron '{Cron}'",
+                _logger.LogDebug("Registered recurring job {JobId} for {Name} with cron '{Cron}'",
                     jobId, resource.Name, resource.CronExpression);
             }
 

--- a/src/SportsData.Provider/Application/Processors/InSeasonDocumentPolicy.cs
+++ b/src/SportsData.Provider/Application/Processors/InSeasonDocumentPolicy.cs
@@ -23,8 +23,16 @@ namespace SportsData.Provider.Application.Processors
     /// 2026-09-07: ESPN emits one probability item per play — the index is
     /// append-only and completed entries never change, and its exclusion sent
     /// every item to ESPN each 15s live cycle (611,931 processed in one evening
-    /// for ~500 real items). Expand further (drives, per-game roster)
-    /// deliberately, once proven.
+    /// for ~500 real items).
+    /// <see cref="DocumentType.EventCompetitionDrive"/> added 2026-09-08 after
+    /// the plays/probs fix VERIFIED in prod (233x/900x reductions) left drives
+    /// as the #1 remaining amplifier (36,276 processed for one game's ~25
+    /// drives): the drives index is append-only and only the ACTIVE drive
+    /// mutates (plays append to it) — and the active drive is the newest item,
+    /// i.e. exactly the live edge the fan-out already re-fetches every cycle.
+    /// Completed drives share plays' accepted correction gap (a rare late edit
+    /// to an old drive is not re-fetched until reenrich). Expand further
+    /// (per-game roster) deliberately, once proven.
     ///
     /// See docs/features/in-season-cache-bypass-fix.md and
     /// docs/features/live-sourcing-already-seen-skip.md.
@@ -35,6 +43,7 @@ namespace SportsData.Provider.Application.Processors
         {
             DocumentType.EventCompetitionPlay,
             DocumentType.EventCompetitionProbability,
+            DocumentType.EventCompetitionDrive,
         };
 
         public static bool IsImmutableInSeason(DocumentType documentType)

--- a/test/unit/SportsData.Provider.Tests.Unit/Application/Documents/DocumentRequestedHandlerTests.cs
+++ b/test/unit/SportsData.Provider.Tests.Unit/Application/Documents/DocumentRequestedHandlerTests.cs
@@ -917,6 +917,8 @@ public class DocumentRequestedHandlerTests : ProviderTestBase<DocumentRequestedH
         "http://sports.core.api.espn.com/v2/sports/football/leagues/college-football/events/401628420/competitions/401628420/plays";
     private const string SkipProbabilitiesBaseUrl =
         "http://sports.core.api.espn.com/v2/sports/football/leagues/college-football/events/401628420/competitions/401628420/probabilities";
+    private const string SkipDrivesBaseUrl =
+        "http://sports.core.api.espn.com/v2/sports/football/leagues/college-football/events/401628420/competitions/401628420/drives";
 
     private static string ThreeItemIndexJson(string baseUrl) =>
         "{\"count\":3,\"pageIndex\":1,\"pageSize\":25,\"pageCount\":1,\"items\":[" +
@@ -975,6 +977,7 @@ public class DocumentRequestedHandlerTests : ProviderTestBase<DocumentRequestedH
     [Theory]
     [InlineData(SkipPlaysBaseUrl, DocumentType.EventCompetitionPlay)]
     [InlineData(SkipProbabilitiesBaseUrl, DocumentType.EventCompetitionProbability)]
+    [InlineData(SkipDrivesBaseUrl, DocumentType.EventCompetitionDrive)]
     public async Task PriorityClaimedImmutableItems_SkippedAtFanOut_ExceptLiveEdge(
         string baseUrl, DocumentType documentType)
     {

--- a/test/unit/SportsData.Provider.Tests.Unit/Application/Processors/InSeasonDocumentPolicyTests.cs
+++ b/test/unit/SportsData.Provider.Tests.Unit/Application/Processors/InSeasonDocumentPolicyTests.cs
@@ -16,6 +16,10 @@ public class InSeasonDocumentPolicyTests
     // change. Excluding it sent every item to ESPN each 15s live cycle
     // (611,931 processed 2026-09-06 for ~500 real items).
     [InlineData(DocumentType.EventCompetitionProbability, true)]
+    // Append-only index; only the ACTIVE drive mutates and it is always the
+    // newest item — exactly the live edge the fan-out keeps re-fetching.
+    // 36,276 processed 2026-09-07 for one game's ~25 real drives.
+    [InlineData(DocumentType.EventCompetitionDrive, true)]
     // Mutable aggregates → must keep bypassing cache in-season to stay fresh.
     [InlineData(DocumentType.EventCompetitionStatus, false)]
     [InlineData(DocumentType.EventCompetitionSituation, false)]


### PR DESCRIPTION
## What

Adds `EventCompetitionDrive` to `InSeasonDocumentPolicy.ImmutableInSeasonTypes` — the follow-up promoted by last night's verification of #733/#734.

## Why now

The plays/probs skip verified emphatically in prod (SMU @ FSU, 09-07): plays 1,314,943 → 5,652 (**233x**), probabilities 611,931 → 692 (**~900x**), 98,032 fan-out skips recorded. That left drives as the #1 remaining amplifier — **36,276 processed for one game's ~25 real drives**, the climbing line on both the ESPN cache panel and Producer's documents-by-type chart (15s fan-out × growing drive count).

## Why it's safe

Structurally identical to plays:
- The drives index is **append-only**; only the **active** drive mutates (plays append to it) — and the active drive is always the newest item, i.e. exactly the **live edge** the fan-out already re-fetches every cycle. The existing carve-out covers its whole mutation window.
- Completed drives share plays' accepted correction gap (a rare late ESPN edit to an old drive surfaces via reenrich, not live polling) — documented since the original in-season-cache-bypass design, whose draft classification listed drives as an intended expansion from day one.

One line of policy; it inherits the entire #733 machinery (immutable-serve, L1 claim + L2 persisted-and-published skip on Priority traffic, leaf-path serve). No config, no migration.

## Testing

- 111 passed (Provider suite): classification pin + a drives row in the fan-out skip-except-live-edge theory
- Prod verification: next live slate's drive totals should land near drive-count + edge refetches (~hundreds, not 36K), and the climbing red line flattens

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XPkLHDqNKDA4krjqknFmSq